### PR TITLE
get_user_by_eppn: Raise exception if no user is found.

### DIFF
--- a/src/eduid/userdb/support/db.py
+++ b/src/eduid/userdb/support/db.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from bson import ObjectId
 
 from eduid.userdb.db import TUserDbDocument
+from eduid.userdb.exceptions import UserDoesNotExist
 from eduid.userdb.proofing import LetterProofingState
 from eduid.userdb.signup import SignupUserDB
 from eduid.userdb.support import models
@@ -33,15 +34,18 @@ class SupportUserDB(UserDB[SupportUser]):
         :param query: search query, can be a user eppn, nin, mail address or phone number
         :return: A list of user docs
         """
-        results = list()
+        results: List[Optional[SupportUser]] = list()
         # We could do this with a custom filter (and one db call) but it is better to lean on existing methods
         # if the way we find users change in the future
-        results.append(self.get_user_by_eppn(query))
+        try:
+            results.append(self.get_user_by_eppn(query))
+        except UserDoesNotExist:
+            pass
         results.append(self.get_user_by_nin(query))
         results.extend(self.get_users_by_mail(query))
         results.extend(self.get_users_by_phone(query))
         users = [user for user in results if user]
-        return users
+        return [x for x in users if x is not None]
 
 
 class SupportSignupUserDB(SignupUserDB):

--- a/src/eduid/userdb/tests/test_userdb.py
+++ b/src/eduid/userdb/tests/test_userdb.py
@@ -32,10 +32,11 @@
 import logging
 
 import bson
+import pytest
 
 from eduid.common.testing_base import normalised_data
 from eduid.userdb import User
-from eduid.userdb.exceptions import UserOutOfSync
+from eduid.userdb.exceptions import UserDoesNotExist, UserOutOfSync
 from eduid.userdb.fixtures.passwords import signup_password
 from eduid.userdb.fixtures.users import UserFixtures
 from eduid.userdb.testing import MongoTestCase
@@ -91,7 +92,8 @@ class TestUserDB(MongoTestCase):
 
     def test_get_user_by_eppn_not_found(self):
         """Test user lookup using unknown"""
-        assert self.amdb.get_user_by_eppn("abc123") is None
+        with pytest.raises(UserDoesNotExist):
+            self.amdb.get_user_by_eppn("abc123")
 
 
 class UserMissingMeta(MongoTestCase):
@@ -136,7 +138,6 @@ class UpdateUser(MongoTestCase):
 
     def test_stale_user_meta_version(self):
         test_user = self.amdb.get_user_by_eppn(self.user.eppn)
-        assert test_user is not None
         test_user.given_name = "new_given_name"
         test_user.meta.new_version()
 

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -46,7 +46,7 @@ from pydantic import BaseModel, Extra, Field, root_validator, validator
 from eduid.userdb.credentials import CredentialList
 from eduid.userdb.db import BaseDB, TUserDbDocument
 from eduid.userdb.element import UserDBValueError
-from eduid.userdb.exceptions import UserHasNotCompletedSignup, UserIsRevoked
+from eduid.userdb.exceptions import UserDoesNotExist, UserHasNotCompletedSignup, UserIsRevoked
 from eduid.userdb.identity import IdentityList, IdentityType
 from eduid.userdb.ladok import Ladok
 from eduid.userdb.locked_identity import LockedIdentityList
@@ -266,7 +266,10 @@ class User(BaseModel):
 
         private_userdb = cast(UserDB[TUserSubclass], private_userdb)
 
-        private_user = private_userdb.get_user_by_eppn(user.eppn)
+        try:
+            private_user = private_userdb.get_user_by_eppn(user.eppn)
+        except UserDoesNotExist:
+            private_user = None
         logger.debug(f"{cls}: User in private database: {private_user}")
 
         new_user = cls.from_dict(data=user.to_dict())

--- a/src/eduid/userdb/userdb.py
+++ b/src/eduid/userdb/userdb.py
@@ -271,7 +271,7 @@ class UserDB(BaseDB, Generic[UserVar], ABC):
         filter = {"$or": [old_filter, new_filter]}
         return self._get_user_by_filter(filter)
 
-    def get_user_by_eppn(self, eppn: Optional[str]) -> Optional[UserVar]:
+    def get_user_by_eppn(self, eppn: Optional[str]) -> UserVar:
         """
         Look for a user using the eduPersonPrincipalName.
 
