### PR TITLE
Remember webauthn authenticator type per credential.

### DIFF
--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -17,6 +17,8 @@ from eduid.userdb.credentials import Credential
 
 __author__ = 'ft'
 
+from eduid.userdb.credentials.fido import WebauthnAuthenticator
+
 from eduid.userdb.element import ElementKey
 from eduid.webapp.common.authn.acs_enums import AuthnAcsAction, EidasAcsAction
 
@@ -92,11 +94,18 @@ class ResetPasswordNS(SessionNSBase):
     extrasec_webauthn_state: Optional[str] = None
 
 
+class WebauthnRegistration(SessionNSBase):
+    # Data stored between webauthn register "begin" and "complete"
+    webauthn_state: WebauthnState
+    authenticator: WebauthnAuthenticator
+
+
 class SecurityNS(SessionNSBase):
     # used for new change_password
     generated_password_hash: Optional[str] = None
-    # used for update user data from offical source
+    # used for update user data from official source
     user_requested_update: Optional[datetime] = None
+    webauthn_registration: Optional[WebauthnRegistration] = None
 
 
 class Signup(TimestampedNS):

--- a/src/eduid/webapp/eidas/tests/test_app.py
+++ b/src/eduid/webapp/eidas/tests/test_app.py
@@ -16,7 +16,7 @@ from mock import patch
 from eduid.common.config.base import EduidEnvironment
 from eduid.userdb import LockedIdentityNin, Nin
 from eduid.userdb.credentials import U2F, Webauthn
-from eduid.userdb.credentials.fido import FidoCredential
+from eduid.userdb.credentials.fido import FidoCredential, WebauthnAuthenticator
 from eduid.userdb.element import ElementKey
 from eduid.webapp.common.api.messages import TranslatableMsg, redirect_with_msg
 from eduid.webapp.common.api.testing import EduidAPITestCase
@@ -190,6 +190,7 @@ class EidasTests(EduidAPITestCase):
                 attest_obj='test',
                 description='test',
                 created_by='test',
+                authenticator=WebauthnAuthenticator.cross_platform,
             )
         user.credentials.add(mfa_token)
         self.request_user_sync(user)

--- a/src/eduid/webapp/idp/tests/test_actions.py
+++ b/src/eduid/webapp/idp/tests/test_actions.py
@@ -43,6 +43,7 @@ from mock import patch
 
 from eduid.userdb.actions.action import ActionResultMFA
 from eduid.userdb.credentials import U2F, Webauthn
+from eduid.userdb.credentials.fido import WebauthnAuthenticator
 from eduid.userdb.idp import IdPUser
 from eduid.userdb.tou import ToUEvent
 from eduid.vccs.client import VCCSClient
@@ -86,6 +87,7 @@ class TestActions(SSOIdPTests):
             app_id='https://dev.eduid.se/u2f-app-id.json',
             attest_obj='test_attest_obj',
             description='test_description',
+            authenticator=WebauthnAuthenticator.cross_platform,
         )
 
     def update_config(self, config):
@@ -201,6 +203,7 @@ class TestActions(SSOIdPTests):
             app_id='https://dev.eduid.se/u2f-app-id.json',
             attest_obj='test_attest_obj',
             description='test_description',
+            authenticator=WebauthnAuthenticator.cross_platform,
         )
         self.test_user.credentials.add(webauthn)
         self.amdb.save(self.test_user, check_sync=False)
@@ -381,6 +384,7 @@ class TestActions(SSOIdPTests):
             app_id='https://dev.eduid.se/u2f-app-id.json',
             attest_obj='test_attest_obj',
             description='test_description',
+            authenticator=WebauthnAuthenticator.cross_platform,
         )
         self.test_user.credentials.add(webauthn)
         self.amdb.save(self.test_user, check_sync=False)

--- a/src/eduid/webapp/security/helpers.py
+++ b/src/eduid/webapp/security/helpers.py
@@ -95,6 +95,8 @@ class SecurityMsg(TranslatableMsg):
     navet_data_incomplete = 'security.navet-data-incomplete'
     user_updated = 'security.user-updated'
     no_webauthn = 'security.webauthn-token-notfound'
+    invalid_authenticator = 'security.webauthn-invalid-authenticator'
+    missing_registration_state = 'security.webauthn-missing-registration-state'
 
 
 def credentials_to_registered_keys(user_u2f_tokens: List[FidoCredential]) -> List[U2FRegisteredKey]:


### PR DESCRIPTION
This is needed to request the right UI for the registered credential
when doing authentication, when we start allowing platform
authenticators.