### PR TITLE
remove obsolete forcing of assurance

### DIFF
--- a/src/eduid/webapp/idp/login_context.py
+++ b/src/eduid/webapp/idp/login_context.py
@@ -233,14 +233,11 @@ class LoginContextSAML(LoginContext):
 
     def get_requested_authn_context(self) -> Optional[EduidAuthnContextClass]:
         """
-        Check if the SP has explicit Authn preferences in the metadata (some SPs are not
-        capable of conveying this preference in the RequestedAuthnContext)
+        Return the authn context (if any) that was originally requested.
 
         TODO: Don't just return the first one, but the most relevant somehow.
         """
-        res = _pick_authn_context(self.authn_contexts, self.request_ref)
-
-        return res
+        return _pick_authn_context(self.authn_contexts, self.request_ref)
 
 
 class LoginContextOtherDevice(LoginContext):

--- a/src/eduid/webapp/idp/login_context.py
+++ b/src/eduid/webapp/idp/login_context.py
@@ -240,8 +240,6 @@ class LoginContextSAML(LoginContext):
         """
         res = _pick_authn_context(self.authn_contexts, self.request_ref)
 
-        attributes = self.saml_req.sp_entity_attributes
-
         return res
 
 

--- a/src/eduid/webapp/idp/login_context.py
+++ b/src/eduid/webapp/idp/login_context.py
@@ -241,17 +241,7 @@ class LoginContextSAML(LoginContext):
         res = _pick_authn_context(self.authn_contexts, self.request_ref)
 
         attributes = self.saml_req.sp_entity_attributes
-        if "http://www.swamid.se/assurance-requirement" in attributes:
-            # TODO: This is probably obsolete and not present anywhere in SWAMID metadata anymore
-            new_authn = _pick_authn_context(attributes["http://www.swamid.se/assurance-requirement"], self.request_ref)
-            logger.debug(
-                f"Entity {self.saml_req.sp_entity_id} has AuthnCtx preferences in metadata. "
-                f"Overriding {res} -> {new_authn}"
-            )
-            try:
-                res = EduidAuthnContextClass(new_authn)
-            except ValueError:
-                logger.debug(f"Ignoring unknown authnContextClassRef found in metadata: {new_authn}")
+
         return res
 
 


### PR DESCRIPTION
Entities with obsolete metadata triggered the code resulting in failed logins
Propably after patch to not accept unknown accr
8b5d535ecf2c996f6a1bca5813f9b1f0d00acb8f