### PR TITLE
Deprecated for over 3 years ago

### DIFF
--- a/src/eduid/webapp/idp/assurance_data.py
+++ b/src/eduid/webapp/idp/assurance_data.py
@@ -23,9 +23,6 @@ class SwamidAssurance(str, Enum):
     SWAMID_AL1 = "http://www.swamid.se/policy/assurance/al1"
     SWAMID_AL2 = "http://www.swamid.se/policy/assurance/al2"
     SWAMID_AL3 = "http://www.swamid.se/policy/assurance/al3"
-    SWAMID_AL2_MFA_HIGH = (
-        "http://www.swamid.se/policy/authentication/swamid-al2-mfa-hi"  # deprecated but keep around for a while
-    )
     REFEDS_ASSURANCE = "https://refeds.org/assurance"
     REFEDS_IAP_HIGH = "https://refeds.org/assurance/IAP/high"
     REFEDS_IAP_LOW = "https://refeds.org/assurance/IAP/low"

--- a/src/eduid/webapp/idp/settings/common.py
+++ b/src/eduid/webapp/idp/settings/common.py
@@ -158,7 +158,6 @@ class IdPConfig(EduIDBaseAppConfig, TouConfigMixin, WebauthnConfigMixin2, AmConf
             SwamidAssurance.SWAMID_AL1,
             SwamidAssurance.SWAMID_AL2,
             SwamidAssurance.SWAMID_AL3,
-            SwamidAssurance.SWAMID_AL2_MFA_HIGH,  # deprecated but keep around for a while
             SwamidAssurance.REFEDS_ASSURANCE,
             SwamidAssurance.REFEDS_ID_UNIQUE,
             SwamidAssurance.REFEDS_EPPN_UNIQUE,


### PR DESCRIPTION
SWAMID AL2 MFA HIGH was deprecated in the federation for over 3 years ago and should not be used in the federation any more. All hail SWAMID AL3!