### PR TITLE
adjust address size and use given name marks

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -25,7 +25,10 @@ jobs:
 
       - name: Install packages
         run: |
-          sudo apt install xmlsec1  # pysaml2 needs to find an xmlsec1 binary
+          sudo apt update
+          # pysaml2 needs to find an xmlsec1 binary
+          # PIL/EpsImagePlugin.py needs to find a ghostscript binary
+          sudo apt install xmlsec1 ghostscript
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ vscode_pip: vscode_venv
 vscode_packages:
 	$(info Installing apt packages in devcontainer)
 	sudo apt-get update
-	sudo apt install -y swig xmlsec1 python3-venv docker.io
+	sudo apt install -y swig xmlsec1 python3-venv docker.io ghostscript
 
 # This target is used by the devcontainer.json to configure the devcontainer
 vscode: vscode_packages vscode_pip vscode_hosts

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -32,6 +32,43 @@ from eduid.webapp.common.api.utils import get_from_current_app, save_and_sync_us
 __author__ = "lundberg"
 
 
+def get_marked_given_name(given_name: str, given_name_marking: str) -> str:
+    """
+    Given name marking denotes up to two given names, and is used to determine
+    which of the given names are to be primarily used in addressing a person.
+    For this purpose, the given_name_marking is two numbers:
+        indexing starting at 1
+        the second can be 0 for only one mark
+        hyphenated names are counted separately (i.e. Jan-Erik are two separate names)
+            assuming they are always marked together as per example in documentation
+
+    current version of documentation:
+    https://www.skatteverket.se/download/18.2cf1b5cd163796a5c8bf20e/1530691773712/AllmanBeskrivning.pdf
+
+    :param given_name: Given name
+    :param given_name_marking: Given name marking
+
+    :return: Marked given name (Tilltalsnamn)
+    """
+    if not given_name_marking or "00" == given_name_marking:
+        return given_name
+
+    # cheating with indexing
+    _given_names = [None]
+    for name in given_name.split():
+        _given_names.append(name)
+        if "-" in name:
+            # hyphenated names are counted separately
+            _given_names.append(None)
+    _marked_names = []
+    for i in given_name_marking:
+        _marked_names.append(_given_names[int(i)])
+    # remove None values
+    # i.e. 0 index and hyphenated names second part placeholder
+    _marked_names = [name for name in _marked_names if name is not None]
+    return " ".join(_marked_names)
+
+
 def set_user_names_from_nin_proofing(
     user: TUserSubclass,
     proofing_log_entry: TNinProofingLogElementSubclass,
@@ -64,13 +101,8 @@ def set_user_names_from_official_address(
     given_name_marking = proofing_log_entry.user_postal_address.name.given_name_marking
     user.display_name = f"{user.given_name} {user.surname}"
     if given_name_marking:
-        _name_index = (int(given_name_marking) // 10) - 1  # ex. "20" -> 1 (second GivenName is real given name)
-        try:
-            _given_name = user.given_name.split()[_name_index]
-            user.display_name = f"{_given_name} {user.surname}"
-        except IndexError:
-            # At least occasionally, we've seen GivenName 'Jan-Erik Martin' with GivenNameMarking 30
-            pass
+        _given_name = get_marked_given_name(user.given_name, given_name_marking)
+        user.display_name = f"{_given_name} {user.surname}"
     current_app.logger.info("User names set from official address")
     current_app.logger.debug(
         f"{proofing_log_entry.user_postal_address.name} resulted in given_name: {user.given_name}, "

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass
-from typing import Any, Optional, TypeVar, Union, cast, overload
+from typing import Any, Iterable, List, Optional, TypeVar, Union, cast, overload
 
 from flask import current_app, render_template, request
 
@@ -32,7 +32,7 @@ from eduid.webapp.common.api.utils import get_from_current_app, save_and_sync_us
 __author__ = "lundberg"
 
 
-def get_marked_given_name(given_name: str, given_name_marking: str) -> str:
+def get_marked_given_name(given_name: str, given_name_marking: Optional[str]) -> str:
     """
     Given name marking denotes up to two given names, and is used to determine
     which of the given names are to be primarily used in addressing a person.
@@ -54,19 +54,19 @@ def get_marked_given_name(given_name: str, given_name_marking: str) -> str:
         return given_name
 
     # cheating with indexing
-    _given_names = [None]
+    _given_names: List[Optional[str]] = [None]
     for name in given_name.split():
         _given_names.append(name)
         if "-" in name:
             # hyphenated names are counted separately
             _given_names.append(None)
-    _marked_names = []
+    _optional_marked_names: List[Optional[str]] = []
     for i in given_name_marking:
-        _marked_names.append(_given_names[int(i)])
+        _optional_marked_names.append(_given_names[int(i)])
     # remove None values
     # i.e. 0 index and hyphenated names second part placeholder
-    _marked_names = [name for name in _marked_names if name is not None]
-    return " ".join(_marked_names)
+    _marked_names: List[str] = [name for name in _optional_marked_names if name is not None]
+    return " ".join(list(_marked_names))
 
 
 def set_user_names_from_nin_proofing(

--- a/src/eduid/webapp/common/api/tests/test_nin_helpers.py
+++ b/src/eduid/webapp/common/api/tests/test_nin_helpers.py
@@ -24,6 +24,7 @@ from eduid.userdb.proofing.state import NinProofingState
 from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.api.helpers import (
     add_nin_to_user,
+    get_marked_given_name,
     set_user_names_from_foreign_id,
     set_user_names_from_nin_proofing,
     verify_nin_for_user,
@@ -441,3 +442,12 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
             assert user.given_name == "Testaren Test"
             assert user.surname == "Testsson"
             assert user.display_name == "Test Testsson"
+
+    def test_get_given_name_from_marking(self):
+        assert get_marked_given_name("Jan-Erik Martin", "30") == "Martin"
+        assert get_marked_given_name("Eva Mia", "20") == "Mia"
+        assert get_marked_given_name("Kjell Olof", "12") == "Kjell Olof"
+        assert get_marked_given_name("Hedvig Britt-Marie", "23") == "Britt-Marie"
+
+        assert get_marked_given_name("Jan-Erik Martin", "00") == "Jan-Erik Martin"
+        assert get_marked_given_name("Jan-Erik Martin", None) == "Jan-Erik Martin"

--- a/src/eduid/webapp/letter_proofing/pdf.py
+++ b/src/eduid/webapp/letter_proofing/pdf.py
@@ -8,6 +8,7 @@ from typing import Mapping
 from xhtml2pdf import pisa
 
 from eduid.common.rpc.msg_relay import FullPostalAddress
+from eduid.webapp.common.api.helpers import get_marked_given_name
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,9 @@ def format_address(recipient: Mapping):
     """
     try:
         # TODO: Take GivenNameMarking in to account
-        given_name = recipient.get("Name", {})["GivenName"]  # Mandatory
+        _given_name_marking = recipient.get("Name", {}).get("GivenNameMarking", None)  # Optional
+        _given_name = recipient.get("Name", {})["GivenName"]  # Mandatory
+        given_name = get_marked_given_name(_given_name, _given_name_marking)
         middle_name = recipient.get("Name", {}).get("MiddleName", "")  # Optional
         surname = recipient.get("Name", {})["Surname"]  # Mandatory
         name = f"{given_name!s} {middle_name!s} {surname!s}"
@@ -82,7 +85,7 @@ def create_pdf(
 
     letter_template = render_template(
         "letter.jinja2",
-        sunet_logo=f"file://{templates_path}/sunet_logo.eps",
+        sunet_logo=f"{templates_path}/sunet_logo.eps",
         recipient_name=name,
         recipient_care_of=care_of,
         recipient_address=address,

--- a/src/eduid/webapp/letter_proofing/templates/letter.jinja2
+++ b/src/eduid/webapp/letter_proofing/templates/letter.jinja2
@@ -17,7 +17,7 @@
             @frame recipient_frame {
                 -pdf-frame-content: recipient_content;
                 /* -pdf-frame-border: 1; for debugging the layout */
-            left: 121mm; width: 77mm; top: 44mm; height: 20.5mm;
+                left: 121mm; width: 87mm; top: 44mm; height: 21.9mm;
             }
             @frame heading_frame {
                 /* -pdf-frame-border: 1; for debugging the layout */

--- a/src/eduid/webapp/letter_proofing/tests/test_pdf.py
+++ b/src/eduid/webapp/letter_proofing/tests/test_pdf.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 from datetime import datetime
 from io import BytesIO, StringIO
 
+from pypdf import PdfReader
+
 from eduid.common.rpc.msg_relay import FullPostalAddress
 from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.letter_proofing import pdf
@@ -153,7 +155,7 @@ class CreatePDFTest(EduidAPITestCase):
                         OrderedDict(
                             [
                                 ("GivenNameMarking", "20"),
-                                ("GivenName", "Testaren Test"),
+                                ("GivenName", "Testaren Test Adam Bertil Cesar David"),
                                 ("MiddleName", "Tester"),
                                 ("Surname", "Testsson"),
                             ]
@@ -185,3 +187,12 @@ class CreatePDFTest(EduidAPITestCase):
                     letter_wait_time_hours=336,
                 )
         self.assertIsInstance(pdf_document, (StringIO, BytesIO))
+
+        pdf_text = PdfReader(pdf_document).pages[0].extract_text()
+        assert (
+            """Test Tester Testsson
+C/O TESTAREN & TESTSSON
+\xd6RGATAN 79 LGH 10 LGH 4321
+12345 LANDET"""
+            in pdf_text
+        )


### PR DESCRIPTION
size of address field in generated pdf should handle addresses with extra row (i.e. c/o)

file path to logo

helper function to get name from given names and given name marks

test to check that generated pdf has generated visible address

tests for given name marking evaluations