### PR TITLE
make the webauthn code session agnostic

### DIFF
--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -58,6 +58,9 @@ class Common(SessionNSBase):
     preferred_language: Optional[str] = None
 
 
+WebauthnState = NewType('WebauthnState', Dict[str, Any])
+
+
 class MfaAction(SessionNSBase):
     success: bool = False
     error: Optional[MfaActionError] = None
@@ -66,7 +69,7 @@ class MfaAction(SessionNSBase):
     authn_instant: Optional[str] = None
     authn_context: Optional[str] = None
     # Webauthn MFA parameters
-    webauthn_state: Optional[Dict[str, Any]] = None
+    webauthn_state: Optional[WebauthnState] = None
 
 
 class TimestampedNS(SessionNSBase):

--- a/src/eduid/webapp/reset_password/helpers.py
+++ b/src/eduid/webapp/reset_password/helpers.py
@@ -47,7 +47,6 @@ from eduid.userdb.logs import MailAddressProofing, PhoneNumberProofing
 from eduid.userdb.reset_password import (
     ResetPasswordEmailAndPhoneState,
     ResetPasswordEmailState,
-    ResetPasswordState,
     ResetPasswordUser,
 )
 from eduid.userdb.reset_password.element import CodeElement
@@ -389,7 +388,9 @@ def get_extra_security_alternatives(user: User) -> dict:
     tokens = fido_tokens.get_user_credentials(user)
 
     if tokens:
-        alternatives['tokens'] = fido_tokens.start_token_verification(user, current_app.conf.fido2_rp_id)
+        alternatives['tokens'] = fido_tokens.start_token_verification(
+            user, current_app.conf.fido2_rp_id, session.mfa_action
+        )
 
     return alternatives
 


### PR DESCRIPTION
This fixes a bug in the new IdP API where it (the IdP) clears the
content from the session before trying to do webauthn verification, but
it also makes us able to support concurrent webauthn actions in a
session in the future, by avoiding necessarily having the state globally
shared.