### PR TITLE
prepare for letting pydantic do the serializing instead of to_dict

### DIFF
--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -139,8 +139,8 @@ class Element(BaseModel):
     modified_ts: datetime = Field(default_factory=utc_now)
     # This is a short-term hack to deploy new dataclass based elements without
     # any changes to data in the production database. Remove after a burn-in period.
-    no_created_ts_in_db: bool = False
-    no_modified_ts_in_db: bool = False
+    no_created_ts_in_db: bool = Field(default=False, exclude=True)
+    no_modified_ts_in_db: bool = Field(default=False, exclude=True)
 
     class Config:
         allow_population_by_field_name = True  # allow setting created_ts by name, not just it's alias
@@ -205,15 +205,13 @@ class Element(BaseModel):
         """
         # If there was no modified_ts in the data that was loaded from the database,
         # don't write one back if it matches the implied one of created_ts
-        if 'no_modified_ts_in_db' in data:
-            if data.pop('no_modified_ts_in_db') is True:
-                if data.get('modified_ts') == data.get('created_ts'):
-                    del data['modified_ts']
+        if self.no_modified_ts_in_db is True:
+            if data.get('modified_ts') == data.get('created_ts'):
+                del data['modified_ts']
 
-        if 'no_created_ts_in_db' in data:
-            if data.pop('no_created_ts_in_db') is True:
-                if 'created_ts' in data:
-                    del data['created_ts']
+        if self.no_created_ts_in_db is True:
+            if 'created_ts' in data:
+                del data['created_ts']
 
         return data
 
@@ -234,7 +232,7 @@ class VerifiedElement(Element, ABC):
     Elements that can be verified or not.
     """
 
-    is_verified: bool = False
+    is_verified: bool = Field(default=False, alias='verified')
     verified_by: Optional[str] = None
     verified_ts: Optional[datetime] = None
 

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -178,7 +178,6 @@ class User(BaseModel):
             data['tou'] = self.tou.to_list_of_dicts()
         data['locked_identity'] = self.locked_identity.to_list_of_dicts()
         data['profiles'] = self.profiles.to_list_of_dicts()
-        data['orcid'] = None
         if self.orcid is not None:
             data['orcid'] = self.orcid.to_dict()
         if self.ladok is not None:

--- a/src/eduid/workers/am/testing.py
+++ b/src/eduid/workers/am/testing.py
@@ -38,7 +38,9 @@ __author__ = 'leifj'
 
 import logging
 from copy import deepcopy
+from datetime import timezone, datetime
 from typing import Any, Dict, Optional
+from uuid import UUID
 
 import bson
 import pytest
@@ -96,6 +98,19 @@ USER_DATA = {
         'id': 'orcid_unique_id',
         'verified': True,
         'created_by': 'orcid',
+    },
+    'ladok': {
+        'created_ts': datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
+        'modified_ts': datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
+        'verified_by': 'eduid-ladok',
+        'external_id': UUID('9555f3de-dd32-4bed-8e36-72ef00fb4df2'),
+        'university': {
+            'created_ts': datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
+            'modified_ts': datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
+            'ladok_name': 'ab',
+            'name': {'sv': 'Lärosätesnamn', 'en': 'University Name'},
+        },
+        'verified': True,
     },
 }
 


### PR DESCRIPTION
make sure no_created_ts_in_db and no_modified_ts_in_db never get to the db
added test case for ladok userdata