### PR TITLE
Add administrative_number to Svipe identities

### DIFF
--- a/src/eduid/userdb/fixtures/identity.py
+++ b/src/eduid/userdb/fixtures/identity.py
@@ -48,6 +48,7 @@ unverified_eidas_identity = EIDASIdentity(
 
 verified_svipe_identity = SvipeIdentity(
     svipe_id="unique-svipe-id-1",
+    administrative_number="1234567890",
     date_of_birth=datetime.fromisoformat("1978-09-02T00:00:00"),
     country_code="DE",
     created_ts=datetime.fromisoformat("2022-09-02T10:23:25"),
@@ -59,6 +60,7 @@ verified_svipe_identity = SvipeIdentity(
 
 unverified_svipe_identity = SvipeIdentity(
     svipe_id="unique-svipe-id-2",
+    administrative_number="0123456789",
     date_of_birth=datetime.fromisoformat("1977-09-02T00:00:00"),
     country_code="DE",
     created_ts=datetime.fromisoformat("2022-09-02T10:23:25"),

--- a/src/eduid/userdb/identity.py
+++ b/src/eduid/userdb/identity.py
@@ -154,6 +154,7 @@ class SvipeIdentity(ForeignIdentityElement):
     #  A globally unique identifier issued by Svipe to the user. Under normal conditions, a given person will retain
     #  the same Svipe ID even after renewing the underlying identity document.
     svipe_id: str
+    administrative_number: str
 
     @property
     def unique_key_name(self) -> str:

--- a/src/eduid/webapp/svipe_id/proofing.py
+++ b/src/eduid/webapp/svipe_id/proofing.py
@@ -94,14 +94,15 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
 
         date_of_birth = self.session_info.birthdate
         new_identity = SvipeIdentity(
+            administrative_number=self.session_info.document_administrative_number,
+            country_code=self.session_info.document_nationality,
             created_by=current_app.conf.app_name,
             date_of_birth=datetime(year=date_of_birth.year, month=date_of_birth.month, day=date_of_birth.day),
-            country_code=self.session_info.document_nationality,
-            verified_by=current_app.conf.app_name,
             is_verified=True,
-            svipe_id=self.session_info.svipe_id,
             proofing_method=IdentityProofingMethod.SVIPE_ID,
             proofing_version=current_app.conf.svipe_id_proofing_version,
+            svipe_id=self.session_info.svipe_id,
+            verified_by=current_app.conf.app_name,
         )
 
         # check if the just verified identity matches the locked identity

--- a/src/eduid/webapp/svipe_id/tests/test_app.py
+++ b/src/eduid/webapp/svipe_id/tests/test_app.py
@@ -412,10 +412,11 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
         userinfo = self.get_mock_userinfo(issuing_country=country, nationality=country)
         user.identities.add(
             SvipeIdentity(
-                svipe_id=userinfo.svipe_id,
-                date_of_birth=datetime.combine(userinfo.birthdate.today(), datetime.min.time()),
+                administrative_number=userinfo.document_administrative_number,
                 country_code=country.alpha2,
+                date_of_birth=datetime.combine(userinfo.birthdate.today(), datetime.min.time()),
                 is_verified=True,
+                svipe_id=userinfo.svipe_id,
             )
         )
         self.request_user_sync(user)
@@ -450,10 +451,11 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
         userinfo = self.get_mock_userinfo(issuing_country=country, nationality=country)
         user.locked_identity.add(
             SvipeIdentity(
-                svipe_id="another_svipe_id",
-                date_of_birth=datetime.combine(userinfo.birthdate, datetime.min.time()),
+                administrative_number=userinfo.document_administrative_number,
                 country_code="DK",
+                date_of_birth=datetime.combine(userinfo.birthdate, datetime.min.time()),
                 is_verified=True,
+                svipe_id="another_svipe_id",
             )
         )
         user.given_name = userinfo.given_name
@@ -475,9 +477,10 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
             expect_msg=SvipeIDMsg.identity_verify_success,
         )
         new_locked_identity = SvipeIdentity(
-            svipe_id=userinfo.svipe_id,
-            date_of_birth=datetime.combine(userinfo.birthdate.today(), datetime.min.time()),
+            administrative_number=userinfo.document_administrative_number,
             country_code="DK",
+            date_of_birth=datetime.combine(userinfo.birthdate.today(), datetime.min.time()),
+            svipe_id=userinfo.svipe_id,
         )
         self._verify_user_parameters(
             eppn, identity_verified=True, num_proofings=1, num_mfa_tokens=0, locked_identity=new_locked_identity
@@ -490,14 +493,63 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
         eppn = self.unverified_test_user.eppn
         country = countries.get("Denmark")
 
+        userinfo = self.get_mock_userinfo(issuing_country=country, nationality=country)
+
         # add a locked svipe identity that will NOT match the new identity
         user = self.app.central_userdb.get_user_by_eppn(eppn)
         user.locked_identity.add(
             SvipeIdentity(
-                svipe_id="another_svipe_id",
+                administrative_number=userinfo.document_administrative_number,
+                country_code=userinfo.document_nationality,
                 date_of_birth=datetime.today(),  # not matching the new identity
-                country_code="DK",
                 is_verified=True,
+                svipe_id="another_svipe_id",
+            )
+        )
+        self.app.central_userdb.save(user)
+
+        with self.app.test_request_context():
+            endpoint = url_for("svipe_id.verify_identity")
+
+        start_auth_response = self._start_auth(endpoint=endpoint, data=self.default_frontend_data, eppn=eppn)
+        state, nonce = self._get_state_and_nonce(self.get_response_payload(start_auth_response)["location"])
+        userinfo = self.get_mock_userinfo(issuing_country=country, nationality=country)
+        response = self.mock_authorization_callback(state=state, nonce=nonce, userinfo=userinfo)
+        assert response.status_code == 302
+        self._verify_status(
+            finish_url=response.headers["Location"],
+            frontend_action=self.default_frontend_data["frontend_action"],
+            frontend_state=self.default_frontend_data["frontend_state"],
+            method=self.default_frontend_data["method"],
+            expect_error=True,
+            expect_msg=CommonMsg.locked_identity_not_matching,
+        )
+        self._verify_user_parameters(
+            eppn, identity_verified=False, num_proofings=0, num_mfa_tokens=0, locked_identity=user.locked_identity.svipe
+        )
+
+    @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
+    def test_verify_foreign_identity_replace_locked_identity_fail_admin_number(self, mock_request_user_sync: MagicMock):
+        mock_request_user_sync.side_effect = self.request_user_sync
+
+        eppn = self.unverified_test_user.eppn
+        country = countries.get("Denmark")
+        admin_number = "1234567890"
+        other_admin_number = "0987654321"
+
+        userinfo = self.get_mock_userinfo(
+            issuing_country=country, nationality=country, administrative_number=admin_number
+        )
+
+        # add a locked svipe identity that will NOT match the new identity
+        user = self.app.central_userdb.get_user_by_eppn(eppn)
+        user.locked_identity.add(
+            SvipeIdentity(
+                administrative_number=other_admin_number,  # not matching the new identity
+                country_code=userinfo.document_nationality,
+                date_of_birth=datetime.combine(userinfo.birthdate.today(), datetime.min.time()),
+                is_verified=True,
+                svipe_id="another_svipe_id",
             )
         )
         self.app.central_userdb.save(user)
@@ -525,7 +577,7 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_verify_foreign_identity_already_verified_nin(
-        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock
     ):
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync

--- a/src/eduid/webapp/svipe_id/tests/test_app.py
+++ b/src/eduid/webapp/svipe_id/tests/test_app.py
@@ -15,6 +15,7 @@ from eduid.webapp.common.proofing.messages import ProofingMsg
 from eduid.webapp.common.proofing.testing import ProofingTests
 from eduid.webapp.svipe_id.app import SvipeIdApp, svipe_id_init_app
 from eduid.webapp.svipe_id.helpers import SvipeDocumentUserInfo, SvipeIDMsg
+from eduid.webapp.svipe_id.settings.common import SvipeClientConfig
 
 __author__ = "lundberg"
 
@@ -249,6 +250,31 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
 
     def test_app_starts(self):
         assert self.app.conf.app_name == "testing"
+
+    def test_client_claims_config(self):
+        data = {
+            "svipe_client": {
+                "client_id": "x",
+                "client_secret": "y",
+                "issuer": "https://issuer.example.edu/",
+                "claims_request": {
+                    "com.svipe:document_administrative_number": {"essential": True},
+                    "com.svipe:document_expiry_date": {"essential": True},
+                    "com.svipe:document_issuing_country": {"essential": True},
+                    "com.svipe:document_nationality": {"essential": True},
+                    "com.svipe:document_number": {"essential": True},
+                    "birthdate": {"essential": True},
+                    "com.svipe:document_type_sdn_en": {"essential": True},
+                    "com.svipe:meta_transaction_id": {"essential": True},
+                    "com.svipe:svipeid": {"essential": True},
+                    "family_name": {"essential": True},
+                    "given_name": {"essential": True},
+                    "name": None,
+                },
+            },
+        }
+        cfg = SvipeClientConfig.parse_obj(data["svipe_client"])
+        assert cfg.claims_request == data["svipe_client"]["claims_request"]
 
     def test_authenticate(self):
         response = self.browser.get("/")


### PR DESCRIPTION
We want them in locked identities to prevent the possibility of identity transfers to another person with the same country and date of birth.
