### PR TITLE
bugfix: look for a credential recently used in both login and reauthn

### DIFF
--- a/src/eduid/webapp/authn/helpers.py
+++ b/src/eduid/webapp/authn/helpers.py
@@ -1,24 +1,33 @@
+import logging
+from typing import Optional
+
 from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.credentials import Credential
 from eduid.webapp.common.authn.acs_enums import AuthnAcsAction
 from eduid.webapp.common.session import session
+from eduid.webapp.common.session.namespaces import SP_AuthnRequest
+
+logger = logging.getLogger(__name__)
 
 
 def credential_used_to_authenticate(credential: Credential, max_age: int) -> bool:
     """
     Check if a particular credential was used to authenticate (using the eduID IdP and authn).
     """
-    current_action = None
-    login_action = session.authn.sp.get_authn_for_action(AuthnAcsAction.login)
-    reauthn_actions = session.authn.sp.get_authn_for_action(AuthnAcsAction.reauthn)
-    if login_action and credential.key in login_action.credentials_used:
-        current_action = login_action
-    elif reauthn_actions and credential.key in reauthn_actions.credentials_used:
-        current_action = reauthn_actions
+    logger.debug(f'Checking if credential {credential} has been used in the last {max_age} seconds')
 
-    if current_action and credential.key in current_action.credentials_used:
-        if current_action.authn_instant is not None:
-            age = (utc_now() - current_action.authn_instant).total_seconds()
+    login = session.authn.sp.get_authn_for_action(AuthnAcsAction.login)
+    reauthn = session.authn.sp.get_authn_for_action(AuthnAcsAction.reauthn)
+
+    if _credential_recently_used(credential, login, max_age) or _credential_recently_used(credential, reauthn, max_age):
+        return True
+    return False
+
+
+def _credential_recently_used(credential: Credential, action: Optional[SP_AuthnRequest], max_age: int) -> bool:
+    if action and credential.key in action.credentials_used:
+        if action.authn_instant is not None:
+            age = (utc_now() - action.authn_instant).total_seconds()
             if 0 < age < max_age:
                 return True
     return False


### PR DESCRIPTION
Previously, if credential X was used 1500 seconds ago in login, and 7
seconds ago in reauthn, we would say it was too old because 1500 > max_age.