@@ -279,8 +279,11 @@ class UserDB(BaseDB, Generic[UserVar], ABC):
         """
         # allow eppn=None as convenience, to not have to check it everywhere before calling this function
         if eppn is None:
-            return None
-        return self._get_user_by_attr("eduPersonPrincipalName", eppn)
+            raise ValueError("eppn must not be None")
+        res = self._get_user_by_attr("eduPersonPrincipalName", eppn)
+        if not res:
+            raise UserDoesNotExist(f"No user with eppn {repr(eppn)}")
+        return res
 
     def _get_user_by_attr(self, attr: str, value: Any) -> Optional[UserVar]:
         """

--- a/src/eduid/webapp/authn/views.py
+++ b/src/eduid/webapp/authn/views.py
@@ -42,7 +42,7 @@ from saml2.saml import NAMEID_FORMAT_UNSPECIFIED, NameID, Subject
 from werkzeug.exceptions import Forbidden
 from werkzeug.wrappers import Response as WerkzeugResponse
 
-from eduid.userdb.exceptions import MultipleUsersReturned
+from eduid.userdb.exceptions import MultipleUsersReturned, UserDoesNotExist
 from eduid.webapp.authn import acs_actions  # acs_action needs to be imported to be loaded
 from eduid.webapp.authn.app import current_authn_app as current_app
 from eduid.webapp.common.api.errors import EduidErrorsContext, goto_errors_response
@@ -250,8 +250,9 @@ def logout() -> WerkzeugResponse:
         current_app.logger.info("Session cookie has expired, no logout action needed")
         return redirect(location)
 
-    user = current_app.central_userdb.get_user_by_eppn(eppn)
-    if not user:
+    try:
+        user = current_app.central_userdb.get_user_by_eppn(eppn)
+    except UserDoesNotExist:
         current_app.logger.error(f"User {eppn} not found, no logout action needed")
         return redirect(location)
 
@@ -333,8 +334,7 @@ def signup_authn() -> WerkzeugResponse:
         except MultipleUsersReturned:
             current_app.logger.error(f"There are more than one user with eduPersonPrincipalName = {eppn}")
             return redirect(location_on_fail)
-
-        if not user:
+        except UserDoesNotExist:
             current_app.logger.error(f"No user with eduPersonPrincipalName = {eppn} found")
             return redirect(location_on_fail)
 

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -129,7 +129,6 @@ class EduidAPITestCase(CommonTestCase):
 
         # Load the user from the database so that it can be saved there again in tests
         _test_user = self.amdb.get_user_by_eppn(users[0])
-        assert _test_user is not None
         # Initialize some convenience variables on self based on the first user in `users'
         self.test_user = _test_user
         self.test_user_data = self.test_user.to_dict()

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -14,7 +14,7 @@ from flask.wrappers import Request
 
 from eduid.common.misc.timeutil import utc_now
 from eduid.userdb import User, UserDB
-from eduid.userdb.exceptions import MultipleUsersReturned, UserDBValueError
+from eduid.userdb.exceptions import MultipleUsersReturned, UserDBValueError, UserDoesNotExist
 from eduid.webapp.common.api.exceptions import ApiException
 
 logger = logging.getLogger(__name__)
@@ -85,14 +85,14 @@ def get_user() -> User:
         raise ApiException("Not authorized", status_code=401)
     try:
         # Get user from central database
-        user = current_app.central_userdb.get_user_by_eppn(session.common.eppn)
-        if user:
-            return user
-        logger.error(f"Could not find user {session.common.eppn} in central database.")
-        raise ApiException("Not authorized", status_code=401)
+        return current_app.central_userdb.get_user_by_eppn(session.common.eppn)
 
     except MultipleUsersReturned:
         logger.exception(f"Found multiple users in central database for eppn {session.common.eppn}.")
+        raise ApiException("Not authorized", status_code=401)
+
+    except UserDoesNotExist:
+        logger.error(f"Could not find user {session.common.eppn} in central database.")
         raise ApiException("Not authorized", status_code=401)
 
 

