### PR TITLE
Rework external credentials

### DIFF
--- a/src/eduid/userdb/credentials/external.py
+++ b/src/eduid/userdb/credentials/external.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, Mapping, Optional, Type
+
+from bson import ObjectId
+from pydantic import Field, validator
+
+from eduid.userdb.credentials import Credential
+
+__author__ = 'ft'
+
+from eduid.userdb.element import ElementKey
+
+
+class TrustFramework(str, Enum):
+    SWECONN = 'SWECONN'
+
+
+class ExternalCredential(Credential):
+    credential_id: str = Field(alias='id')
+    framework: TrustFramework
+
+    @validator('credential_id', pre=True)
+    def credential_id_objectid(cls, v):
+        """ Turn ObjectId into string """
+        if isinstance(v, ObjectId):
+            v = str(v)
+        if not isinstance(v, str):
+            raise TypeError('must be a string or ObjectId')
+        return v
+
+    @property
+    def key(self) -> ElementKey:
+        """
+        Return the element that is used as key.
+        """
+        return ElementKey(self.credential_id)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = super().to_dict()
+        data['framework'] = self.framework.value
+        return data
+
+
+class SwedenConnectCredential(ExternalCredential):
+    # To be technology neutral, we don't want to store e.g. the SAML authnContextClassRef in the database,
+    # and mapping a level to an authnContextClassRef really ought to be dependant on configuration matching
+    # the IdP:s expected values at a certain time. Such configuration is better to have in the SP than in
+    # the database layer.
+    level: str  # a value like "loa3", "eidas_sub", ...
+
+    @classmethod
+    def new(cls: Type[SwedenConnectCredential], level: str) -> SwedenConnectCredential:
+        return cls(framework=TrustFramework.SWECONN, level=level, credential_id=str(ObjectId()))
+
+
+def external_credential_from_dict(data: Mapping[str, Any]) -> Optional[ExternalCredential]:
+    if data['framework'] == TrustFramework.SWECONN.value:
+        return SwedenConnectCredential.from_dict(data)
+    return None

--- a/src/eduid/userdb/credentials/external.py
+++ b/src/eduid/userdb/credentials/external.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from enum import Enum, unique
+from enum import Enum
 from typing import Any, Dict, Mapping, Optional, Type
 
 from bson import ObjectId
 from pydantic import Field, validator
 
 from eduid.userdb.credentials import Credential
-
-__author__ = 'ft'
-
 from eduid.userdb.element import ElementKey
 
 

--- a/src/eduid/userdb/credentials/external.py
+++ b/src/eduid/userdb/credentials/external.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, unique
 from typing import Any, Dict, Mapping, Optional, Type
 
 from bson import ObjectId

--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -81,7 +81,7 @@ from __future__ import annotations
 import copy
 from abc import ABC
 from datetime import datetime
-from typing import Any, Dict, Generic, List, NewType, Optional, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Mapping, NewType, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel, Extra, Field, validator
 from pydantic.generics import GenericModel
@@ -152,18 +152,18 @@ class Element(BaseModel):
         return f'<eduID {self.__class__.__name__}: {self.dict()}>'
 
     @classmethod
-    def from_dict(cls: Type[TElementSubclass], data: Dict[str, Any]) -> TElementSubclass:
+    def from_dict(cls: Type[TElementSubclass], data: Mapping[str, Any]) -> TElementSubclass:
         """
         Construct element from a data dict in eduid format.
         """
         if not isinstance(data, dict):
             raise UserDBValueError(f"Invalid data: {data}")
 
-        data = copy.deepcopy(data)  # to not modify callers data
+        _data = copy.deepcopy(data)  # to not modify callers data
 
-        data = cls._from_dict_transform(data)
+        _data = cls._from_dict_transform(_data)
 
-        return cls(**data)
+        return cls(**_data)
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/src/eduid/userdb/tests/test_credentials.py
+++ b/src/eduid/userdb/tests/test_credentials.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 import eduid.userdb.element
 import eduid.userdb.exceptions
-from eduid.userdb.credentials import CredentialList, U2F
+from eduid.userdb.credentials import U2F, CredentialList
 from eduid.userdb.credentials.external import SwedenConnectCredential
 from eduid.userdb.element import ElementKey
 

--- a/src/eduid/userdb/tests/test_credentials.py
+++ b/src/eduid/userdb/tests/test_credentials.py
@@ -7,7 +7,9 @@ from pydantic import ValidationError
 
 import eduid.userdb.element
 import eduid.userdb.exceptions
-from eduid.userdb.credentials import U2F, CredentialList
+from eduid.userdb.credentials import CredentialList, U2F
+from eduid.userdb.credentials.external import SwedenConnectCredential
+from eduid.userdb.element import ElementKey
 
 __author__ = 'lundberg'
 
@@ -112,7 +114,7 @@ class TestCredentialList(unittest.TestCase):
         assert obtained == expected, 'List of credentials with added password different than expected'
 
     def test_remove(self):
-        self.three.remove(str(ObjectId('333333333333333333333333')))
+        self.three.remove(ElementKey(str(ObjectId('333333333333333333333333'))))
         now_two = self.three
 
         expected = self.two.to_list_of_dicts()
@@ -122,7 +124,7 @@ class TestCredentialList(unittest.TestCase):
 
     def test_remove_unknown(self):
         with self.assertRaises(eduid.userdb.exceptions.UserDBValueError):
