### PR TITLE
Use a custom ApiRouter.api_route to allow for endpoints with and with…

### DIFF
--- a/src/eduid/scimapi/api_router.py
+++ b/src/eduid/scimapi/api_router.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Callable
+
+from fastapi import APIRouter as FastAPIRouter
+from fastapi.types import DecoratedCallable
+
+__author__ = 'lundberg'
+
+# Workaround from https://github.com/tiangolo/fastapi/issues/2060#issuecomment-834868906
+#
+# Adds endpoints with and without trailing slash, only adds the one without a trailing slash to docs
+#
+
+
+class APIRouter(FastAPIRouter):
+    def api_route(
+        self, path: str, *, include_in_schema: bool = True, **kwargs: Any
+    ) -> Callable[[DecoratedCallable], DecoratedCallable]:
+        if path.endswith("/"):
+            path = path[:-1]
+
+        add_path = super().api_route(path, include_in_schema=include_in_schema, **kwargs)
+
+        alternate_path = path + "/"
+        add_alternate_path = super().api_route(alternate_path, include_in_schema=False, **kwargs)
+
+        def decorator(func: DecoratedCallable) -> DecoratedCallable:
+            add_alternate_path(func)
+            return add_path(func)
+
+        return decorator

--- a/src/eduid/scimapi/routers/events.py
+++ b/src/eduid/scimapi/routers/events.py
@@ -2,8 +2,9 @@
 from datetime import timedelta
 from typing import Optional
 
-from fastapi import APIRouter, Response
+from fastapi import Response
 
+from eduid.scimapi.api_router import APIRouter
 from eduid.scimapi.context_request import ContextRequest, ContextRequestRoute
 from eduid.scimapi.db.eventdb import ScimApiEvent, ScimApiEventResource
 from eduid.scimapi.exceptions import BadRequest, NotFound

--- a/src/eduid/scimapi/routers/groups.py
+++ b/src/eduid/scimapi/routers/groups.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Response
+from fastapi import Response
 
+from eduid.scimapi.api_router import APIRouter
 from eduid.scimapi.context_request import ContextRequest, ContextRequestRoute
 from eduid.scimapi.db.eventdb import EventLevel, EventStatus, add_api_event
 from eduid.scimapi.exceptions import BadRequest, NotFound

--- a/src/eduid/scimapi/routers/invites.py
+++ b/src/eduid/scimapi/routers/invites.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from typing import Optional
 
-from fastapi import APIRouter, Response
+from fastapi import Response
 
+from eduid.scimapi.api_router import APIRouter
 from eduid.scimapi.context_request import ContextRequest, ContextRequestRoute
 from eduid.scimapi.db.common import ScimApiEmail, ScimApiName, ScimApiPhoneNumber, ScimApiProfile
 from eduid.scimapi.db.eventdb import EventLevel, EventStatus, add_api_event

--- a/src/eduid/scimapi/routers/login.py
+++ b/src/eduid/scimapi/routers/login.py
@@ -1,8 +1,9 @@
 import datetime
 
-from fastapi import APIRouter, Response
+from fastapi import Response
 from jwcrypto import jwt
 
+from eduid.scimapi.api_router import APIRouter
 from eduid.scimapi.context_request import ContextRequest
 from eduid.scimapi.exceptions import Unauthorized
 from eduid.scimapi.models.login import TokenRequest

--- a/src/eduid/scimapi/routers/status.py
+++ b/src/eduid/scimapi/routers/status.py
@@ -2,8 +2,9 @@
 from os import environ
 from typing import Mapping
 
-from fastapi import APIRouter, Response
+from fastapi import Response
 
+from eduid.scimapi.api_router import APIRouter
 from eduid.scimapi.context_request import ContextRequest, ContextRequestRoute
 from eduid.scimapi.models.status import StatusResponse
 from eduid.scimapi.routers.utils.status import check_mongo, check_neo4j, get_cached_response, set_cached_response

--- a/src/eduid/scimapi/routers/users.py
+++ b/src/eduid/scimapi/routers/users.py
@@ -2,8 +2,9 @@ import pprint
 from dataclasses import replace
 from typing import Optional
 
-from fastapi import APIRouter, Response
+from fastapi import Response
 
+from eduid.scimapi.api_router import APIRouter
 from eduid.scimapi.context_request import ContextRequest, ContextRequestRoute
 from eduid.scimapi.db.common import ScimApiEmail, ScimApiLinkedAccount, ScimApiName, ScimApiPhoneNumber
 from eduid.scimapi.db.eventdb import EventLevel, EventStatus, add_api_event


### PR DESCRIPTION
…out trailing slash