--- a/src/eduid/webapp/common/proofing/base.py
+++ b/src/eduid/webapp/common/proofing/base.py
@@ -100,7 +100,6 @@ class ProofingFunctions(ABC, Generic[SessionInfoVar]):
 
         # re-load the user from central db before returning
         _user = current_app.central_userdb.get_user_by_eppn(proofing_user.eppn)
-        assert _user is not None  # please mypy
         return VerifyCredentialResult(user=_user)
 
     def match_identity(self, user: User, proofing_method: ProofingMethod) -> MatchResult:

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -64,7 +64,6 @@ class ProofingTests(EduidAPITestCase):
         and then again at the end to ensure the right set of changes occurred to the user in the database.
         """
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        assert user is not None
         user_mfa_tokens = user.credentials.filter(FidoCredential)
 
         # Check token status

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -151,9 +151,6 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     # Get user from central database
     user = current_app.central_userdb.get_user_by_eppn(session.common.eppn)
-    if user is None:
-        # Please mypy
-        raise RuntimeError(f"No user with eppn {session.common.eppn} found")
 
     parsed = args.proofing_method.parse_session_info(args.session_info, backdoor=args.backdoor)
     if parsed.error:

--- a/src/eduid/webapp/eidas/proofing.py
+++ b/src/eduid/webapp/eidas/proofing.py
@@ -149,7 +149,6 @@ class FrejaProofingFunctions(SwedenConnectProofingFunctions[NinSessionInfo]):
         current_app.stats.count(name="nin_verified")
         # re-load the user from central db before returning
         _user = current_app.central_userdb.get_user_by_eppn(proofing_user.eppn)
-        assert _user is not None  # please mypy
         return VerifyUserResult(user=ProofingUser.from_user(_user, current_app.private_userdb))
 
     def identity_proofing_element(self, user: User) -> ProofingElementResult:
@@ -319,7 +318,6 @@ class EidasProofingFunctions(SwedenConnectProofingFunctions[ForeignEidSessionInf
         current_app.stats.count(name="eidas_verified")
         # load the user from central db before returning
         _user = current_app.central_userdb.get_user_by_eppn(proofing_user.eppn)
-        assert _user is not None  # please mypy
         return VerifyUserResult(user=_user)
 
     def identity_proofing_element(self, user: User) -> ProofingElementResult:
@@ -431,9 +429,6 @@ def _find_or_add_credential(
 
     # Reload the user from the central database, to not overwrite any earlier NIN proofings
     _user = current_app.central_userdb.get_user_by_eppn(user.eppn)
-    if _user is None:
-        # Please mypy
-        raise RuntimeError(f"Could not reload user {user}")
 
     proofing_user = ProofingUser.from_user(_user, current_app.private_userdb)
 

--- a/src/eduid/webapp/eidas/tests/test_app.py
+++ b/src/eduid/webapp/eidas/tests/test_app.py
@@ -18,12 +18,10 @@ from eduid.common.rpc.msg_relay import DeregisteredCauseCode, DeregistrationInfo
 from eduid.userdb import NinIdentity
 from eduid.userdb.credentials import U2F, Webauthn
 from eduid.userdb.credentials.external import EidasCredential, ExternalCredential, SwedenConnectCredential
-from eduid.userdb.credentials.fido import FidoCredential
 from eduid.userdb.element import ElementKey
-from eduid.userdb.identity import EIDASIdentity, EIDASLoa, IdentityElement, PridPersistence
+from eduid.userdb.identity import EIDASIdentity, EIDASLoa, PridPersistence
 from eduid.webapp.authn.views import FALLBACK_FRONTEND_ACTION
 from eduid.webapp.common.api.messages import CommonMsg, TranslatableMsg, redirect_with_msg
-from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.common.authn.acs_enums import AuthnAcsAction, EidasAcsAction
 from eduid.webapp.common.authn.cache import OutstandingQueriesCache
 from eduid.webapp.common.proofing.messages import ProofingMsg
@@ -234,8 +232,6 @@ class EidasTests(ProofingTests):
 
     def add_token_to_user(self, eppn: str, credential_id: str, token_type) -> Union[U2F, Webauthn]:
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        # please mypy
-        assert user is not None
         mfa_token: Union[U2F, Webauthn]
         if token_type == "u2f":
             mfa_token = U2F(
@@ -262,8 +258,6 @@ class EidasTests(ProofingTests):
 
     def add_nin_to_user(self, eppn: str, nin: str, verified: bool) -> NinIdentity:
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        # please mypy
-        assert user is not None
         nin_element = NinIdentity(number=nin, created_by="test", is_verified=verified)
         user.identities.add(nin_element)
         self.request_user_sync(user)
@@ -271,8 +265,6 @@ class EidasTests(ProofingTests):
 
     def set_eidas_for_user(self, eppn: str, identity: EIDASIdentity, verified: bool) -> None:
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        # please mypy
-        assert user is not None
         identity.is_verified = verified
         user.identities.replace(element=identity)
         if verified is True:

--- a/src/eduid/webapp/ladok/tests/test_app.py
+++ b/src/eduid/webapp/ladok/tests/test_app.py
@@ -52,7 +52,6 @@ class LadokTests(EduidAPITestCase):
 
         # remove Ladok data from test user
         user = self.app.central_userdb.get_user_by_eppn(eppn=self.test_user_eppn)
-        assert user is not None
         user.ladok = None
         self.app.central_userdb.save(user)
 

--- a/src/eduid/webapp/personal_data/tests/test_app.py
+++ b/src/eduid/webapp/personal_data/tests/test_app.py
@@ -38,7 +38,7 @@ from flask import Response
 from mock import patch
 
 from eduid.userdb.element import ElementKey
-from eduid.userdb.exceptions import UserDoesNotExist
+from eduid.webapp.common.api.exceptions import ApiException
 from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.personal_data.app import PersonalDataApp, pd_init_app
 
@@ -163,7 +163,7 @@ class PersonalDataTests(EduidAPITestCase):
         self.assertIsNone(user_data["payload"].get("passwords"))
 
     def test_get_unknown_user(self):
-        with self.assertRaises(UserDoesNotExist):
+        with self.assertRaises(ApiException):
             self._get_user(eppn="fooo-fooo")
 
     def test_get_user_all_data(self):
@@ -205,7 +205,7 @@ class PersonalDataTests(EduidAPITestCase):
         assert user_data["payload"].get("passwords") is None
 
     def test_get_unknown_user_all_data(self):
-        with self.assertRaises(UserDoesNotExist):
+        with self.assertRaises(ApiException):
             self._get_user_all_data(eppn="fooo-fooo")
 
     def test_post_user(self):

--- a/src/eduid/webapp/personal_data/tests/test_app.py
+++ b/src/eduid/webapp/personal_data/tests/test_app.py
@@ -38,7 +38,7 @@ from flask import Response
 from mock import patch
 
 from eduid.userdb.element import ElementKey
-from eduid.webapp.common.api.exceptions import ApiException
+from eduid.userdb.exceptions import UserDoesNotExist
 from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.personal_data.app import PersonalDataApp, pd_init_app
 
@@ -104,7 +104,6 @@ class PersonalDataTests(EduidAPITestCase):
         if not verified_user:
             # Remove verified identities from the users
             user = self.app.central_userdb.get_user_by_eppn(eppn)
-            assert user is not None  # please mypy
             for identity in user.identities.verified:
                 user.identities.remove(ElementKey(identity.identity_type.value))
             self.app.central_userdb.save(user)
@@ -164,7 +163,7 @@ class PersonalDataTests(EduidAPITestCase):
         self.assertIsNone(user_data["payload"].get("passwords"))
 
     def test_get_unknown_user(self):
-        with self.assertRaises(ApiException):
+        with self.assertRaises(UserDoesNotExist):
             self._get_user(eppn="fooo-fooo")
 
     def test_get_user_all_data(self):
@@ -206,7 +205,7 @@ class PersonalDataTests(EduidAPITestCase):
         assert user_data["payload"].get("passwords") is None
 
     def test_get_unknown_user_all_data(self):
-        with self.assertRaises(ApiException):
+        with self.assertRaises(UserDoesNotExist):
             self._get_user_all_data(eppn="fooo-fooo")
 
     def test_post_user(self):

--- a/src/eduid/webapp/reset_password/tests/test_app.py
+++ b/src/eduid/webapp/reset_password/tests/test_app.py
@@ -180,7 +180,6 @@ class ResetPasswordTests(EduidAPITestCase):
 
         # check that the user has verified data
         user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
-        assert user is not None
         verified_phone_numbers = user.phone_numbers.verified
         self.assertEqual(len(verified_phone_numbers), 1)
         assert user.identities.nin is not None
@@ -305,7 +304,6 @@ class ResetPasswordTests(EduidAPITestCase):
         assert isinstance(state1, ResetPasswordEmailState)
 
         user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
-        assert user is not None
         alternatives = get_extra_security_alternatives(user)
         state1.extra_security = alternatives
         state1.email_code.is_verified = True
@@ -369,7 +367,6 @@ class ResetPasswordTests(EduidAPITestCase):
             credential.update(credential_data)
         webauthn_credential = Webauthn.from_dict(credential)
         user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
-        assert user is not None
         user.credentials.add(webauthn_credential)
         self.app.central_userdb.save(user)
 
@@ -428,7 +425,6 @@ class ResetPasswordTests(EduidAPITestCase):
         mock_get_vccs_client.return_value = TestVCCSClient()
 
         user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
-        assert user is not None
 
         response = self._post_email_address(data1=data1)
         state = self.app.password_reset_state_db.get_state_by_eppn(self.test_user.eppn)

--- a/src/eduid/webapp/security/tests/test_app.py
+++ b/src/eduid/webapp/security/tests/test_app.py
@@ -157,7 +157,6 @@ class SecurityTests(EduidAPITestCase):
         mock_request_user_sync.side_effect = self.request_user_sync
 
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
-        assert user is not None
         assert user.identities.nin is not None
         assert user.identities.nin.is_verified is True
 
@@ -188,7 +187,6 @@ class SecurityTests(EduidAPITestCase):
         mock_request_user_sync.side_effect = self.request_user_sync
 
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
-        assert user is not None
         assert user.identities.nin is not None
         assert user.identities.nin.is_verified is True
 

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -145,7 +145,6 @@ class SecurityWebauthnTests(EduidAPITestCase):
             authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
         )
         test_user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
-        assert test_user is not None
         test_user.credentials.add(credential)
         self.app.central_userdb.save(test_user)
         return credential
@@ -309,7 +308,6 @@ class SecurityWebauthnTests(EduidAPITestCase):
         eppn = self.test_user.eppn
 
         test_user = self.app.central_userdb.get_user_by_eppn(eppn)
-        assert test_user is not None
         # Remove all credentials except the password
         test_user.credentials = CredentialList(elements=test_user.credentials.filter(Password))
         self.app.central_userdb.save(test_user)
@@ -322,7 +320,6 @@ class SecurityWebauthnTests(EduidAPITestCase):
 
         # Verify what's in the database now matches our expectations
         test_user = self.app.central_userdb.get_user_by_eppn(eppn)
-        assert test_user is not None
         assert len(test_user.credentials.filter(FidoCredential)) == 1
 
         response = self.browser.post("/webauthn/remove", data={})

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -23,7 +23,7 @@ from eduid.queue.db import QueueItem, SenderInfo
 from eduid.queue.db.message import EduidSignupEmail
 from eduid.queue.db.message.payload import OldEduidSignupEmail
 from eduid.userdb import MailAddress, NinIdentity, PhoneNumber, Profile, User
-from eduid.userdb.exceptions import UserHasNotCompletedSignup, UserOutOfSync
+from eduid.userdb.exceptions import UserDoesNotExist, UserHasNotCompletedSignup, UserOutOfSync
 from eduid.userdb.logs import MailAddressProofing
 from eduid.userdb.signup import Invite, InviteType, SCIMReference, SignupUser
 from eduid.userdb.tou import ToUEvent
@@ -120,9 +120,10 @@ def generate_eppn() -> str:
     """
     for _ in range(10):
         eppn_int = struct.unpack("I", os.urandom(4))[0]
