### PR TITLE
refactor SSOSession and related classes to pydantic basemodels

### DIFF
--- a/src/eduid/userdb/userdb.py
+++ b/src/eduid/userdb/userdb.py
@@ -41,6 +41,7 @@ import eduid.userdb.exceptions
 from eduid.userdb.db import BaseDB
 from eduid.userdb.exceptions import DocumentDoesNotExist, EduIDUserDBError, MultipleUsersReturned, UserDoesNotExist
 from eduid.userdb.user import User
+from eduid.userdb.util import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -282,7 +283,7 @@ class UserDB(BaseDB):
         # XXX add modified_by info. modified_ts alone is not unique when propagated to eduid.workers.am.
 
         modified = user.modified_ts
-        user.modified_ts = datetime.utcnow()
+        user.modified_ts = utc_now()
         if modified is None:
             # profile has never been modified through the dashboard.
             # possibly just created in signup.

--- a/src/eduid/webapp/common/session/logindata.py
+++ b/src/eduid/webapp/common/session/logindata.py
@@ -33,13 +33,6 @@ class ExternalMfaData(BaseModel):
     authn_context: str
     timestamp: datetime
 
-    def to_session_dict(self) -> Dict[str, Any]:
-        return self.dict()
-
-    @classmethod
-    def from_session_dict(cls, data: Mapping[str, Any]):
-        return cls(**data)
-
 
 @dataclass
 class SSOLoginData:

--- a/src/eduid/webapp/idp/app.py
+++ b/src/eduid/webapp/idp/app.py
@@ -126,7 +126,7 @@ class IdPApp(EduIDBaseApp):
             self.logger.debug(f'Looked up SSO session using session ID {repr(_session_id)}:\n{_sso}')
 
         if not _sso:
-            self.logger.debug("SSO session not found using 'id' parameter or IdP SSO cookie")
+            self.logger.debug('SSO session not found using IdP SSO cookie')
 
             if session.idp.sso_cookie_val is not None:
                 self.logger.debug('Found potential sso_cookie_val in the eduID session')
@@ -145,12 +145,12 @@ class IdPApp(EduIDBaseApp):
 
     def get_sso_session_id(self) -> Optional[SSOSessionId]:
         """
-        Get the SSO session id from the IdP SSO cookie, with fallback to hopefully unused 'id' query string parameter.
+        Get the SSO session id from the IdP SSO cookie.
 
         :return: SSO session id
         """
         # local import to avoid import-loop
-        from eduid.webapp.idp.mischttp import parse_query_string, read_cookie
+        from eduid.webapp.idp.mischttp import read_cookie
 
         _session_id = read_cookie(self.conf.sso_cookie.key)
         if _session_id:
@@ -160,14 +160,6 @@ class IdPApp(EduIDBaseApp):
                 f'Got SSO session ID from IdP SSO cookie {repr(_session_id)} -> {repr(_decoded_session_id)}'
             )
             return SSOSessionId(_decoded_session_id)
-
-        query = parse_query_string()
-        if query and 'id' in query:
-            self.logger.warning('Found "id" in query string - this was thought to be obsolete')
-            self.logger.debug("Parsed query string :\n{!s}".format(pprint.pformat(query)))
-            _session_id = query['id']
-            self.logger.debug(f'Got SSO session ID from query string: {_session_id}')
-            return SSOSessionId(bytes(_session_id, 'ascii'))
 
         return None
 

--- a/src/eduid/webapp/idp/app.py
+++ b/src/eduid/webapp/idp/app.py
@@ -140,8 +140,11 @@ class IdPApp(EduIDBaseApp):
                         f'Found no SSO session, but found one from session.idp.sso_cookie_val: {_other_sso}'
                     )
 