-            self.one.remove(str(ObjectId('55002741d00690878ae9b603')))
+            self.one.remove(ElementKey(str(ObjectId('55002741d00690878ae9b603'))))
 
     def test_generated(self):
         match = self.three.find('222222222222222222222222')
@@ -131,3 +133,17 @@ class TestCredentialList(unittest.TestCase):
         match = self.three.find('333333333333333333333333')
         assert isinstance(match, Password)
         assert match.is_generated is True
+
+    def test_external_credential(self):
+        _id = ElementKey(str(ObjectId()))
+        # A SwedenConnectCredential as stored in the database
+        data = {'framework': 'SWECONN', 'level': 'loa3', 'credential_id': _id}
+        this = CredentialList.from_list_of_dicts([data])
+        assert this.elements != []
+        assert this.to_list_of_dicts() == [data]
+
+        # check object access
+        cred = this.elements[0]
+        assert isinstance(cred, SwedenConnectCredential)
+        assert cred.level == 'loa3'
+        assert cred.key == _id

--- a/src/eduid/webapp/common/authn/fido_tokens.py
+++ b/src/eduid/webapp/common/authn/fido_tokens.py
@@ -33,7 +33,7 @@ import base64
 import json
 import logging
 import pprint
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 from fido2 import cbor
 from fido2.client import ClientData
@@ -160,7 +160,7 @@ class WebauthnResult(BaseModel):
     credential_key: ElementKey
 
 
-def verify_webauthn(user: User, request_dict: Dict[str, Any], rp_id: str, state: MfaAction) -> WebauthnResult:
+def verify_webauthn(user: User, request_dict: Mapping[str, Any], rp_id: str, state: MfaAction) -> WebauthnResult:
     """
     Verify received Webauthn data against the user's credentials.
 

--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -171,7 +171,13 @@ class EduidSession(SessionMixin, MutableMapping):
 
     @mfa_action.deleter
     def mfa_action(self):
-        """ When an MFA action is completed, it is removed entirely from the session """
+        """
+        This can be thought of as the scratch area where the eidas SP communicates information back to the IdP.
+
+        Today, it is global state. We ought to make it either a (finite size) mapping or a list of MfaAction
+        to be able to correctly handle more than one authentication at a time.
+
+        When an MFA action is completed, it is removed entirely from the session """
         self._namespaces.mfa_action = None
         del self['mfa_action']
 

--- a/src/eduid/webapp/common/session/logindata.py
+++ b/src/eduid/webapp/common/session/logindata.py
@@ -9,6 +9,7 @@ from urllib.parse import urlencode
 
 from pydantic import BaseModel
 
+from eduid.userdb.element import ElementKey
 from eduid.webapp.common.session.namespaces import (
     IdP_OtherDevicePendingRequest,
     IdP_PendingRequest,
@@ -41,6 +42,7 @@ class ExternalMfaData(BaseModel):
     issuer: str
     authn_context: str
     timestamp: datetime
+    credential_id: Optional[ElementKey]
 
 
 @dataclass

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -17,6 +17,8 @@ from eduid.userdb.credentials import Credential
 
 __author__ = 'ft'
 
+from eduid.userdb.credentials.external import TrustFramework
+
 from eduid.userdb.credentials.fido import WebauthnAuthenticator
 from eduid.userdb.element import ElementKey
 from eduid.webapp.common.authn.acs_enums import AuthnAcsAction, EidasAcsAction
@@ -81,7 +83,10 @@ class MfaAction(SessionNSBase):
     error: Optional[MfaActionError] = None
     login_ref: Optional[str] = None
     authn_req_ref: Optional[AuthnRequestRef] = None
+    credential_used: Optional[ElementKey] = None
     # Third-party MFA parameters
+    framework: Optional[TrustFramework] = None
+    required_loa: Optional[str] = None
     issuer: Optional[str] = None
     authn_instant: Optional[str] = None
     authn_context: Optional[str] = None

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -18,7 +18,6 @@ from eduid.userdb.credentials import Credential
 __author__ = 'ft'
 
 from eduid.userdb.credentials.external import TrustFramework
-
 from eduid.userdb.credentials.fido import WebauthnAuthenticator
 from eduid.userdb.element import ElementKey
 from eduid.webapp.common.authn.acs_enums import AuthnAcsAction, EidasAcsAction

--- a/src/eduid/webapp/common/session/redis_session.py
+++ b/src/eduid/webapp/common/session/redis_session.py
@@ -315,10 +315,10 @@ class RedisEncryptedSession(collections.abc.MutableMapping):
         :param data_dict: Data to be stored
         :return: serialized data
         """
-        logger.debug(f'Storing data in Redis[{self.short_id}]:\n{repr(data_dict)}')
+        data_json = json.dumps(data_dict, cls=EduidJSONEncoder)
+        logger.debug(f'Storing data in Redis[{self.short_id}]:\n{data_json}')
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
         # Version data to make it easier to know how to decode it on reading