-        eppn = proquint.uint2quint(eppn_int)
-        user = current_app.central_userdb.get_user_by_eppn(eppn)
-        if not user:
+        eppn: str = proquint.uint2quint(eppn_int)
+        try:
+            current_app.central_userdb.get_user_by_eppn(eppn)
+        except UserDoesNotExist:
             return eppn
     current_app.logger.critical("generate_eppn finished without finding a new unique eppn")
     abort(500)

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -1101,7 +1101,6 @@ class SignupTests(EduidAPITestCase, MockedScimAPIMixin):
                 assert eppn is not None
                 assert sess.signup.credentials.password is None
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        assert user is not None
         assert user.mail_addresses.to_list()[0].email == email
 
     def test_create_user_eppn_in_session(self):
@@ -1221,7 +1220,6 @@ class SignupTests(EduidAPITestCase, MockedScimAPIMixin):
                 assert eppn is not None
 
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        assert user is not None
         assert user.given_name == invite.given_name
         assert user.surname == invite.surname
         assert user.mail_addresses.to_list()[0].email == invite.get_primary_mail_address()
@@ -1243,7 +1241,6 @@ class SignupTests(EduidAPITestCase, MockedScimAPIMixin):
                 assert eppn is not None
 
         user = self.app.central_userdb.get_user_by_eppn(eppn)