-            for this in self.sso_sessions.get_sessions_for_user(session.common.eppn, self.userdb):
-                self.logger.info(f'Found no SSO session, but found SSO session for user {session.common.eppn}: {this}')
+            if session.common.eppn:
+                for this in self.sso_sessions.get_sessions_for_user(session.common.eppn, self.userdb):
+                    self.logger.info(
+                        f'Found no SSO session, but found SSO session for user {session.common.eppn}: {this}'
+                    )
 
             return None
         self.logger.debug(f'Loaded SSO session {_sso}')

--- a/src/eduid/webapp/idp/helpers.py
+++ b/src/eduid/webapp/idp/helpers.py
@@ -19,6 +19,7 @@ class IdPMsg(str, TranslatableMsg):
     wrong_credentials = 'idp.wrong_credentials'
     user_temporary_locked = 'idp.user_temporary_locked'
     credential_expired = 'idp.credential_expired'
+    general_failure = 'idp.general_failure'
 
 
 @unique

--- a/src/eduid/webapp/idp/idp_saml.py
+++ b/src/eduid/webapp/idp/idp_saml.py
@@ -165,6 +165,9 @@ class IdP_SAMLRequest(object):
         try:
             _subject = self._req_info.subject_id()
             return _subject.text.strip()
+        except AttributeError:
+            # pysaml trips over itself here if there is no Subject ID: 'NoneType' object has no attribute 'keys'
+            logger.debug('No Subject ID in AuthnRequest')
         except Exception as exc:
             logger.debug(f'Could not get Subject ID from AuthnRequest: {exc}')
         return None

