### PR TITLE
Deny users not in database

### DIFF
--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -23,7 +23,7 @@ class Config(object):
     mfa_stepup_issuer_to_entity_id: Mapping[str, str]
     virt_idp_to_data_owner: Mapping[str, str]
     scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
-    allow_users_not_in_database: Optional[bool] = False
+    allow_users_not_in_database: bool = False
 
 
 class ScimAttributes(ResponseMicroService):

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -19,12 +19,12 @@ logger = logging.getLogger(__name__)
 @dataclass
 class Config(object):
     mongo_uri: str
-    idp_to_data_owner: Mapping[str, str] = field(default_factory=dict)
-    virt_idp_to_data_owner: Mapping[str, str] = field(default_factory=dict)
-    fallback_data_owner: Optional[str] = None
-    scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
-    mfa_stepup_issuer_to_entity_id: Mapping[str, str] = field(default_factory=dict)
     allow_users_not_in_database: bool = False
+    fallback_data_owner: Optional[str] = None
+    idp_to_data_owner: Mapping[str, str] = field(default_factory=dict)
+    mfa_stepup_issuer_to_entity_id: Mapping[str, str] = field(default_factory=dict)
+    scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
+    virt_idp_to_data_owner: Mapping[str, str] = field(default_factory=dict)
 
 
 class ScimAttributes(ResponseMicroService):

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -103,7 +103,7 @@ class ScimAttributes(ResponseMicroService):
         else:
             if self.config.allow_users_not_in_database:
                 logger.info(
-                    "User not found in database but letting through since 'allow_users_not_in_database' is set to False"
+                    "User not found in database but letting through since 'allow_users_not_in_database' is set to True"
                 )
             else:
                 raise SATOSAAuthenticationError(context.state, f"User not found in database")

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -7,6 +7,7 @@ import satosa.context
 import satosa.internal
 from saml2.mdstore import MetaData
 from satosa.attribute_mapping import AttributeMapper
+from satosa.exception import SATOSAAuthenticationError
 from satosa.micro_services.base import ResponseMicroService
 from satosa.routing import STATE_KEY as ROUTER_STATE_KEY
 
@@ -97,6 +98,8 @@ class ScimAttributes(ResponseMicroService):
                     ]
             data.mfa_stepup_accounts = _stepup_accounts
             logger.debug(f"MFA stepup accounts: {data.mfa_stepup_accounts}")
+        else:
+            raise SATOSAAuthenticationError(context.state, "User not found in database")
 
         return super().process(context, data)
 

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Config(object):
+    allow_users_not_in_database: Optional[bool] = False
     mongo_uri: str
     idp_to_data_owner: Mapping[str, str]
     mfa_stepup_issuer_to_entity_id: Mapping[str, str]
@@ -99,7 +100,12 @@ class ScimAttributes(ResponseMicroService):
             data.mfa_stepup_accounts = _stepup_accounts
             logger.debug(f"MFA stepup accounts: {data.mfa_stepup_accounts}")
         else:
-            raise SATOSAAuthenticationError(context.state, "User not found in database")
+            allow_users_not_in_database = self.config.allow_users_not_in_database
+            if allow_users_not_in_database:
+                logger.info(f"User not found in database but letting through since 'allow_users_not_in_database' is set to {allow_users_not_in_database}")
+            else:
+                raise SATOSAAuthenticationError(context.state, f"User not found in database")
+
 
         return super().process(context, data)
 

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -101,10 +101,9 @@ class ScimAttributes(ResponseMicroService):
             data.mfa_stepup_accounts = _stepup_accounts
             logger.debug(f"MFA stepup accounts: {data.mfa_stepup_accounts}")
         else:
-            allow_users_not_in_database = self.config.allow_users_not_in_database
-            if allow_users_not_in_database:
+            if self.config.allow_users_not_in_database:
                 logger.info(
-                    f"User not found in database but letting through since 'allow_users_not_in_database' is set to {allow_users_not_in_database}"
+                    "User not found in database but letting through since 'allow_users_not_in_database' is set to False"
                 )
             else:
                 raise SATOSAAuthenticationError(context.state, f"User not found in database")

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -131,7 +131,7 @@ class ScimAttributes(ResponseMicroService):
         # Look for explicit information about what data owner to use for this IdP
         issuer = frontend_name
         data_owner: Optional[str] = self.config.virt_idp_to_data_owner.get(issuer)
-        # Fallback to issuer. Do we need that?
+        # Fallback to issuer. E.g Skolverkets idpproxy
         if not data_owner:
             issuer = data.auth_info.issuer
             data_owner = self.config.idp_to_data_owner.get(issuer)

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -20,9 +20,9 @@ logger = logging.getLogger(__name__)
 class Config(object):
     mongo_uri: str
     idp_to_data_owner: Mapping[str, str]
-    mfa_stepup_issuer_to_entity_id: Mapping[str, str]
     virt_idp_to_data_owner: Mapping[str, str]
     scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
+    mfa_stepup_issuer_to_entity_id: Mapping[str, str] = field(default_factory=dict)
     allow_users_not_in_database: bool = False
 
 

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -102,10 +102,11 @@ class ScimAttributes(ResponseMicroService):
         else:
             allow_users_not_in_database = self.config.allow_users_not_in_database
             if allow_users_not_in_database:
-                logger.info(f"User not found in database but letting through since 'allow_users_not_in_database' is set to {allow_users_not_in_database}")
+                logger.info(
+                    f"User not found in database but letting through since 'allow_users_not_in_database' is set to {allow_users_not_in_database}"
+                )
             else:
                 raise SATOSAAuthenticationError(context.state, f"User not found in database")
-
 
         return super().process(context, data)
 

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -18,12 +18,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Config(object):
-    allow_users_not_in_database: Optional[bool] = False
     mongo_uri: str
     idp_to_data_owner: Mapping[str, str]
     mfa_stepup_issuer_to_entity_id: Mapping[str, str]
     virt_idp_to_data_owner: Mapping[str, str]
     scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
+    allow_users_not_in_database: Optional[bool] = False
 
 
 class ScimAttributes(ResponseMicroService):

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 @dataclass
 class Config(object):
     mongo_uri: str
-    idp_to_data_owner: Mapping[str, str]
-    virt_idp_to_data_owner: Mapping[str, str]
+    idp_to_data_owner: Mapping[str, str] = field(default_factory=dict)
+    virt_idp_to_data_owner: Mapping[str, str] = field(default_factory=dict)
     fallback_data_owner: Optional[str] = None
     scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
     mfa_stepup_issuer_to_entity_id: Mapping[str, str] = field(default_factory=dict)

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -21,7 +21,7 @@ class Config(object):
     mongo_uri: str
     idp_to_data_owner: Mapping[str, str]
     virt_idp_to_data_owner: Mapping[str, str]
-    fallback_data_owner: str = None
+    fallback_data_owner: Optional[str] = None
     scope_to_data_owner: Mapping[str, str] = field(default_factory=dict)
     mfa_stepup_issuer_to_entity_id: Mapping[str, str] = field(default_factory=dict)
     allow_users_not_in_database: bool = False


### PR DESCRIPTION
Users must first be added to the SCIM database in order to use this proxy IdP. If user doesn't exist Satosa will redirect the user back to the SP which will handle/display the error message.