### PR TITLE
Handle multiple organizations using the same IdP

### DIFF
--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -119,8 +119,8 @@ class ScimAttributes(ResponseMicroService):
         self, data: satosa.internal.InternalData, scopes: Set[str], frontend_name: str
     ) -> Optional[ScimApiUser]:
         # Look for explicit information about what data owner to use for this IdP
-        data_owner: Optional[str] = self.config.virt_idp_to_data_owner.get(frontend_name)
         issuer = frontend_name
+        data_owner: Optional[str] = self.config.virt_idp_to_data_owner.get(issuer)
         # Fallback to issuer. Do we need that?
         if not data_owner:
             issuer = data.auth_info.issuer

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -20,8 +20,8 @@ class Config(object):
     mongo_uri: str
     idp_to_data_owner: Mapping[str, str]
     mfa_stepup_issuer_to_entity_id: Mapping[str, str]
-    scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
     virt_idp_to_data_owner: Mapping[str, str]
+    scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
 
 
 class ScimAttributes(ResponseMicroService):
@@ -124,7 +124,7 @@ class ScimAttributes(ResponseMicroService):
         # Fallback to issuer. Do we need that?
         if not data_owner:
             issuer = data.auth_info.issuer
-            data_owner: Optional[str] = self.config.idp_to_data_owner.get(issuer)
+            data_owner = self.config.idp_to_data_owner.get(issuer)
 
         if data_owner:
             logger.debug(f"Data owner for issuer {issuer}: {data_owner}")


### PR DESCRIPTION
When multiple organization uses the same IdP we can't determine their data owner key by the issuer so instead we need to fetch the key from the configuration based on the name of the virtual IdP.