--- a/src/eduid/webapp/idp/login.py
+++ b/src/eduid/webapp/idp/login.py
@@ -562,7 +562,6 @@ def do_verify() -> WerkzeugResponse:
     if pwauth.authndata:
         _authn_credentials = [pwauth.authndata]
     _sso_session = SSOSession(
-        user_id=pwauth.user.user_id,
         authn_request_id=_ticket.saml_req.request_id,
         authn_credentials=_authn_credentials,
         idp_user=pwauth.user,

--- a/src/eduid/webapp/idp/login.py
+++ b/src/eduid/webapp/idp/login.py
@@ -573,7 +573,6 @@ def do_verify() -> WerkzeugResponse:
     # used to avoid requiring subsequent authentication for the same user during a limited
     # period of time, by storing the session-id in a browser cookie.
     current_app.sso_sessions.save(_sso_session)
-    current_app.logger.debug(f'Saved SSO session {repr(_sso_session.session_id)}')
 
     # INFO-Log the request id (sha1 of SAML request) and the sso_session
     current_app.logger.info(

--- a/src/eduid/webapp/idp/logout.py
+++ b/src/eduid/webapp/idp/logout.py
@@ -114,7 +114,7 @@ class SLO(Service):
         if _session_id:
             # If the binding is REDIRECT, we can get the SSO session to log out from the
             # client SSO session
-            _session = current_app.sso_sessions.get_session(_session_id, current_app.userdb)
+            _session = current_app.sso_sessions.get_session(_session_id)
             if _session:
                 sessions += [_session]
         else:
@@ -123,7 +123,7 @@ class SLO(Service):
             # unfortunately.
             _username = current_app.IDP.ident.find_local_id(_name_id)
             current_app.logger.debug(f'Logout message name_id: {repr(_name_id)} found username {repr(_username)}')
-            sessions += current_app.sso_sessions.get_sessions_for_user(_username, current_app.userdb)
+            sessions += current_app.sso_sessions.get_sessions_for_user(_username)
 
         _session_ids = [x.session_id for x in sessions]
         current_app.logger.debug(

--- a/src/eduid/webapp/idp/logout.py
+++ b/src/eduid/webapp/idp/logout.py
@@ -158,7 +158,7 @@ class SLO(Service):
                 )
             except KeyError:
                 current_app.logger.info(f'{req_key}: logout sso_key={repr(this)}, result=not_found')
-                res = 0
+                res = False
             if not res:
                 fail += 1
         if fail:

--- a/src/eduid/webapp/idp/sso_session.py
+++ b/src/eduid/webapp/idp/sso_session.py
@@ -80,7 +80,7 @@ class SSOSession:
     authn_credentials: List[AuthnData]
     eppn: str
     idp_user: IdPUser = field(repr=False)  # extra info - not serialised
-    _id: Optional[ObjectId] = None
+    _id: ObjectId = field(default_factory=ObjectId)
     session_id: SSOSessionId = field(default_factory=lambda: create_session_id())
     created_ts: datetime = field(default_factory=utc_now)
     external_mfa: Optional[ExternalMfaData] = None

--- a/src/eduid/webapp/idp/sso_session.py
+++ b/src/eduid/webapp/idp/sso_session.py
@@ -87,7 +87,13 @@ class SSOSession:
     authn_timestamp: datetime = field(default_factory=utc_now)
 
     def __str__(self) -> str:
-        return f'<{self.__class__.__name__}: eppn={self.eppn}, ts={self.authn_timestamp.isoformat()}>'
+        # Session id allows impersonation if leaked, so only log a small part of it
+        short_sessionid = self.session_id[:6].decode('ascii') + '...'
+        return (
+            f'<{self.__class__.__name__}: _id={self._id}, session_id={short_sessionid}, eppn={self.eppn}, '
+            f'created={self.created_ts.isoformat()}, authn_ts={self.authn_timestamp.isoformat()}, '
+            f'age={self.minutes_old}m>'
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         """ Return the object in dict format (serialized for storing in MongoDB).

--- a/src/eduid/webapp/idp/sso_session.py
+++ b/src/eduid/webapp/idp/sso_session.py
@@ -34,24 +34,33 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, NewType, Optional, Type
 
-import bson
 from bson import ObjectId
+from pydantic import BaseModel, Field
 
 from eduid.common.misc.timeutil import utc_now
+from eduid.userdb.credentials.base import CredentialKey
 from eduid.userdb.idp import IdPUser, IdPUserDb
 from eduid.webapp.common.session.logindata import ExternalMfaData
 from eduid.webapp.idp.idp_authn import AuthnData
 
 # A distinct type for session ids
-SSOSessionId = NewType('SSOSessionId', bytes)
+SSOSessionId = NewType('SSOSessionId', str)
 
 
-@dataclass
-class SSOSession:
+def create_session_id() -> SSOSessionId:
+    """
+    Create a unique value suitable for use as session identifier.
+
+    The uniqueness and inability to guess is security critical!
+    :return: session_id as bytes (to match what cookie decoding yields)
+    """
+    return SSOSessionId(str(uuid.uuid4()))
+
+
+class SSOSession(BaseModel):
     """
     Single Sign On sessions are used to remember a previous authentication
     performed, to avoid re-authenticating users for every Service Provider
@@ -74,91 +83,40 @@ class SSOSession:
 
     """
 
-    authn_request_id: str  # This should be obsolete now - used to be used to 'break' forceAuthn looping
-    authn_credentials: List[AuthnData]
     eppn: str
-    idp_user: IdPUser = field(repr=False)  # extra info - not serialised
-    _id: ObjectId = field(default_factory=ObjectId)
-    session_id: SSOSessionId = field(default_factory=lambda: create_session_id())
-    created_ts: datetime = field(default_factory=utc_now)
+    authn_credentials: List[AuthnData]
+    authn_request_id: str = ''  # This should be obsolete now - used to be used to 'break' forceAuthn looping
+    authn_timestamp: datetime = Field(default_factory=utc_now)
+    created_ts: datetime = Field(default_factory=utc_now)
+    expires_at: datetime = Field(default_factory=lambda: utc_now() + timedelta(minutes=5))
     external_mfa: Optional[ExternalMfaData] = None
-    authn_timestamp: datetime = field(default_factory=utc_now)
+    obj_id: ObjectId = Field(default_factory=ObjectId, alias='_id')
+    session_id: SSOSessionId = Field(default_factory=create_session_id)
+
+    class Config:
+        allow_population_by_field_name = True  # allow setting obj_id by name, not just by it's alias (_id)
+        arbitrary_types_allowed = True  # allow ObjectId
 
     def __str__(self) -> str:
         # Session id allows impersonation if leaked, so only log a small part of it
-        short_sessionid = self.session_id[:6].decode('ascii') + '...'
+        short_sessionid = self.session_id[:6] + '...'
         return (
-            f'<{self.__class__.__name__}: _id={self._id}, session_id={short_sessionid}, eppn={self.eppn}, '
+            f'<{self.__class__.__name__}: _id={self.obj_id}, session_id={short_sessionid}, eppn={self.eppn}, '
             f'created={self.created_ts.isoformat()}, authn_ts={self.authn_timestamp.isoformat()}, '
-            f'age={self.minutes_old}m>'
+            f'expires_at={self.expires_at.isoformat()}, age={self.minutes_old}m>'
         )
 
     def to_dict(self) -> Dict[str, Any]:
         """ Return the object in dict format (serialized for storing in MongoDB).
-
-        For legacy reasons, some of the attributes are stored in an 'inner' scope called 'data':
-
-        {
-            '_id': ObjectId('5fcde44d56cf512b51f1ac4e'),
-            'session_id': b'ZjYzOTcwNWItYzUyOS00M2U1LWIxODQtODMxYTJhZjQ0YzA1',
-            'username': 'hubba-bubba',
-            'data': {
-                'authn_request_id': 'id-IgHyGTmxBEORfx5NJ',
-                'authn_credentials': [
-                    {
-                        'cred_id': '5fc8b78cbdaa0bf337490db1',
-                        'authn_ts': datetime.fromisoformat('2020-09-13T12:26:40+00:00'),
-                    }
-                ],
-                'authn_timestamp': 1600000000,
-                'external_mfa': None,
-            },
-            'created_ts': datetime.fromisoformat('2020-12-07T08:14:05.744+00:00'),
-        }
-         """
-        res = asdict(self)
-        res['authn_credentials'] = [x.to_dict() for x in self.authn_credentials]
-        if self.external_mfa is not None:
-            res['external_mfa'] = self.external_mfa.to_session_dict()
-        # Remove extra fields
-        del res['idp_user']
-        # Use integer format for this in the database until this code (from_dict() below) has been
-        # deployed everywhere so we can switch to datetime.
-        # TODO: Switch over to datetime.
-        res['authn_timestamp'] = int(self.authn_timestamp.timestamp())
-        # Store these attributes in an 'inner' scope (called 'data')
-        _data = {}
-        for this in ['authn_request_id', 'authn_credentials', 'authn_timestamp', 'external_mfa']:
-            _data[this] = res.pop(this)
-        res['data'] = _data
-        # rename 'eppn' to 'username' in the database, for legacy reasons
-        res['username'] = res.pop('eppn')
+        """
+        res = self.dict()
+        res['_id'] = res.pop('obj_id')
         return res
 
     @classmethod
-    def from_dict(cls: Type[SSOSession], data: Mapping[str, Any], userdb: IdPUserDb) -> SSOSession:
+    def from_dict(cls: Type[SSOSession], data: Mapping[str, Any]) -> SSOSession:
         """ Construct element from a data dict in database format. """
-
-        _data = dict(data)  # to not modify callers data
-        if 'data' in _data:
-            # move contents from 'data' to top-level of dict
-            _data.update(_data.pop('data'))
-        _data['authn_credentials'] = [AuthnData.from_dict(x) for x in _data['authn_credentials']]
-        if 'external_mfa' in _data and _data['external_mfa'] is not None:
-            _data['external_mfa'] = [ExternalMfaData.from_session_dict(x) for x in _data['external_mfa']]
-        # rename 'username' to 'eppn'
-        if 'eppn' not in _data:
-            _data['eppn'] = _data.pop('username')
-        if 'eppn' in _data:
-            _data['idp_user'] = userdb.lookup_user(_data['eppn'])
-            if not _data['idp_user']:
-                raise RuntimeError(f'User with eppn {repr(_data["eppn"])} not found')
-        # Compatibility code to convert integer format to datetime format. Keep this until nothing writes
-        # authn_timestamp as integers, and all the existing sessions have expired.
-        # TODO: Remove this code when all sessions in the database have datetime authn_timestamps.
-        if isinstance(_data.get('authn_timestamp'), int):
-            _data['authn_timestamp'] = datetime.fromtimestamp(_data['authn_timestamp'], tz=timezone.utc)
-        return cls(**_data)
+        return cls(**data)
 
     @property
     def public_id(self) -> str:
@@ -166,7 +124,7 @@ class SSOSession:
         Return a identifier for this session that can't be used to hijack sessions
         if leaked through a log file etc.
         """
-        return f'{self.eppn}.{self.authn_timestamp.timestamp()}'
+        return f'{self.eppn}.{self.created_ts.replace(microsecond=0).isoformat()}'
 
     @property
     def minutes_old(self) -> int:
@@ -180,11 +138,8 @@ class SSOSession:
             raise ValueError(f'data should be AuthnData (not {type(authn)})')
 
         # Store only the latest use of a particular credential.
-        _creds: Dict[str, AuthnData] = {x.cred_id: x for x in self.authn_credentials}
+        _creds: Dict[CredentialKey, AuthnData] = {x.cred_id: x for x in self.authn_credentials}
         _existing = _creds.get(authn.cred_id)
-        # TODO: remove this in the future - don't have to set tz when all SSO sessions without such have expired
-        if _existing and _existing.timestamp.tzinfo is None:
-            _existing.timestamp = _existing.timestamp.replace(tzinfo=timezone.utc)
         # only replace if newer
         if not _existing or authn.timestamp > _existing.timestamp:
             _creds[authn.cred_id] = authn
@@ -192,13 +147,3 @@ class SSOSession:
         # sort on cred_id to have deterministic order in tests
         _list = list(_creds.values())
         self.authn_credentials = sorted(_list, key=lambda x: x.cred_id)
-
-
-def create_session_id() -> SSOSessionId:
-    """
-    Create a unique value suitable for use as session identifier.
-
-    The uniqueness and inability to guess is security critical!
-    :return: session_id as bytes (to match what cookie decoding yields)
-    """
-    return SSOSessionId(bytes(str(uuid.uuid4()), 'ascii'))

--- a/src/eduid/webapp/idp/tests/test_SSO.py
+++ b/src/eduid/webapp/idp/tests/test_SSO.py
@@ -230,11 +230,7 @@ class TestSSO(SSOIdPTests):
             user = self.get_user_set_nins(self.test_user.eppn, [])
 
         sso_session_1 = SSOSession(
-            user_id=user.user_id,
-            authn_request_id='some-unique-id-1',
-            authn_credentials=[],
-            idp_user=user,
-            eppn=user.eppn,
+            authn_request_id='some-unique-id-1', authn_credentials=[], idp_user=user, eppn=user.eppn,
         )
         if 'u2f' in credentials and not user.credentials.filter(U2F).to_list():
             # add a U2F credential to the user

--- a/src/eduid/webapp/idp/tests/test_SSOSession.py
+++ b/src/eduid/webapp/idp/tests/test_SSOSession.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from bson import ObjectId
 
+from eduid.userdb.credentials.base import CredentialKey
 from eduid.webapp.idp.idp_authn import AuthnData
 from eduid.webapp.idp.sso_session import SSOSession
 from eduid.webapp.idp.tests.test_app import IdPTests
@@ -13,62 +14,61 @@ class test_SSOSession(IdPTests):
         # This is real data extracted from MongoDB before a lot of refactoring
         self.data = {
             '_id': ObjectId('5fcde44d56cf512b51f1ac4e'),
-            'session_id': b'ZjYzOTcwNWItYzUyOS00M2U1LWIxODQtODMxYTJhZjQ0YzA1',
-            'username': self.test_user.eppn,
-            'data': {
-                'authn_request_id': 'id-IgHyGTmxBEORfx5NJ',
-                'authn_credentials': [
-                    {
-                        'cred_id': '5fc8b78cbdaa0bf337490db1',
-                        'authn_ts': datetime.fromisoformat('2020-09-13T12:26:40+00:00'),
-                    }
-                ],
-                'authn_timestamp': 1600000000,
-                'external_mfa': None,
-            },
+            'session_id': 'ZjYzOTcwNWItYzUyOS00M2U1LWIxODQtODMxYTJhZjQ0YzA1',
+            'eppn': self.test_user.eppn,
+            'authn_request_id': 'id-IgHyGTmxBEORfx5NJ',
+            'authn_credentials': [
+                {
+                    'cred_id': '5fc8b78cbdaa0bf337490db1',
+                    'timestamp': datetime.fromisoformat('2020-09-13T12:26:40+00:00'),
+                }
+            ],
+            'authn_timestamp': datetime.fromisoformat('2020-09-13T12:26:40+00:00'),
+            'external_mfa': None,
             'created_ts': datetime.fromisoformat('2020-12-07T08:14:05.744+00:00'),
+            'expires_at': datetime.fromisoformat('2020-12-08T00:00:00+00:00'),
         }
 
     def test_from_dict(self):
-        session = SSOSession.from_dict(self.data, self.app.userdb)
+        session = SSOSession.from_dict(self.data)
         assert session.authn_timestamp == datetime.fromisoformat('2020-09-13T12:26:40+00:00')
         assert session.authn_credentials[0].cred_id == "5fc8b78cbdaa0bf337490db1"
         assert session.authn_credentials[0].timestamp == datetime.fromisoformat('2020-09-13T12:26:40+00:00')
 
     def test_str_method(self):
-        session = SSOSession.from_dict(self.data, self.app.userdb)
+        session = SSOSession.from_dict(self.data)
         assert len(str(session)) > 40
 
     def test_with_datetime_authn_timestamp(self):
-        int_session = SSOSession.from_dict(self.data, self.app.userdb)
+        int_session = SSOSession.from_dict(self.data)
         data = dict(self.data)
         # Change authn_timestamp to datetime format.
         data['authn_timestamp'] = datetime.fromisoformat('2020-09-13T12:26:40+00:00')
-        datetime_session = SSOSession.from_dict(data, self.app.userdb)
+        datetime_session = SSOSession.from_dict(data)
         assert int_session.authn_timestamp == datetime_session.authn_timestamp
         assert isinstance(datetime_session.authn_timestamp, datetime)
 
     def test_to_dict_from_dict(self):
-        session1 = SSOSession.from_dict(self.data, self.app.userdb)
-        session2 = SSOSession.from_dict(session1.to_dict(), self.app.userdb)
+        session1 = SSOSession.from_dict(self.data)
+        session2 = SSOSession.from_dict(session1.to_dict())
         assert session1.to_dict() == session2.to_dict()
         assert session2.to_dict() == self.data
 
     def test_only_store_newest_credential_use(self):
-        pw = AuthnData(cred_id='password', timestamp=datetime.fromtimestamp(10, tz=timezone.utc))
-        older = AuthnData(cred_id='token', timestamp=datetime.fromtimestamp(20, tz=timezone.utc))
-        newer = AuthnData(cred_id='token', timestamp=datetime.fromtimestamp(30, tz=timezone.utc))
+        pw = AuthnData(cred_id=CredentialKey('password'), timestamp=datetime.fromtimestamp(10, tz=timezone.utc))
+        older = AuthnData(cred_id=CredentialKey('token'), timestamp=datetime.fromtimestamp(20, tz=timezone.utc))
+        newer = AuthnData(cred_id=CredentialKey('token'), timestamp=datetime.fromtimestamp(30, tz=timezone.utc))
 
         _data = dict(self.data)
-        _data['data']['authn_credentials'] = []
-        session1 = SSOSession.from_dict(_data, self.app.userdb)
+        _data['authn_credentials'] = []
+        session1 = SSOSession.from_dict(_data)
         session1.add_authn_credential(pw)
         session1.add_authn_credential(older)
         session1.add_authn_credential(newer)
 
         assert session1.authn_credentials == [pw, newer]
 
-        session2 = SSOSession.from_dict(_data, self.app.userdb)
+        session2 = SSOSession.from_dict(_data)
         session2.add_authn_credential(pw)
         session2.add_authn_credential(newer)
         session2.add_authn_credential(older)

--- a/src/eduid/webapp/idp/tests/test_SSOSession.py
+++ b/src/eduid/webapp/idp/tests/test_SSOSession.py
@@ -16,7 +16,6 @@ class test_SSOSession(IdPTests):
             'session_id': b'ZjYzOTcwNWItYzUyOS00M2U1LWIxODQtODMxYTJhZjQ0YzA1',
             'username': self.test_user.eppn,
             'data': {
-                'user_id': self.test_user.user_id,
                 'authn_request_id': 'id-IgHyGTmxBEORfx5NJ',
                 'authn_credentials': [
                     {
@@ -38,7 +37,7 @@ class test_SSOSession(IdPTests):
 
     def test_str_method(self):
         session = SSOSession.from_dict(self.data, self.app.userdb)
-        assert str(session) == '<SSOSession: eppn=hubba-bubba, ts=2020-09-13T12:26:40+00:00>'
+        assert len(str(session)) > 40
 
     def test_with_datetime_authn_timestamp(self):
         int_session = SSOSession.from_dict(self.data, self.app.userdb)

--- a/src/eduid/webapp/idp/tests/test_actions.py
+++ b/src/eduid/webapp/idp/tests/test_actions.py
@@ -76,10 +76,7 @@ class TestActions(SSOIdPTests):
         self.test_action = self.actions.add_action(self.test_user.eppn, action_type='dummy', preference=100, params={})
 
         self.sso_session = SSOSession(
-            authn_request_id='some-unique-id-1',
-            authn_credentials=[],
-            idp_user=cast(IdPUser, self.test_user),
-            eppn=self.test_user.eppn,
+            authn_request_id='some-unique-id-1', authn_credentials=[], eppn=self.test_user.eppn,
         )
         self.app.sso_sessions.save(self.sso_session)
 
@@ -283,13 +280,13 @@ class TestActions(SSOIdPTests):
 
     def test_add_mfa_action_already_authn_not(self):
         self._test_add_2nd_mfa_action(success=False, expected_num_actions=2)
-        sso_session = self.app.sso_sessions.get_session(self.sso_session.session_id, self.app.userdb)
+        sso_session = self.app.sso_sessions.get_session(self.sso_session.session_id)
         assert sso_session is not None
         assert sso_session.authn_credentials == []
 
     def test_add_2nd_mfa_action_no_context(self):
         self._test_add_2nd_mfa_action(expected_num_actions=0)
-        sso_session = self.app.sso_sessions.get_session(self.sso_session.session_id, self.app.userdb)
+        sso_session = self.app.sso_sessions.get_session(self.sso_session.session_id)
         assert sso_session is not None
         assert len(sso_session.authn_credentials) == 1
         authdata = sso_session.authn_credentials[0]
@@ -297,7 +294,7 @@ class TestActions(SSOIdPTests):
 
     def test_add_2nd_mfa_action_no_context_wrong_key(self):
         self._test_add_2nd_mfa_action(cred_key='wrong key', expected_num_actions=2)
-        sso_session = self.app.sso_sessions.get_session(self.sso_session.session_id, self.app.userdb)
+        sso_session = self.app.sso_sessions.get_session(self.sso_session.session_id)
         assert sso_session is not None
         assert sso_session.authn_credentials == []
 

--- a/src/eduid/webapp/idp/tests/test_actions.py
+++ b/src/eduid/webapp/idp/tests/test_actions.py
@@ -76,7 +76,6 @@ class TestActions(SSOIdPTests):
         self.test_action = self.actions.add_action(self.test_user.eppn, action_type='dummy', preference=100, params={})
 
         self.sso_session = SSOSession(
-            user_id=self.test_user.user_id,
             authn_request_id='some-unique-id-1',
             authn_credentials=[],
             idp_user=cast(IdPUser, self.test_user),
@@ -469,6 +468,5 @@ class TestActions(SSOIdPTests):
         credentials_used = [x.cred_id for x in sso_session.authn_credentials]
         assert credentials_used == expected_credentials_used
         assert sso_session.eppn == self.test_user.eppn
-        assert sso_session.user_id == self.test_user.user_id
         assert sso_session.minutes_old <= 1
         assert sso_session.external_mfa is None

--- a/src/eduid/webapp/idp/tests/test_app.py
+++ b/src/eduid/webapp/idp/tests/test_app.py
@@ -240,4 +240,4 @@ class IdPTests(EduidAPITestCase):
     def get_sso_session(self, sso_cookie_val: str) -> Optional[SSOSession]:
         if sso_cookie_val is None:
             return None
-        return self.app.sso_sessions.get_session(b64decode(sso_cookie_val), self.app.userdb)
+        return self.app.sso_sessions.get_session(sso_cookie_val)

--- a/src/eduid/webapp/idp/views.py
+++ b/src/eduid/webapp/idp/views.py
@@ -40,7 +40,7 @@ from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith
 from eduid.webapp.common.api.exceptions import EduidForbidden, EduidTooManyRequests
 from eduid.webapp.common.api.messages import FluxData, error_response, success_response
 from eduid.webapp.common.session import session
-from eduid.webapp.common.session.namespaces import ReqSHA1, RequestRef
+from eduid.webapp.common.session.namespaces import RequestRef
 from eduid.webapp.idp.app import current_idp_app as current_app
 from eduid.webapp.idp.assurance import get_requested_authn_context
 from eduid.webapp.idp.helpers import IdPAction, IdPMsg
@@ -210,7 +210,6 @@ def pwauth(ref: RequestRef, username: str, password: str) -> FluxData:
     # used to avoid requiring subsequent authentication for the same user during a limited
     # period of time, by storing the session-id in a browser cookie.
     current_app.sso_sessions.save(_sso_session)
-    current_app.logger.debug(f'Saved SSO session {repr(_sso_session.session_id)}')
 
     # INFO-Log the request id and the sso_session
     authn_ref = get_requested_authn_context(ticket)

--- a/src/eduid/webapp/idp/views.py
+++ b/src/eduid/webapp/idp/views.py
@@ -30,12 +30,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+from datetime import timedelta
 from typing import List
 
 from flask import Blueprint, redirect, request, url_for
 from werkzeug.exceptions import BadRequest
 from werkzeug.wrappers import Response as WerkzeugResponse
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith
 from eduid.webapp.common.api.exceptions import EduidForbidden, EduidTooManyRequests
 from eduid.webapp.common.api.messages import FluxData, error_response, success_response
@@ -199,11 +201,10 @@ def pwauth(ref: RequestRef, username: str, password: str) -> FluxData:
     if pwauth.authndata:
         _authn_credentials = [pwauth.authndata]
     _sso_session = SSOSession(
-        user_id=pwauth.user.user_id,
         authn_request_id=ticket.saml_req.request_id,
         authn_credentials=_authn_credentials,
-        idp_user=pwauth.user,
         eppn=pwauth.user.eppn,
+        expires_at=utc_now() + timedelta(seconds=current_app.conf.sso_session_lifetime * 60),
     )
 
     # This session contains information about the fact that the user was authenticated. It is


### PR DESCRIPTION
incompatibilities:
    
  - changes the session cookie content from bytes to str (UUID)
  - adds expires_at field for more controllable auto-expire in mongodb