-        data_json = json.dumps(data_dict, cls=EduidJSONEncoder)
         versioned = {
             'v2': bytes(
                 self.secret_box.encrypt(data_json.encode('ascii'), nonce, encoder=nacl.encoding.Base64Encoder)

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-
+from typing import Optional
 
 from flask import request
 from werkzeug.wrappers import Response as WerkzeugResponse
 
 from eduid.userdb import LockedIdentityNin, User
+from eduid.userdb.credentials.external import SwedenConnectCredential, TrustFramework
 from eduid.userdb.credentials.fido import FidoCredential
+from eduid.userdb.element import ElementKey
 from eduid.userdb.logs import MFATokenProofing
 from eduid.userdb.proofing.user import ProofingUser
 from eduid.webapp.authn.helpers import credential_used_to_authenticate
@@ -22,7 +24,8 @@ from eduid.webapp.common.authn.utils import get_saml_attribute
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.namespaces import MfaActionError, SP_AuthnRequest
 from eduid.webapp.eidas.app import current_eidas_app as current_app
-from eduid.webapp.eidas.helpers import EidasMsg, token_verify_BACKDOOR, verify_nin_from_external_mfa
+from eduid.webapp.eidas.helpers import EidasMsg, verify_nin_from_external_mfa
+from eduid.webapp.eidas.helpers import token_verify_BACKDOOR
 
 __author__ = 'lundberg'
 
@@ -120,7 +123,7 @@ def token_verify_action(session_info: SessionInfo, user: User, authndata: SP_Aut
         return redirect_with_msg(redirect_url, CommonMsg.navet_error)
     proofing_log_entry = MFATokenProofing(
         eppn=proofing_user.eppn,
-        created_by='eduid-eidas',
+        created_by=current_app.conf.app_name,
         nin=user_nin.number,
         issuer=issuer,
         authn_context_class=authn_context,
@@ -261,7 +264,51 @@ def mfa_authentication_action(session_info: SessionInfo, authndata: SP_AuthnRequ
     session.mfa_action.issuer = session_info['issuer']
     session.mfa_action.authn_instant = session_info['authn_info'][0][2]
     session.mfa_action.authn_context = get_authn_ctx(session_info)
+    session.mfa_action.credential_used = _find_or_add_credential(
+        user, session.mfa_action.framework, session.mfa_action.required_loa
+    )
     current_app.stats.count(name='mfa_auth_success')
     current_app.stats.count(name=f'mfa_auth_{session_info["issuer"]}_success')
     current_app.logger.info(f'Redirecting to: {redirect_url}')
     return redirect_with_msg(redirect_url, EidasMsg.action_completed, error=False)
+
+
+def _find_or_add_credential(
+    user: User, framework: Optional[TrustFramework], required_loa: Optional[str]
+) -> Optional[ElementKey]:
+    if framework != TrustFramework.SWECONN:
+        current_app.logger.info(f'Not recording credential used for unknown trust framework: {framework}')
+        return None
+
+    for this in user.credentials.filter(SwedenConnectCredential):
+        if this.level == required_loa:
+            current_app.logger.debug(f'Found suitable credential on user: {this}')
+            return this.key
+
+    cred = SwedenConnectCredential.new(level=required_loa)
+    cred.created_by = current_app.conf.app_name
+    if required_loa == "loa3":
+        # TODO: proof token as SWAMID_AL2_MFA_HI?
+        pass
+
+    # Reload the user from the central database, to not overwrite any earlier NIN proofings
+    user = current_app.central_userdb.get_user_by_eppn(session.common.eppn)
+    if user is None:
+        # Please mypy
+        raise RuntimeError(f'No user with eppn {session.common.eppn} found')
+
+    proofing_user = ProofingUser.from_user(user, current_app.private_userdb)
+
+    proofing_user.credentials.add(cred)
+
+    current_app.logger.info(f'Adding new credential to proofing_user: {cred}')
+
+    # Save proofing_user to private db
+    current_app.private_userdb.save(proofing_user)
+
+    # Ask am to sync proofing_user to central db
+    current_app.logger.info(f'Request sync for proofing_user {proofing_user}')
+    result = current_app.am_relay.request_user_sync(proofing_user)
+    current_app.logger.info(f'Sync result for proofing_user {proofing_user}: {result}')
+
+    return cred.key

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -24,8 +24,7 @@ from eduid.webapp.common.authn.utils import get_saml_attribute
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.namespaces import MfaActionError, SP_AuthnRequest
 from eduid.webapp.eidas.app import current_eidas_app as current_app
-from eduid.webapp.eidas.helpers import EidasMsg, verify_nin_from_external_mfa
-from eduid.webapp.eidas.helpers import token_verify_BACKDOOR
+from eduid.webapp.eidas.helpers import EidasMsg, token_verify_BACKDOOR, verify_nin_from_external_mfa
 
 __author__ = 'lundberg'
 

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -123,7 +123,7 @@ def token_verify_action(session_info: SessionInfo, user: User, authndata: SP_Aut
         return redirect_with_msg(redirect_url, CommonMsg.navet_error)
     proofing_log_entry = MFATokenProofing(
         eppn=proofing_user.eppn,
-        created_by=current_app.conf.app_name,
+        created_by='eduid-eidas',
         nin=user_nin.number,
         issuer=issuer,
         authn_context_class=authn_context,
@@ -291,7 +291,7 @@ def _find_or_add_credential(
             return this.key
 
     cred = SwedenConnectCredential.new(level=required_loa)
-    cred.created_by = current_app.conf.app_name
+    cred.created_by = 'eduid-eidas'
     if required_loa == "loa3":
         # TODO: proof token as SWAMID_AL2_MFA_HI?
         pass

--- a/src/eduid/webapp/eidas/helpers.py
+++ b/src/eduid/webapp/eidas/helpers.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 from dateutil.parser import parse as dt_parse
 from flask import request
+from eduid.userdb.credentials.external import TrustFramework
 from saml2 import BINDING_HTTP_REDIRECT
 from saml2.client import Saml2Client
 from saml2.metadata import entity_descriptor
@@ -65,8 +66,15 @@ class EidasMsg(TranslatableMsg):
 
 
 def create_authn_request(
-    authn_ref: AuthnRequestRef, selected_idp: str, required_loa: str, force_authn: bool = False
+    authn_ref: AuthnRequestRef,
+    framework: TrustFramework,
+    selected_idp: str,
+    required_loa: str,
+    force_authn: bool = False,
 ) -> AuthnRequest:
+
+    if framework != TrustFramework.SWECONN:
+        raise ValueError(f'Unrecognised trust framework: {framework}')
 
     kwargs: Dict[str, Any] = {
         "force_authn": str(force_authn).lower(),

--- a/src/eduid/webapp/eidas/helpers.py
+++ b/src/eduid/webapp/eidas/helpers.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, Optional
 
 from dateutil.parser import parse as dt_parse
 from flask import request
-from eduid.userdb.credentials.external import TrustFramework
 from saml2 import BINDING_HTTP_REDIRECT
 from saml2.client import Saml2Client
 from saml2.metadata import entity_descriptor
@@ -15,6 +14,7 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 
 from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.credentials import Credential
+from eduid.userdb.credentials.external import TrustFramework
 from eduid.userdb.logs import MFATokenProofing, SwedenConnectProofing
 from eduid.userdb.proofing import NinProofingElement, ProofingUser
 from eduid.userdb.proofing.state import NinProofingState

--- a/src/eduid/webapp/eidas/settings/common.py
+++ b/src/eduid/webapp/eidas/settings/common.py
@@ -40,6 +40,7 @@ from typing import Dict, Mapping, Optional
 from pydantic import Field
 
 from eduid.common.config.base import AmConfigMixin, EduIDBaseAppConfig, MagicCookieMixin, MsgConfigMixin
+from eduid.userdb.credentials.external import TrustFramework
 
 
 class EidasConfig(EduIDBaseAppConfig, MagicCookieMixin, AmConfigMixin, MsgConfigMixin):
@@ -55,6 +56,7 @@ class EidasConfig(EduIDBaseAppConfig, MagicCookieMixin, AmConfigMixin, MsgConfig
     token_verify_redirect_url: str
     nin_verify_redirect_url: str
 
+    trust_framework: TrustFramework = TrustFramework.SWECONN
     required_loa: str = 'loa3'  # one of authentication_context_map below
 
     # Federation config

--- a/src/eduid/webapp/idp/assurance.py
+++ b/src/eduid/webapp/idp/assurance.py
@@ -35,17 +35,12 @@
 import logging
 from typing import Dict, List, Optional, Sequence
 
-from eduid.userdb.credentials import (
-    FidoCredential,
-    METHOD_SWAMID_AL2_MFA,
-    METHOD_SWAMID_AL2_MFA_HI,
-    Password,
-)
-from eduid.userdb.credentials.external import ExternalCredential, TrustFramework, SwedenConnectCredential
+from eduid.userdb.credentials import METHOD_SWAMID_AL2_MFA, METHOD_SWAMID_AL2_MFA_HI, FidoCredential, Password
+from eduid.userdb.credentials.external import ExternalCredential, SwedenConnectCredential, TrustFramework
 from eduid.userdb.element import ElementKey
 from eduid.userdb.idp import IdPUser
 from eduid.webapp.common.session.logindata import LoginContext, LoginContextSAML
-from eduid.webapp.common.session.namespaces import OnetimeCredType, OnetimeCredential
+from eduid.webapp.common.session.namespaces import OnetimeCredential, OnetimeCredType
 from eduid.webapp.idp.app import current_idp_app
 from eduid.webapp.idp.app import current_idp_app as current_app
 from eduid.webapp.idp.assurance_data import AuthnInfo, EduidAuthnContextClass, UsedCredential, UsedWhere

--- a/src/eduid/webapp/idp/exceptions.py
+++ b/src/eduid/webapp/idp/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from flask import render_template, request
 from werkzeug.exceptions import HTTPException

--- a/src/eduid/webapp/idp/idp_authn.py
+++ b/src/eduid/webapp/idp/idp_authn.py
@@ -59,6 +59,13 @@ from eduid.webapp.idp.settings.common import IdPConfig
 logger = logging.getLogger(__name__)
 
 
+class ExternalAuthnData(BaseModel):
+    """ Per-authentication remembered data about a used ExternalCredential """
+
+    issuer: str
+    authn_context: str
+
+
 class AuthnData(BaseModel):
     """
     Data about a successful authentication.
@@ -68,6 +75,7 @@ class AuthnData(BaseModel):
 
     cred_id: ElementKey
     timestamp: datetime = Field(default_factory=utc_now, alias='authn_ts')  # authn_ts was the old name in the db
+    external: Optional[ExternalAuthnData] = None
 
     class Config:
         allow_population_by_field_name = True  # allow setting timestamp using it's name, not just the alias

--- a/src/eduid/webapp/idp/idp_saml.py
+++ b/src/eduid/webapp/idp/idp_saml.py
@@ -2,15 +2,15 @@ import logging
 from hashlib import sha1
 from typing import Any, Dict, List, Mapping, NewType, Optional, Type, Union
 
-from werkzeug.exceptions import HTTPException
-
 import saml2.server
-from eduid.webapp.idp.assurance_data import AuthnInfo
-from eduid.webapp.idp.mischttp import HttpArgs
 from saml2.s_utils import UnknownPrincipal, UnknownSystemEntity, UnravelError, UnsupportedBinding
 from saml2.saml import Issuer
 from saml2.samlp import RequestedAuthnContext
 from saml2.sigver import verify_redirect_signature
+from werkzeug.exceptions import HTTPException
+
+from eduid.webapp.idp.assurance_data import AuthnInfo
+from eduid.webapp.idp.mischttp import HttpArgs
 
 ResponseArgs = NewType('ResponseArgs', Dict[str, Any])
 

--- a/src/eduid/webapp/idp/login.py
+++ b/src/eduid/webapp/idp/login.py
@@ -24,6 +24,7 @@ from defusedxml import ElementTree as DefusedElementTree
 from flask import make_response, redirect, render_template, request, url_for
 from flask_babel import gettext as _
 from pydantic import BaseModel
+from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT
 from werkzeug.exceptions import BadRequest, Forbidden, TooManyRequests
 from werkzeug.wrappers import Response as WerkzeugResponse
 
@@ -56,7 +57,6 @@ from eduid.webapp.idp.other_device.data import OtherDeviceState
 from eduid.webapp.idp.service import SAMLQueryParams, Service
 from eduid.webapp.idp.sso_session import SSOSession
 from eduid.webapp.idp.tou_action import add_tou_action, need_tou_acceptance
-from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT
 
 
 class MustAuthenticate(Exception):

--- a/src/eduid/webapp/idp/mfa_action.py
+++ b/src/eduid/webapp/idp/mfa_action.py
@@ -35,12 +35,12 @@ from typing import List, Optional
 from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.actions import Action
 from eduid.userdb.actions.action import ActionResultMFA, ActionResultThirdPartyMFA
-from eduid.userdb.credentials import Credential, FidoCredential, U2F, Webauthn
+from eduid.userdb.credentials import U2F, Credential, FidoCredential, Webauthn
 from eduid.userdb.credentials.external import SwedenConnectCredential
 from eduid.userdb.idp.user import IdPUser
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.logindata import ExternalMfaData, LoginContext
-from eduid.webapp.common.session.namespaces import OnetimeCredType, OnetimeCredential, RequestRef
+from eduid.webapp.common.session.namespaces import OnetimeCredential, OnetimeCredType, RequestRef
 from eduid.webapp.idp.app import current_idp_app as current_app
 from eduid.webapp.idp.assurance_data import EduidAuthnContextClass
 from eduid.webapp.idp.idp_authn import AuthnData

--- a/src/eduid/webapp/idp/mfa_action.py
+++ b/src/eduid/webapp/idp/mfa_action.py
@@ -36,6 +36,7 @@ from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.actions import Action
 from eduid.userdb.actions.action import ActionResultMFA, ActionResultThirdPartyMFA
 from eduid.userdb.credentials import Credential, FidoCredential, U2F, Webauthn
+from eduid.userdb.credentials.external import SwedenConnectCredential
 from eduid.userdb.idp.user import IdPUser
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.logindata import ExternalMfaData, LoginContext
@@ -64,7 +65,13 @@ def need_security_key(user: IdPUser, ticket: LoginContext) -> bool:
         else:
             credential = user.credentials.find(cred_key)
         if isinstance(credential, OnetimeCredential):
+            # OLD way
             if credential.type == OnetimeCredType.external_mfa:
+                logger.debug(f'User has authenticated using external MFA for this request: {credential}')
+                return False
+        elif isinstance(credential, SwedenConnectCredential):
+            # NEW way
+            if credential.level == 'loa3':
                 logger.debug(f'User has authenticated using external MFA for this request: {credential}')
                 return False
         elif isinstance(credential, FidoCredential):

--- a/src/eduid/webapp/idp/mischttp.py
+++ b/src/eduid/webapp/idp/mischttp.py
@@ -20,13 +20,13 @@ from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Type
 
 from flask import make_response, redirect, request
+from saml2 import BINDING_HTTP_REDIRECT
 from werkzeug.exceptions import BadRequest, InternalServerError
 from werkzeug.wrappers import Response as WerkzeugResponse
 
 from eduid.common.config.base import CookieConfig
 from eduid.webapp.common.api.sanitation import SanitationProblem, Sanitizer
 from eduid.webapp.idp.settings.common import IdPConfig
-from saml2 import BINDING_HTTP_REDIRECT
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/webapp/idp/sso_session.py
+++ b/src/eduid/webapp/idp/sso_session.py
@@ -89,6 +89,8 @@ class SSOSession(BaseModel):
     authn_timestamp: datetime = Field(default_factory=utc_now)
     created_ts: datetime = Field(default_factory=utc_now)
     expires_at: datetime = Field(default_factory=lambda: utc_now() + timedelta(minutes=5))
+    # TODO: should be obsolete now, everything in here should also be available in authn_credentials
+    #       (AuthnData.external), stored per credential instead of once per session.
     external_mfa: Optional[ExternalMfaData] = None
     obj_id: ObjectId = Field(default_factory=ObjectId, alias='_id')
     session_id: SSOSessionId = Field(default_factory=create_session_id)

--- a/src/eduid/webapp/idp/tests/test_SSO.py
+++ b/src/eduid/webapp/idp/tests/test_SSO.py
@@ -38,12 +38,15 @@ import logging
 from typing import List, Mapping, Optional, Sequence, Union
 from uuid import uuid4
 
-from werkzeug.exceptions import BadRequest
-
 import saml2.server
 import saml2.time_util
+from saml2 import BINDING_HTTP_POST
+from saml2.authn_context import PASSWORDPROTECTEDTRANSPORT
+from saml2.s_utils import UnravelError
+from werkzeug.exceptions import BadRequest
+
 from eduid.common.misc.timeutil import utc_now
-from eduid.userdb.credentials import Credential, METHOD_SWAMID_AL2_MFA, METHOD_SWAMID_AL2_MFA_HI, Password, U2F
+from eduid.userdb.credentials import METHOD_SWAMID_AL2_MFA, METHOD_SWAMID_AL2_MFA_HI, U2F, Credential, Password
 from eduid.userdb.idp import IdPUser
 from eduid.userdb.nin import Nin, NinList
 from eduid.webapp.common.session import session
@@ -56,9 +59,6 @@ from eduid.webapp.idp.login import NextResult, login_next_step
 from eduid.webapp.idp.sso_session import SSOSession
 from eduid.webapp.idp.tests.test_app import IdPTests
 from eduid.webapp.idp.util import b64encode
-from saml2 import BINDING_HTTP_POST
-from saml2.authn_context import PASSWORDPROTECTEDTRANSPORT
-from saml2.s_utils import UnravelError
 
 SWAMID_AL1 = 'http://www.swamid.se/policy/assurance/al1'
 SWAMID_AL2 = 'http://www.swamid.se/policy/assurance/al2'

--- a/src/eduid/webapp/idp/tests/test_SSOSession.py
+++ b/src/eduid/webapp/idp/tests/test_SSOSession.py
@@ -20,6 +20,7 @@ class test_SSOSession(IdPTests):
             'authn_credentials': [
                 {
                     'cred_id': '5fc8b78cbdaa0bf337490db1',
+                    'external': None,
                     'timestamp': datetime.fromisoformat('2020-09-13T12:26:40+00:00'),
                 }
             ],

--- a/src/eduid/webapp/idp/views/mfa_auth.py
+++ b/src/eduid/webapp/idp/views/mfa_auth.py
@@ -1,22 +1,30 @@
 from copy import deepcopy
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional, Union
 
 from flask import Blueprint, request
 
 from eduid.common.misc.timeutil import utc_now
-from eduid.userdb.credentials import FidoCredential
+from eduid.userdb import User
+from eduid.userdb.credentials import Credential, FidoCredential
 from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith
 from eduid.webapp.common.api.messages import FluxData, error_response, success_response
 from eduid.webapp.common.authn import fido_tokens
-from eduid.webapp.common.session import session
+from eduid.webapp.common.session import EduidSession, session
 from eduid.webapp.common.session.logindata import ExternalMfaData
-from eduid.webapp.common.session.namespaces import MfaActionError, OnetimeCredType, OnetimeCredential, RequestRef
+from eduid.webapp.common.session.namespaces import (
+    MfaAction,
+    MfaActionError,
+    OnetimeCredType,
+    OnetimeCredential,
+    RequestRef,
+)
 from eduid.webapp.idp.app import current_idp_app as current_app
 from eduid.webapp.idp.helpers import IdPMsg
 from eduid.webapp.idp.idp_authn import AuthnData
 from eduid.webapp.idp.login import get_ticket
 from eduid.webapp.idp.schemas import MfaAuthRequestSchema, MfaAuthResponseSchema
 from eduid.webapp.idp.service import SAMLQueryParams
+from eduid.webapp.idp.sso_session import SSOSession
 
 mfa_auth_views = Blueprint('mfa_auth', __name__, url_prefix='')
 
@@ -24,7 +32,7 @@ mfa_auth_views = Blueprint('mfa_auth', __name__, url_prefix='')
 @mfa_auth_views.route('/mfa_auth', methods=['POST'])
 @UnmarshalWith(MfaAuthRequestSchema)
 @MarshalWith(MfaAuthResponseSchema)
-def mfa_auth(ref: RequestRef, webauthn_response: Optional[Dict[str, str]] = None) -> FluxData:
+def mfa_auth(ref: RequestRef, webauthn_response: Optional[Mapping[str, str]] = None) -> FluxData:
     current_app.logger.debug('\n\n')
     current_app.logger.debug(f'--- MFA authentication ({request.method}) ---')
 
@@ -52,42 +60,98 @@ def mfa_auth(ref: RequestRef, webauthn_response: Optional[Dict[str, str]] = None
     saved_mfa_action = deepcopy(session.mfa_action)
     del session.mfa_action
 
+    credential = _check_external_mfa(saved_mfa_action, session, user, ref, sso_session)
+    if isinstance(credential, FluxData):
+        return credential
+
+    if not credential:
+        # No external MFA
+        credential = _check_webauthn(webauthn_response, saved_mfa_action, user)
+        if isinstance(credential, FluxData):
+            return credential
+
+    _utc_now = utc_now()
+
+    authn = AuthnData(cred_id=credential.key, timestamp=_utc_now)
+    sso_session.add_authn_credential(authn)
+    current_app.logger.debug(f'AuthnData to save: {authn}')
+
+    current_app.logger.debug(f'Saving SSO session {sso_session}')
+    current_app.sso_sessions.save(sso_session)
+
+    current_app.authn.log_authn(user, success=[credential.key], failure=[])
+
+    # Remember the MFA credential used for this particular request
+    session.idp.log_credential_used(ref, credential, _utc_now)
+
+    return success_response(payload={'finished': True})
+
+
+def _check_external_mfa(
+    mfa_action: MfaAction, session: EduidSession, user: User, ref: RequestRef, sso_session: Optional[SSOSession]
+) -> Optional[Union[Credential, FluxData]]:
+
     # Third party service MFA
-    if saved_mfa_action.success is True:  # Explicit check that success is the boolean True
-        current_app.logger.info(f'User {user} logged in using external MFA service {saved_mfa_action.issuer}')
+    if mfa_action.success is True:  # Explicit check that success is the boolean True
+        if mfa_action.login_ref:
+            # TODO: Make this an unconditional check once frontend has been updated to pass login_ref to
+            #       the eidas /mfa-authenticate endpoint
+            if mfa_action.login_ref != ref:
+                current_app.logger.info(f'MFA data in session does not match this request, rejecting')
+                return error_response(message=IdPMsg.general_failure)
+
+        current_app.logger.info(f'User {user} logged in using external MFA service {mfa_action.issuer}')
 
         _utc_now = utc_now()
 
         # External MFA authentication
         sso_session.external_mfa = ExternalMfaData(
-            issuer=saved_mfa_action.issuer, authn_context=saved_mfa_action.authn_context, timestamp=_utc_now
-        )
-        # Remember the MFA credential used for this particular request
-        otc = OnetimeCredential(
-            type=OnetimeCredType.external_mfa,
-            issuer=sso_session.external_mfa.issuer,
-            authn_context=sso_session.external_mfa.authn_context,
+            issuer=mfa_action.issuer,
+            authn_context=mfa_action.authn_context,
             timestamp=_utc_now,
+            credential_id=mfa_action.credential_used,
         )
-        session.idp.log_credential_used(ref, otc, _utc_now)
 
-        return success_response(payload={'finished': True})
+        if not mfa_action.credential_used:
+            # OLD way of referencing external MFA
+            # Remember the MFA credential used for this particular request
+            otc = OnetimeCredential(
+                type=OnetimeCredType.external_mfa,
+                issuer=sso_session.external_mfa.issuer,
+                authn_context=sso_session.external_mfa.authn_context,
+                timestamp=_utc_now,
+            )
+            session.idp.log_credential_used(ref, otc, _utc_now)
+            return otc
+
+        # NEW way
+        cred = user.credentials.find(mfa_action.credential_used)
+        if cred:
+            current_app.logger.debug(f'Logging credential used in session: {cred}')
+            session.idp.log_credential_used(ref, cred, _utc_now)
+        else:
+            current_app.logger.info(f'MFA action credential used not found on user: {mfa_action.credential_used}')
+
+        return cred
 
     # External MFA was tried and failed, mfa_action.error is set in the eidas app
-    if saved_mfa_action.error is not None:
-        if saved_mfa_action.error is MfaActionError.authn_context_mismatch:
+    if mfa_action.error is not None:
+        if mfa_action.error is MfaActionError.authn_context_mismatch:
             return error_response(message=IdPMsg.eidas_authn_context_mismatch)
-        elif saved_mfa_action.error is MfaActionError.authn_too_old:
+        elif mfa_action.error is MfaActionError.authn_too_old:
             return error_response(message=IdPMsg.eidas_reauthn_expired)
-        elif saved_mfa_action.error is MfaActionError.nin_not_matching:
+        elif mfa_action.error is MfaActionError.nin_not_matching:
             return error_response(message=IdPMsg.eidas_nin_not_matching)
         else:
-            current_app.logger.warning(f'eidas returned {saved_mfa_action.error} that did not match an error message')
+            current_app.logger.warning(f'eidas returned {mfa_action.error} that did not match an error message')
             return error_response(message=IdPMsg.general_failure)
 
-    #
-    # No external MFA
-    #
+    return None
+
+
+def _check_webauthn(
+    webauthn_response: Optional[Mapping[str, str]], mfa_action: MfaAction, user: User
+) -> Optional[Union[Credential, FluxData]]:
     if webauthn_response is None:
         payload: Dict[str, Any] = {'finished': False}
 
@@ -101,12 +165,12 @@ def mfa_auth(ref: RequestRef, webauthn_response: Optional[Dict[str, str]] = None
     #
     # Process webauthn_response
     #
-    if not saved_mfa_action.webauthn_state:
+    if not mfa_action.webauthn_state:
         current_app.logger.error(f'No active webauthn challenge found in the session, can\'t do verification')
         return error_response(message=IdPMsg.general_failure)
 
     try:
-        result = fido_tokens.verify_webauthn(user, webauthn_response, current_app.conf.fido2_rp_id, saved_mfa_action)
+        result = fido_tokens.verify_webauthn(user, webauthn_response, current_app.conf.fido2_rp_id, mfa_action)
     except fido_tokens.VerificationProblem:
         current_app.logger.exception('Webauthn verification failed')
         current_app.logger.debug(f'webauthn_response: {repr(webauthn_response)}')
@@ -117,23 +181,9 @@ def mfa_auth(ref: RequestRef, webauthn_response: Optional[Dict[str, str]] = None
     if not result.success:
         return error_response(message=IdPMsg.mfa_auth_failed)
 
-    _utc_now = utc_now()
-
     cred = user.credentials.find(result.credential_key)
     if not cred:
         current_app.logger.error(f'Could not find credential {result.credential_key} on user {user}')
         return error_response(message=IdPMsg.general_failure)
 
-    authn = AuthnData(cred_id=result.credential_key, timestamp=_utc_now)
-    sso_session.add_authn_credential(authn)
-    current_app.logger.debug(f'AuthnData to save: {authn}')
-
-    current_app.logger.debug(f'Saving SSO session {sso_session}')
-    current_app.sso_sessions.save(sso_session)
-
-    current_app.authn.log_authn(user, success=[result.credential_key], failure=[])
-
-    # Remember the MFA credential used for this particular request
-    session.idp.log_credential_used(ref, cred, _utc_now)
-
-    return success_response(payload={'finished': True})
+    return cred

--- a/src/eduid/webapp/idp/views/mfa_auth.py
+++ b/src/eduid/webapp/idp/views/mfa_auth.py
@@ -15,8 +15,8 @@ from eduid.webapp.common.session.logindata import ExternalMfaData
 from eduid.webapp.common.session.namespaces import (
     MfaAction,
     MfaActionError,
-    OnetimeCredType,
     OnetimeCredential,
+    OnetimeCredType,
     RequestRef,
 )
 from eduid.webapp.idp.app import current_idp_app as current_app

--- a/src/eduid/webapp/idp/views/next.py
+++ b/src/eduid/webapp/idp/views/next.py
@@ -2,6 +2,7 @@ from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
 from flask import Blueprint, url_for
+from saml2 import BINDING_HTTP_POST
 
 from eduid.userdb import LockedIdentityNin
 from eduid.userdb.credentials import FidoCredential, Password
@@ -14,13 +15,9 @@ from eduid.webapp.idp.app import current_idp_app as current_app
 from eduid.webapp.idp.helpers import IdPAction, IdPMsg
 from eduid.webapp.idp.login import SSO, get_ticket, login_next_step
 from eduid.webapp.idp.other_device.device2 import device2_finish
-from eduid.webapp.idp.schemas import (
-    NextRequestSchema,
-    NextResponseSchema,
-)
+from eduid.webapp.idp.schemas import NextRequestSchema, NextResponseSchema
 from eduid.webapp.idp.service import SAMLQueryParams
 from eduid.webapp.idp.sso_session import SSOSession
-from saml2 import BINDING_HTTP_POST
 
 next_views = Blueprint('next', __name__, url_prefix='')
 

--- a/src/eduid/webapp/idp/views/use_other.py
+++ b/src/eduid/webapp/idp/views/use_other.py
@@ -14,15 +14,15 @@ from eduid.webapp.idp.app import current_idp_app as current_app
 from eduid.webapp.idp.helpers import IdPMsg
 from eduid.webapp.idp.mischttp import set_sso_cookie
 from eduid.webapp.idp.other_device.data import OtherDeviceId, OtherDeviceState
+from eduid.webapp.idp.other_device.device1 import device1_check_response_code, device1_state_to_flux_payload
 from eduid.webapp.idp.other_device.device2 import device2_state_to_flux_payload
+from eduid.webapp.idp.other_device.helpers import _get_other_device_state_using_ref
 from eduid.webapp.idp.schemas import (
     UseOther1RequestSchema,
     UseOther1ResponseSchema,
     UseOther2RequestSchema,
     UseOther2ResponseSchema,
 )
-from eduid.webapp.idp.other_device.device1 import device1_check_response_code, device1_state_to_flux_payload
-from eduid.webapp.idp.other_device.helpers import _get_other_device_state_using_ref
 
 other_device_views = Blueprint('other_device', __name__, url_prefix='')
 

--- a/src/eduid/webapp/jsconfig/views.py
+++ b/src/eduid/webapp/jsconfig/views.py
@@ -30,7 +30,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-import time
 from typing import Any, Dict, List
 
 from flask import Blueprint
@@ -83,8 +82,6 @@ def get_dashboard_config() -> FluxData:
     if current_app.conf.fix_dashboard_uppercase_config:
         config_dict = _fix_uppercase_config(config_dict)
 
-    time.sleep(3)
-
     return success_response(payload=config_dict)
 
 
@@ -132,5 +129,4 @@ def get_login_config() -> FluxData:
         'sentry_dsn': current_app.conf.jsapps.sentry_dsn,
         'environment': current_app.conf.jsapps.environment.value,
     }
-    time.sleep(3)
     return success_response(payload=payload)

--- a/src/eduid/webapp/jsconfig/views.py
+++ b/src/eduid/webapp/jsconfig/views.py
@@ -30,6 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+import time
 from typing import Any, Dict, List
 
 from flask import Blueprint
@@ -82,6 +83,8 @@ def get_dashboard_config() -> FluxData:
     if current_app.conf.fix_dashboard_uppercase_config:
         config_dict = _fix_uppercase_config(config_dict)
 
+    time.sleep(3)
+
     return success_response(payload=config_dict)
 
 
@@ -129,4 +132,5 @@ def get_login_config() -> FluxData:
         'sentry_dsn': current_app.conf.jsapps.sentry_dsn,
         'environment': current_app.conf.jsapps.environment.value,
     }
+    time.sleep(3)
     return success_response(payload=payload)


### PR DESCRIPTION
OnetimeCredentials are slightly broken in master, because they are too complex / different than other credentials. This PR adds real ExternalCredential instances to user that use external authentication, making them much more alike the other credentials. 

This should be much easier and robust to work with going forward.