-        assert user is not None
         assert user.given_name == previous_given_name
         assert user.surname == previous_surname
         assert user.mail_addresses.to_list()[0].email == invite.get_primary_mail_address()

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -332,10 +332,6 @@ def get_invite(invite_code: str):
 
     if session.common.is_logged_in:
         user = current_app.central_userdb.get_user_by_eppn(eppn=session.common.eppn)
-        if user is None:
-            current_app.logger.error("User not found but logged in?")
-            current_app.logger.error(f"invite_code: {invite_code}")
-            raise RuntimeError("User not found but logged in?")
         assert user.mail_addresses.primary is not None  # please mypy
         invite_data["user"] = {
             "given_name": user.given_name,
@@ -384,8 +380,6 @@ def complete_invite() -> FluxData:
         return success_response(payload={"state": session.signup.to_dict()})
 
     user = current_app.central_userdb.get_user_by_eppn(eppn=session.common.eppn)
-    if user is None:
-        return error_response(message=CommonMsg.temp_problem)
 
     assert session.signup.invite.invite_code is not None  # please mypy
     try:

--- a/src/eduid/webapp/svipe_id/proofing.py
+++ b/src/eduid/webapp/svipe_id/proofing.py
@@ -82,7 +82,6 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
         current_app.stats.count(name="nin_verified")
         # re-load the user from central db before returning
         _user = current_app.central_userdb.get_user_by_eppn(proofing_user.eppn)
-        assert _user is not None  # please mypy
         return VerifyUserResult(user=ProofingUser.from_user(_user, current_app.private_userdb))
 
     def _verify_foreign_identity(self, user: User) -> VerifyUserResult:
@@ -144,7 +143,6 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
         current_app.stats.count(name="foreign_identity_verified")
         # load the user from central db before returning
         _user = current_app.central_userdb.get_user_by_eppn(proofing_user.eppn)
-        assert _user is not None  # please mypy
         return VerifyUserResult(user=_user)
 
     def _can_replace_identity(self, proofing_user: ProofingUser) -> bool:

--- a/src/eduid/webapp/svipe_id/tests/test_app.py
+++ b/src/eduid/webapp/svipe_id/tests/test_app.py
@@ -27,7 +27,6 @@ class SvipeIdTests(ProofingTests):
         super().setUp(*args, **kwargs, users=["hubba-bubba", "hubba-baar"])
 
         self.unverified_test_user = self.app.central_userdb.get_user_by_eppn("hubba-baar")
-        assert self.unverified_test_user is not None
         self._user_setup()
 
         self.default_frontend_data = {

--- a/src/eduid/workers/amapi/routers/utils/users.py
+++ b/src/eduid/workers/amapi/routers/utils/users.py
@@ -2,7 +2,6 @@ from typing import Union
 
 from deepdiff import DeepDiff
 
-from eduid.common.fastapi.exceptions import BadRequest
 from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.amapi_user import (
     UserUpdateEmailRequest,
@@ -33,8 +32,6 @@ def update_user(
 ) -> UserUpdateResponse:
     """General function for updating a user object"""
     user_obj = req.app.db.get_user_by_eppn(eppn=eppn)
-    if user_obj is None:
-        raise BadRequest(detail=f"Can't find {eppn} in database")
 
     old_user_dict = user_obj.to_dict()
 


### PR DESCRIPTION
When we have an eppn, we can reasonably expect to find a user with that eppn. This avoids having to check the return value in approximately 200 places (although mostly in tests).