### PR TITLE
Update_python_version to 3.11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:0-3.10
+FROM mcr.microsoft.com/devcontainers/python:0-3.11
 
 ARG NONROOT_USER=vscode
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     env:
       PIP_INDEX_URL: https://pypi.sunet.se/simple/
       NEO4J_VERSION: 4.4-enterprise
@@ -52,10 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Set up Python 3.10"
+      - name: "Set up Python 3.11"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -74,7 +74,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.jenkins.yaml
+++ b/.jenkins.yaml
@@ -14,7 +14,7 @@ pre_build_script:
 environment_variables:
   NEO4J_VERSION: "4.4-enterprise"
 script:
-  - "python3.10 -m venv venv"
+  - "python3.11 -m venv venv"
   - ". venv/bin/activate"
   - "pip install -U pip setuptools wheel mypy"
   - "pip install --index-url https://pypi.sunet.se -r requirements/test_requirements.txt"
@@ -31,7 +31,7 @@ extra_jobs:
       github_push: false
       cron: "@daily"
     script:
-      - "python3.10 -m venv venv"
+      - "python3.11 -m venv venv"
       - ". venv/bin/activate"
       - "pip install -U pip setuptools wheel pip-tools mypy"
       - "touch requirements/*in"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 # Set the maximum line length to 120.
 line-length = 120
-target-version = "py310"
+target-version = "py311"
 
 [lint]
 select = ["E", "F", "W", "I", "ASYNC", "UP", "FLY", "PERF", "FURB", "ERA", "ANN"]

--- a/src/eduid/common/config/base.py
+++ b/src/eduid/common/config/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import timedelta
-from enum import Enum, unique
+from enum import Enum, StrEnum, unique
 from pathlib import Path
 from re import Pattern
 from typing import IO, Annotated, Any, TypeVar
@@ -69,7 +69,7 @@ class CookieConfig(BaseModel):
 TRootConfigSubclass = TypeVar("TRootConfigSubclass", bound="RootConfig")
 
 
-class EduidEnvironment(str, Enum):
+class EduidEnvironment(StrEnum):
     dev = "dev"
     staging = "staging"
     production = "production"
@@ -89,7 +89,7 @@ class RootConfig(BaseModel):
 TEduIDBaseAppConfigSubclass = TypeVar("TEduIDBaseAppConfigSubclass", bound="EduIDBaseAppConfig")
 
 
-class LoggingFilters(str, Enum):
+class LoggingFilters(StrEnum):
     """Identifiers to coherently map elements in LocalContext.filters to filter classes in logging dictConfig."""
 
     DEBUG_TRUE: str = "require_debug_true"

--- a/src/eduid/common/fastapi/utils.py
+++ b/src/eduid/common/fastapi/utils.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastapi import Response
 
 from eduid.common.fastapi.context_request import ContextRequest
+from eduid.common.misc.timeutil import utc_now
 
 
 @dataclass
@@ -36,7 +37,7 @@ FAILURE_INFO: dict[str, FailCountItem] = dict()
 
 def log_failure_info(req: ContextRequest, key: str, msg: str, exc: Exception | None = None) -> None:
     if key not in FAILURE_INFO:
-        FAILURE_INFO[key] = FailCountItem(first_failure=datetime.utcnow())
+        FAILURE_INFO[key] = FailCountItem(first_failure=utc_now())
     FAILURE_INFO[key].count += 1
     req.app.context.logger.warning(f"{msg} {FAILURE_INFO[key]}: {exc}")
 
@@ -57,11 +58,11 @@ def check_restart(key: str, restart: int, terminate: int) -> bool:
         info = replace(info, restart_at=info.first_failure + timedelta(seconds=restart))
     if terminate and not info.exit_at:
         info = replace(info, exit_at=info.first_failure + timedelta(seconds=terminate))
-    if info.exit_at and datetime.utcnow() >= info.exit_at:
+    if info.exit_at and utc_now() >= info.exit_at:
         # Exit application and rely on something else restarting it
         sys.exit(1)
-    if info.restart_at and datetime.utcnow() >= info.restart_at:
-        info = replace(info, restart_at=datetime.utcnow() + timedelta(seconds=restart))
+    if info.restart_at and utc_now() >= info.restart_at:
+        info = replace(info, restart_at=utc_now() + timedelta(seconds=restart))
         # Try to restart/reinitialize the failing functionality
         res = True
     FAILURE_INFO[key] = info
@@ -72,7 +73,7 @@ def get_cached_response(req: ContextRequest, resp: Response, key: str) -> Mappin
     cache_for_seconds = req.app.context.config.status_cache_seconds
     resp.headers["Cache-Control"] = f"public,max-age={cache_for_seconds}"
 
-    now = datetime.utcnow()
+    now = utc_now()
     if SIMPLE_CACHE.get(key) is not None and now < SIMPLE_CACHE[key].expire_time:
         if req.app.context.config.debug:
             req.app.context.logger.debug(f"Returned cached response for {key} {now} < {SIMPLE_CACHE[key].expire_time}")
@@ -83,7 +84,7 @@ def get_cached_response(req: ContextRequest, resp: Response, key: str) -> Mappin
 
 def set_cached_response(req: ContextRequest, resp: Response, key: str, data: Mapping) -> None:
     cache_for_seconds = req.app.context.config.status_cache_seconds
-    now = datetime.utcnow()
+    now = utc_now()
     expires = now + timedelta(seconds=cache_for_seconds)
     resp.headers["Expires"] = expires.strftime("%a, %d %b %Y %H:%M:%S UTC")
     SIMPLE_CACHE[key] = SimpleCacheItem(expire_time=expires, data=data)

--- a/src/eduid/common/misc/timeutil.py
+++ b/src/eduid/common/misc/timeutil.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def utc_now() -> datetime:
     """Return current time with tz=UTC"""
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)

--- a/src/eduid/common/models/amapi_user.py
+++ b/src/eduid/common/models/amapi_user.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
@@ -10,7 +10,7 @@ from eduid.userdb.meta import CleanerType, Meta
 __author__ = "masv"
 
 
-class Reason(str, Enum):
+class Reason(StrEnum):
     USER_DECEASED = "user_deceased"
     USER_DEREGISTERED = "user_deregistered"
     NAME_CHANGED = "name_changed"
@@ -19,7 +19,7 @@ class Reason(str, Enum):
     TEST = "test"
 
 
-class Source(str, Enum):
+class Source(StrEnum):
     SKV_NAVET_V2 = "swedish_tax_agency_navet_v2"
     NO_SOURCE = "no_source"
     TEST = "test"

--- a/src/eduid/common/models/bearer_token.py
+++ b/src/eduid/common/models/bearer_token.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping
 from copy import copy
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field, StrictInt, field_validator, model_validator
@@ -11,7 +11,7 @@ from eduid.common.config.base import AuthnBearerTokenConfig, DataOwnerName, Scop
 from eduid.userdb.scimapi.groupdb import ScimApiGroupDB
 
 
-class AuthSource(str, Enum):
+class AuthSource(StrEnum):
     INTERACTION = "interaction"
     CONFIG = "config"
     MDQ = "mdq"

--- a/src/eduid/common/models/gnap_models.py
+++ b/src/eduid/common/models/gnap_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator
@@ -21,7 +21,7 @@ class GnapBaseModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-class ProofMethod(str, Enum):
+class ProofMethod(StrEnum):
     DPOP = "dpop"
     HTTPSIGN = "httpsign"
     JWSD = "jwsd"
@@ -51,7 +51,7 @@ class Key(GnapBaseModel):
         return v
 
 
-class AccessTokenFlags(str, Enum):
+class AccessTokenFlags(StrEnum):
     BEARER = "bearer"
     DURABLE = "durable"
 

--- a/src/eduid/common/models/jose_models.py
+++ b/src/eduid/common/models/jose_models.py
@@ -1,5 +1,5 @@
 import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import AnyUrl, BaseModel, Field
@@ -9,18 +9,18 @@ from eduid.common.misc.timeutil import utc_now
 __author__ = "lundberg"
 
 
-class KeyType(str, Enum):
+class KeyType(StrEnum):
     EC = "EC"
     RSA = "RSA"
     OCT = "oct"
 
 
-class KeyUse(str, Enum):
+class KeyUse(StrEnum):
     SIGN = "sig"
     ENCRYPT = "enc"
 
 
-class KeyOptions(str, Enum):
+class KeyOptions(StrEnum):
     SIGN = "sign"
     VERIFY = "verify"
     ENCRYPT = "encrypt"
@@ -31,13 +31,13 @@ class KeyOptions(str, Enum):
     DERIVE_BITS = "deriveBits"
 
 
-class SupportedAlgorithms(str, Enum):
+class SupportedAlgorithms(StrEnum):
     RS256 = "RS256"
     ES256 = "ES256"
     ES384 = "ES384"
 
 
-class SupportedHTTPMethods(str, Enum):
+class SupportedHTTPMethods(StrEnum):
     POST = "POST"
 
 
@@ -84,7 +84,7 @@ class JWKS(BaseModel):
     keys: list[ECJWK | RSAJWK | SymmetricJWK]
 
 
-class SupportedJWSType(str, Enum):
+class SupportedJWSType(StrEnum):
     JWS = "gnap-binding+jws"
     JWSD = "gnap-binding+jwsd"
 

--- a/src/eduid/common/models/jose_models.py
+++ b/src/eduid/common/models/jose_models.py
@@ -4,9 +4,9 @@ from typing import Any
 
 from pydantic import AnyUrl, BaseModel, Field
 
-__author__ = "lundberg"
+from eduid.common.misc.timeutil import utc_now
 
-from eduid.userdb.util import utc_now
+__author__ = "lundberg"
 
 
 class KeyType(str, Enum):

--- a/src/eduid/common/models/saml2.py
+++ b/src/eduid/common/models/saml2.py
@@ -1,10 +1,10 @@
-from enum import Enum, unique
+from enum import StrEnum, unique
 
 __author__ = "lundberg"
 
 
 @unique
-class EduidAuthnContextClass(str, Enum):
+class EduidAuthnContextClass(StrEnum):
     DIGG_LOA2 = "http://id.elegnamnden.se/loa/1.0/loa2"
     REFEDS_MFA = "https://refeds.org/profile/mfa"
     REFEDS_SFA = "https://refeds.org/profile/sfa"

--- a/src/eduid/common/models/scim_base.py
+++ b/src/eduid/common/models/scim_base.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, TypeVar
+from typing import Annotated, Any, Self
 from uuid import UUID
 
 from bson import ObjectId
@@ -98,9 +98,6 @@ class EduidBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
 
-TSubResource = TypeVar("TSubResource", bound="SubResource")
-
-
 class SubResource(EduidBaseModel):
     value: UUID
     ref: str = Field(alias="$ref")
@@ -115,7 +112,7 @@ class SubResource(EduidBaseModel):
         return self.ref is not None and "/Groups/" in self.ref
 
     @classmethod
-    def from_mapping(cls: type[TSubResource], data: object) -> TSubResource:
+    def from_mapping(cls, data: object) -> Self:
         return cls.model_validate(data)
 
 

--- a/src/eduid/common/models/scim_base.py
+++ b/src/eduid/common/models/scim_base.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Any, Self
 from uuid import UUID
 
@@ -57,7 +57,7 @@ LanguageTag = Annotated[
 ScimDatetime = Annotated[datetime, PlainSerializer(serialize_xml_datetime)]
 
 
-class SCIMSchema(str, Enum):
+class SCIMSchema(StrEnum):
     CORE_20_USER = "urn:ietf:params:scim:schemas:core:2.0:User"
     CORE_20_GROUP = "urn:ietf:params:scim:schemas:core:2.0:Group"
     API_MESSAGES_20_SEARCH_REQUEST = "urn:ietf:params:scim:api:messages:2.0:SearchRequest"
@@ -72,20 +72,20 @@ class SCIMSchema(str, Enum):
     DEBUG_V1 = "https://scim.eduid.se/schema/nutid-DEBUG/v1"
 
 
-class SCIMResourceType(str, Enum):
+class SCIMResourceType(StrEnum):
     USER = "User"
     GROUP = "Group"
     INVITE = "Invite"
     EVENT = "Event"
 
 
-class EmailType(str, Enum):
+class EmailType(StrEnum):
     HOME = "home"
     WORK = "work"
     OTHER = "other"
 
 
-class PhoneNumberType(str, Enum):
+class PhoneNumberType(StrEnum):
     HOME = "home"
     WORK = "work"
     OTHER = "other"

--- a/src/eduid/common/models/scim_invite.py
+++ b/src/eduid/common/models/scim_invite.py
@@ -1,7 +1,7 @@
+from typing import Self
 from uuid import UUID
 
 from pydantic import Field, model_validator
-from typing_extensions import Self
 
 from eduid.common.models.scim_base import (
     BaseCreateRequest,

--- a/src/eduid/common/rpc/msg_relay.py
+++ b/src/eduid/common/rpc/msg_relay.py
@@ -1,5 +1,5 @@
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -70,7 +70,7 @@ class RelationId(NavetModelConfig):
     birth_time_number: str | None = Field(default=None, alias="BirthTimeNumber")
 
 
-class RelationType(str, Enum):
+class RelationType(StrEnum):
     CHILD = "B"
     MOTHER = "MO"
     FATHER = "FA"
@@ -94,7 +94,7 @@ class PostalAddresses(NavetModelConfig):
     official_address: OfficialAddress = Field(alias="OfficialAddress")
 
 
-class DeregisteredCauseCode(str, Enum):
+class DeregisteredCauseCode(StrEnum):
     DECEASED = "AV"
     EMIGRATED = "UV"
     OLD_NIN = "GN"

--- a/src/eduid/common/testing_base.py
+++ b/src/eduid/common/testing_base.py
@@ -5,7 +5,7 @@ import logging.config
 import os
 import uuid
 from collections.abc import Iterable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any, TypeVar
 
@@ -50,7 +50,7 @@ def normalised_data(
                 else:
                     logger.warning(f"No timezone found for datetime: {o}")
                 # Make sure all datetimes has the same type of tzinfo object
-                o = o.replace(tzinfo=timezone.utc)
+                o = o.replace(tzinfo=UTC)
                 o = o.replace(microsecond=0)
                 return o.isoformat()
 

--- a/src/eduid/common/utils.py
+++ b/src/eduid/common/utils.py
@@ -32,22 +32,6 @@ def urlappend(base: str, path: str) -> str:
     return f"{base!s}{path!s}"
 
 
-# TODO: removeprefix and removesuffix be a part of str in python 3.9
-def removeprefix(s: str, prefix: str) -> str:
-    if s.startswith(prefix):
-        return s[len(prefix) :]
-    else:
-        return s[:]
-
-
-def removesuffix(s: str, suffix: str) -> str:
-    # suffix='' should not call self[:-0].
-    if suffix and s.endswith(suffix):
-        return s[: -len(suffix)]
-    else:
-        return s[:]
-
-
 def make_etag(version: ObjectId) -> str:
     return f'W/"{version}"'
 

--- a/src/eduid/graphdb/helpers.py
+++ b/src/eduid/graphdb/helpers.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 __author__ = "lundberg"
 
@@ -8,9 +8,9 @@ def neo4j_ts_to_dt(data: Mapping) -> Mapping[str, datetime | None]:
     created_ts = data.get("created_ts")
     if isinstance(created_ts, int):
         created_ts = datetime.fromtimestamp(created_ts / 1000)  # Milliseconds since 1970
-        created_ts.replace(tzinfo=timezone.utc)
+        created_ts.replace(tzinfo=UTC)
     modified_ts = data.get("modified_ts")
     if isinstance(modified_ts, int):
         modified_ts = datetime.fromtimestamp(modified_ts / 1000)  # Milliseconds since 1970
-        modified_ts.replace(tzinfo=timezone.utc)
+        modified_ts.replace(tzinfo=UTC)
     return {"created_ts": created_ts, "modified_ts": modified_ts}

--- a/src/eduid/graphdb/tests/test_group.py
+++ b/src/eduid/graphdb/tests/test_group.py
@@ -1,7 +1,5 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 from unittest import TestCase
-
-from typing_extensions import NotRequired
 
 from eduid.graphdb.groupdb import Group, User
 

--- a/src/eduid/maccapi/config.py
+++ b/src/eduid/maccapi/config.py
@@ -3,7 +3,6 @@ import logging
 from pydantic import field_validator
 
 from eduid.common.config.base import AuthnBearerTokenConfig, LoggingConfigMixin, StatsConfigMixin
-from eduid.common.utils import removesuffix
 
 logger = logging.getLogger(__name__)
 
@@ -27,5 +26,5 @@ class MAccApiConfig(AuthnBearerTokenConfig, LoggingConfigMixin, StatsConfigMixin
     def application_root_must_not_end_with_slash(cls, v: str) -> str:
         if v.endswith("/"):
             logger.warning(f"application_root should not end with slash ({v})")
-            v = removesuffix(v, "/")
+            v = v.removesuffix("/")
         return v

--- a/src/eduid/queue/db/payload.py
+++ b/src/eduid/queue/db/payload.py
@@ -4,6 +4,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, TypeVar
 
+from eduid.common.misc.timeutil import utc_now
+
 __author__ = "lundberg"
 
 TPayload = TypeVar("TPayload", bound="Payload")
@@ -39,7 +41,7 @@ class RawPayload(Payload):
 @dataclass
 class TestPayload(Payload):
     message: str
-    created_ts: datetime = field(default_factory=datetime.utcnow)
+    created_ts: datetime = field(default_factory=utc_now)
     version: int = 1
 
     @classmethod

--- a/src/eduid/queue/db/queue_item.py
+++ b/src/eduid/queue/db/queue_item.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from bson import ObjectId
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.queue.db.payload import Payload, RawPayload
 from eduid.userdb.db import TUserDbDocument
 
@@ -38,7 +39,7 @@ class QueueItem:
     payload_type: str
     payload: Payload
     item_id: ObjectId = field(default_factory=ObjectId)
-    created_ts: datetime = field(default_factory=datetime.utcnow)
+    created_ts: datetime = field(default_factory=utc_now)
     processed_by: str | None = None
     processed_ts: datetime | None = None
     retries: int = 0

--- a/src/eduid/queue/db/worker.py
+++ b/src/eduid/queue/db/worker.py
@@ -7,6 +7,7 @@ from typing import Any
 from bson import ObjectId
 from pymongo.results import UpdateResult
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.queue.db import Payload, QueueItem
 from eduid.queue.db.client import QueuePayloadMixin
 from eduid.queue.exceptions import PayloadNotRegistered
@@ -102,11 +103,11 @@ class AsyncQueueDB(AsyncBaseDB, QueuePayloadMixin):
             spec["processed_ts"] = None
 
         if min_age_in_seconds is not None:
-            latest_created = datetime.utcnow() + timedelta(seconds=min_age_in_seconds)
+            latest_created = utc_now() + timedelta(seconds=min_age_in_seconds)
             spec["created_ts"] = {"$lt": latest_created}
 
         if expired is not None:
-            now = datetime.utcnow()
+            now = utc_now()
             if expired:
                 spec["expires_at"] = {"$lt": now}
             else:

--- a/src/eduid/queue/db/worker.py
+++ b/src/eduid/queue/db/worker.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping
 from dataclasses import replace
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from bson import ObjectId
@@ -74,7 +74,7 @@ class AsyncQueueDB(AsyncBaseDB, QueuePayloadMixin):
         # Update item with current worker name and ts
         mutable_doc = dict(doc)
         mutable_doc["processed_by"] = worker_name
-        mutable_doc["processed_ts"] = datetime.now(tz=timezone.utc)
+        mutable_doc["processed_ts"] = datetime.now(tz=UTC)
 
         try:
             # Try to parse the queue item to only grab items that are registered with the current db

--- a/src/eduid/queue/decorators.py
+++ b/src/eduid/queue/decorators.py
@@ -4,11 +4,11 @@ from typing import Any
 
 from pymongo.synchronous.collection import Collection
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import MongoDB
 
 # TODO: Refactor but keep transaction audit document structure
 from eduid.userdb.db.base import TUserDbDocument
-from eduid.userdb.util import utc_now
 
 
 class TransactionAudit:

--- a/src/eduid/queue/helpers.py
+++ b/src/eduid/queue/helpers.py
@@ -2,11 +2,11 @@ import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Self
 
 import babel
 from babel.support import Translations
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from typing_extensions import Self
 
 __author__ = "lundberg"
 

--- a/src/eduid/queue/tests/test_mail_worker.py
+++ b/src/eduid/queue/tests/test_mail_worker.py
@@ -8,12 +8,12 @@ from unittest.mock import MagicMock, patch
 from aiosmtplib import SMTPResponse
 
 from eduid.common.config.parsers import load_config
+from eduid.common.misc.timeutil import utc_now
 from eduid.queue.config import QueueWorkerConfig
 from eduid.queue.db.message import EduidSignupEmail
 from eduid.queue.db.message.payload import EduidResetPasswordEmail, EduidTerminationEmail, EduidVerificationEmail
 from eduid.queue.testing import IsolatedWorkerDBMixin, QueueAsyncioTest, SMPTDFixTemporaryInstance
 from eduid.queue.workers.mail import MailQueueWorker
-from eduid.userdb.util import utc_now
 
 __author__ = "lundberg"
 

--- a/src/eduid/queue/tests/test_worker.py
+++ b/src/eduid/queue/tests/test_worker.py
@@ -5,11 +5,11 @@ from datetime import timedelta
 from os import environ
 
 from eduid.common.config.parsers import load_config
+from eduid.common.misc.timeutil import utc_now
 from eduid.queue.config import QueueWorkerConfig
 from eduid.queue.db import QueueItem, TestPayload
 from eduid.queue.testing import IsolatedWorkerDBMixin, QueueAsyncioTest
 from eduid.queue.workers.base import QueueWorker
-from eduid.userdb.util import utc_now
 
 __author__ = "lundberg"
 

--- a/src/eduid/queue/workers/base.py
+++ b/src/eduid/queue/workers/base.py
@@ -6,10 +6,10 @@ from abc import ABC
 from asyncio import CancelledError, Task
 from collections.abc import Sequence
 from dataclasses import replace
-from datetime import datetime
 from os import environ
 
 from eduid.common.logging import init_logging
+from eduid.common.misc.timeutil import utc_now
 from eduid.queue.config import QueueWorkerConfig
 from eduid.queue.db import QueueItem
 from eduid.queue.db.change_event import ChangeEvent, OperationType
@@ -82,7 +82,7 @@ class QueueWorker(ABC):
         """
         Removes the queue item from the database
         """
-        timeit = datetime.utcnow() - queue_item.created_ts
+        timeit = utc_now() - queue_item.created_ts
         await self.db.remove_item(queue_item.item_id)
         logger.info(f"QueueItem with id: {queue_item.item_id} successfully processed after {timeit.seconds}s.")
 

--- a/src/eduid/queue/workers/sink.py
+++ b/src/eduid/queue/workers/sink.py
@@ -9,11 +9,11 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from eduid.common.config.parsers import load_config
+from eduid.common.misc.timeutil import utc_now
 from eduid.queue.config import QueueWorkerConfig
 from eduid.queue.db import QueueItem, SenderInfo
 from eduid.queue.db.message.payload import EduidTestPayload, EduidTestResultPayload
 from eduid.queue.workers.base import QueueWorker
-from eduid.userdb.util import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/scimapi/config.py
+++ b/src/eduid/scimapi/config.py
@@ -3,7 +3,6 @@ import logging
 from pydantic import BaseModel, Field, field_validator
 
 from eduid.common.config.base import AuthnBearerTokenConfig, LoggingConfigMixin
-from eduid.common.utils import removesuffix
 
 logger = logging.getLogger(__name__)
 
@@ -36,5 +35,5 @@ class ScimApiConfig(AuthnBearerTokenConfig, LoggingConfigMixin, AWSMixin):
     def application_root_must_not_end_with_slash(cls, v: str) -> str:
         if v.endswith("/"):
             logger.warning(f"application_root should not end with slash ({v})")
-            v = removesuffix(v, "/")
+            v = v.removesuffix("/")
         return v

--- a/src/eduid/scimapi/middleware.py
+++ b/src/eduid/scimapi/middleware.py
@@ -19,7 +19,6 @@ from eduid.common.models.bearer_token import (
     AuthSource,
     RequestedAccessDenied,
 )
-from eduid.common.utils import removeprefix
 from eduid.scimapi.context import Context
 from eduid.scimapi.context_request import ScimApiContext
 from eduid.scimapi.exceptions import Unauthorized, http_error_detail_handler
@@ -70,7 +69,7 @@ class AuthenticationMiddleware(BaseMiddleware):
     def _is_no_auth_path(self, url: URL) -> bool:
         path = url.path
         # Remove application root from path matching
-        path = removeprefix(path, self.context.config.application_root)
+        path = path.removeprefix(self.context.config.application_root)
         for regex in self.no_authn_urls:
             m = re.match(regex, path)
             if m is not None:

--- a/src/eduid/scimapi/notifications.py
+++ b/src/eduid/scimapi/notifications.py
@@ -2,11 +2,12 @@ __author__ = "lundberg"
 
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from os import environ
 from typing import TYPE_CHECKING, Any, NewType
 
 from eduid.common.config.base import DataOwnerName
+from eduid.common.misc.timeutil import utc_now
 from eduid.queue.db import QueueItem, SenderInfo
 from eduid.queue.db.message.payload import EduidSCIMAPINotification
 from eduid.scimapi.config import ScimApiConfig
@@ -41,7 +42,7 @@ class NotificationRelay:
         """
         Send a request for 'someone else' to POST information about this event to a URL.
         """
-        expires_at = datetime.utcnow() + timedelta(seconds=self.config.invite_expire)
+        expires_at = utc_now() + timedelta(seconds=self.config.invite_expire)
         discard_at = expires_at + timedelta(days=7)
         _urls = self._urls_for(data_owner)
         if not _urls:

--- a/src/eduid/scimapi/routers/events.py
+++ b/src/eduid/scimapi/routers/events.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from fastapi import Response
 
 from eduid.common.fastapi.context_request import ContextRequest
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import SCIMResourceType
 from eduid.scimapi.api_router import APIRouter
 from eduid.scimapi.context_request import ScimApiContext, ScimApiRoute
@@ -10,7 +11,6 @@ from eduid.scimapi.exceptions import BadRequest, ErrorDetail, NotFound
 from eduid.scimapi.models.event import EventCreateRequest, EventResponse
 from eduid.scimapi.routers.utils.events import db_event_to_response, get_scim_referenced
 from eduid.userdb.scimapi import ScimApiEvent, ScimApiEventResource
-from eduid.userdb.util import utc_now
 
 __author__ = "lundberg"
 

--- a/src/eduid/scimapi/routers/login.py
+++ b/src/eduid/scimapi/routers/login.py
@@ -26,7 +26,7 @@ async def get_token(req: ContextRequest, resp: Response, token_req: TokenRequest
     req.app.context.logger.info("Logging in")
     if token_req.data_owner not in req.app.context.config.data_owners:
         raise Unauthorized()
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    now = datetime.datetime.now(tz=datetime.UTC)
     expire = now + datetime.timedelta(seconds=req.app.context.config.authorization_token_expire)
     signing_key = req.app.context.jwks.get_key(req.app.context.config.signing_key_id)
     claims = {

--- a/src/eduid/scimapi/routers/utils/events.py
+++ b/src/eduid/scimapi/routers/utils/events.py
@@ -16,7 +16,7 @@ from eduid.userdb.scimapi import EventLevel, EventStatus, ScimApiEvent, ScimApiE
 if TYPE_CHECKING:
     from eduid.scimapi.context import Context
 
-from eduid.userdb.util import utc_now
+from eduid.common.misc.timeutil import utc_now
 
 __author__ = "lundberg"
 

--- a/src/eduid/scimapi/routers/utils/invites.py
+++ b/src/eduid/scimapi/routers/utils/invites.py
@@ -8,6 +8,7 @@ from fastapi import Request, Response
 from pymongo.errors import DuplicateKeyError
 
 from eduid.common.fastapi.context_request import ContextRequest
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import Email, Meta, Name, PhoneNumber, SCIMResourceType, SCIMSchema, SearchRequest
 from eduid.common.models.scim_invite import InviteCreateRequest, InviteResponse, NutidInviteExtensionV1
 from eduid.common.models.scim_user import NutidUserExtensionV1, Profile
@@ -62,7 +63,7 @@ def create_signup_invite(
         mail_addresses=mails_addresses,
         phone_numbers=phone_numbers,
         finish_url=create_request.nutid_invite_v1.finish_url,
-        expires_at=datetime.utcnow() + timedelta(seconds=req.app.context.config.invite_expire),
+        expires_at=utc_now() + timedelta(seconds=req.app.context.config.invite_expire),
     )
     return signup_invite
 
@@ -142,7 +143,7 @@ def send_invite_mail(req: ContextRequest, signup_invite: SignupInvite) -> bool:
     system_hostname = environ.get("SYSTEM_HOSTNAME", "")  # Underlying hosts name for containers
     hostname = environ.get("HOSTNAME", "")  # Actual hostname or container id
     sender_info = SenderInfo(hostname=hostname, node_id=f"{app_name}@{system_hostname}")
-    expires_at = datetime.utcnow() + timedelta(seconds=req.app.context.config.invite_expire)
+    expires_at = utc_now() + timedelta(seconds=req.app.context.config.invite_expire)
     discard_at = expires_at + timedelta(days=7)
     message = QueueItem(
         version=1,

--- a/src/eduid/scimapi/tests/test_scimbase.py
+++ b/src/eduid/scimapi/tests/test_scimbase.py
@@ -1,7 +1,7 @@
-from datetime import datetime
 from unittest import TestCase
 from uuid import uuid4
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import BaseResponse, Meta, SCIMResourceType, SCIMSchema, SubResource, WeakVersion
 from eduid.common.testing_base import normalised_data
 
@@ -13,8 +13,8 @@ class TestScimBase(TestCase):
         meta = Meta(
             location="http://example.org/group/some-id",
             resource_type=SCIMResourceType.GROUP,
-            created=datetime.utcnow(),
-            last_modified=datetime.utcnow(),
+            created=utc_now(),
+            last_modified=utc_now(),
             version=WeakVersion(),
         )
         meta_dump = meta.json()
@@ -25,8 +25,8 @@ class TestScimBase(TestCase):
         meta = Meta(
             location="http://example.org/group/some-id",
             resource_type=SCIMResourceType.GROUP,
-            created=datetime.utcnow(),
-            last_modified=datetime.utcnow(),
+            created=utc_now(),
+            last_modified=utc_now(),
             version=WeakVersion(),
         )
         base = BaseResponse(id=uuid4(), schemas=[SCIMSchema.CORE_20_USER, SCIMSchema.CORE_20_GROUP], meta=meta)

--- a/src/eduid/scimapi/tests/test_scimgroup.py
+++ b/src/eduid/scimapi/tests/test_scimgroup.py
@@ -2,7 +2,6 @@ __author__ = "lundberg"
 
 import logging
 from collections.abc import Mapping
-from datetime import datetime
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -10,6 +9,7 @@ from bson import ObjectId
 from httpx import Response
 
 from eduid.common.config.base import DataOwnerName
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import Meta, SCIMResourceType, SCIMSchema, WeakVersion
 from eduid.common.testing_base import normalised_data
 from eduid.common.utils import make_etag
@@ -29,8 +29,8 @@ class TestSCIMGroup(TestScimBase):
         self.meta = Meta(
             location="http://example.org/Groups/some-id",
             resource_type=SCIMResourceType.GROUP,
-            created=datetime.utcnow(),
-            last_modified=datetime.utcnow(),
+            created=utc_now(),
+            last_modified=utc_now(),
             version=WeakVersion(),
         )
 

--- a/src/eduid/scimapi/tests/test_sciminvite.py
+++ b/src/eduid/scimapi/tests/test_sciminvite.py
@@ -238,7 +238,7 @@ class TestInviteResource(ScimApiTestCase):
             mail_addresses=mails_addresses,
             phone_numbers=phone_numbers,
             finish_url=invite_data.get("finish_url"),
-            expires_at=datetime.utcnow() + timedelta(seconds=self.context.config.invite_expire),
+            expires_at=utc_now() + timedelta(seconds=self.context.config.invite_expire),
         )
         self.signup_invitedb.save(signup_invite, is_in_database=False)
         return db_invite

--- a/src/eduid/scimapi/tests/test_scimuser.py
+++ b/src/eduid/scimapi/tests/test_scimuser.py
@@ -13,6 +13,7 @@ import bson
 from bson import ObjectId
 from httpx import AsyncClient, Response
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import Email, LanguageTag, Meta, Name, PhoneNumber, SCIMResourceType, SCIMSchema
 from eduid.common.models.scim_user import LinkedAccount, NutidUserExtensionV1, Profile, UserResponse
 from eduid.common.testing_base import normalised_data
@@ -630,7 +631,7 @@ class TestUserResource(ScimApiTestUserResourceBase):
             self.add_user(identifier=str(uuid4()), external_id=f"test-id-{i}", profiles={"test": self.test_profile})
         assert self.userdb
         self.assertEqual(9, self.userdb.db_count())
-        last_modified = datetime.utcnow() - timedelta(hours=1)
+        last_modified = utc_now() - timedelta(hours=1)
         self._perform_search(
             search_filter=f'meta.lastmodified gt "{last_modified.isoformat()}"',
             start=5,
@@ -644,7 +645,7 @@ class TestUserResource(ScimApiTestUserResourceBase):
             self.add_user(identifier=str(uuid4()), external_id=f"test-id-{i}", profiles={"test": self.test_profile})
         assert self.userdb
         self.assertEqual(9, self.userdb.db_count())
-        last_modified = datetime.utcnow() - timedelta(hours=1)
+        last_modified = utc_now() - timedelta(hours=1)
         self._perform_search(
             search_filter=f'meta.lastmodified gt "{last_modified.isoformat()}"',
             count=5,
@@ -658,7 +659,7 @@ class TestUserResource(ScimApiTestUserResourceBase):
             self.add_user(identifier=str(uuid4()), external_id=f"test-id-{i}", profiles={"test": self.test_profile})
         assert self.userdb
         self.assertEqual(9, self.userdb.db_count())
-        last_modified = datetime.utcnow() - timedelta(hours=1)
+        last_modified = utc_now() - timedelta(hours=1)
         self._perform_search(
             search_filter=f'meta.lastmodified gt "{last_modified.isoformat()}"',
             start=7,

--- a/src/eduid/scimapi/tests/test_search_filter.py
+++ b/src/eduid/scimapi/tests/test_search_filter.py
@@ -1,13 +1,13 @@
 import unittest
-from datetime import datetime
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.scimapi.exceptions import BadRequest
 from eduid.scimapi.search import parse_search_filter
 
 
 class TestSearchFilter(unittest.TestCase):
     def test_lastmodified(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
         filter = f'meta.lastModified gt "{now.isoformat()}"'
         sf = parse_search_filter(filter)
         self.assertEqual(sf.attr, "meta.lastmodified")

--- a/src/eduid/userdb/authninfo.py
+++ b/src/eduid/userdb/authninfo.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from eduid.userdb import User
 from eduid.userdb.credentials import U2F, Password, Webauthn
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 __author__ = "eperez"
 
 
-class AuthnCredType(str, Enum):
+class AuthnCredType(StrEnum):
     password = "security.password_credential_type"
     u2f = "security.u2f_credential_type"
     unknown = "security.unknown_credential_type"

--- a/src/eduid/userdb/credentials/base.py
+++ b/src/eduid/userdb/credentials/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from eduid.userdb.element import TVerifiedElementSubclass, VerifiedElement
@@ -9,7 +9,7 @@ __author__ = "ft"
 
 
 # well-known proofing methods
-class CredentialProofingMethod(str, Enum):
+class CredentialProofingMethod(StrEnum):
     SWAMID_AL2_MFA_HI = "SWAMID_AL2_MFA_HI"  # deprecated and replaced by SWAMID_AL3_MFA
     SWAMID_AL3_MFA = "SWAMID_AL3_MFA"
 

--- a/src/eduid/userdb/credentials/external.py
+++ b/src/eduid/userdb/credentials/external.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 from bson import ObjectId
@@ -12,7 +12,7 @@ from eduid.userdb.element import ElementKey
 from eduid.userdb.util import objectid_str
 
 
-class TrustFramework(str, Enum):
+class TrustFramework(StrEnum):
     SWECONN = "SWECONN"
     EIDAS = "EIDAS"
     SVIPE = "SVIPE"

--- a/src/eduid/userdb/db/sync_db.py
+++ b/src/eduid/userdb/db/sync_db.py
@@ -12,10 +12,11 @@ from bson import ObjectId
 from pymongo.database import Database
 from pymongo.errors import PyMongoError
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db.base import BaseMongoDB, TUserDbDocument
 from eduid.userdb.exceptions import DocumentOutOfSync, EduIDUserDBError, MongoConnectionError, MultipleDocumentsReturned
 from eduid.userdb.meta import Meta
-from eduid.userdb.util import format_dict_for_debug, utc_now
+from eduid.userdb.util import format_dict_for_debug
 
 logger = logging.getLogger(__name__)
 extra_logger = logger.getChild("extra_debug")

--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -60,7 +60,7 @@ from eduid.userdb.exceptions import EduIDUserDBError, UserDBValueError
 
 __author__ = "ft"
 
-from eduid.userdb.util import utc_now
+from eduid.common.misc.timeutil import utc_now
 
 
 class ElementError(EduIDUserDBError):

--- a/src/eduid/userdb/group_management/state.py
+++ b/src/eduid/userdb/group_management/state.py
@@ -4,7 +4,7 @@ import copy
 import datetime
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field, fields
-from enum import Enum, unique
+from enum import StrEnum, unique
 from typing import Any
 
 import bson
@@ -16,7 +16,7 @@ __author__ = "lundberg"
 
 
 @unique
-class GroupRole(str, Enum):
+class GroupRole(StrEnum):
     OWNER = "owner"
     MEMBER = "member"
 

--- a/src/eduid/userdb/identity.py
+++ b/src/eduid/userdb/identity.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import Field
@@ -15,14 +15,14 @@ __author__ = "lundberg"
 logger = logging.getLogger(__name__)
 
 
-class IdentityType(str, Enum):
+class IdentityType(StrEnum):
     NIN = "nin"
     EIDAS = "eidas"
     SVIPE = "svipe"
     FREJA = "freja"
 
 
-class IdentityProofingMethod(str, Enum):
+class IdentityProofingMethod(StrEnum):
     # difference in capitalization/underscore/hyphen is intentional as to follow existing proofing log entries
     SVIPE_ID = "svipe_id"
     LETTER = "letter"
@@ -124,13 +124,13 @@ class ForeignIdentityElement(IdentityElement, ABC):
     date_of_birth: datetime
 
 
-class PridPersistence(str, Enum):
+class PridPersistence(StrEnum):
     A = "A"  # Persistence over time is expected to be comparable or better than a Swedish nin
     B = "B"  # Persistence over time is expected to be relatively stable, but lower than a Swedish nin
     C = "C"  # No expectations regarding persistence over time
 
 
-class EIDASLoa(str, Enum):
+class EIDASLoa(StrEnum):
     NF_LOW = "eidas-nf-low"
     NF_SUBSTANTIAL = "eidas-nf-sub"
     NF_HIGH = "eidas-nf-high"
@@ -188,7 +188,7 @@ class SvipeIdentity(ForeignIdentityElement):
         return self.svipe_id
 
 
-class FrejaRegistrationLevel(str, Enum):
+class FrejaRegistrationLevel(StrEnum):
     EXTENDED = "EXTENDED"
     PLUS = "PLUS"
 

--- a/src/eduid/userdb/idp/user.py
+++ b/src/eduid/userdb/idp/user.py
@@ -4,7 +4,7 @@ User and user database module.
 
 import logging
 from dataclasses import dataclass
-from enum import Enum, unique
+from enum import StrEnum, unique
 from typing import Any
 
 from eduid.common.models.saml2 import EduidAuthnContextClass
@@ -52,7 +52,7 @@ class SAMLAttributeSettings:
 
 
 @unique
-class SubjectIDRequest(str, Enum):
+class SubjectIDRequest(StrEnum):
     ANY = "any"
     NONE = "none"
     PAIRWISE_ID = "pairwise-id"

--- a/src/eduid/userdb/meta.py
+++ b/src/eduid/userdb/meta.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated
 
 from bson import ObjectId
@@ -10,7 +10,7 @@ from eduid.common.misc.timeutil import utc_now
 __author__ = "lundberg"
 
 
-class CleanerType(str, Enum):
+class CleanerType(StrEnum):
     SKV = "skatteverket"
     TELE = "teleadress"
     LADOK = "ladok"

--- a/src/eduid/userdb/proofing/state.py
+++ b/src/eduid/userdb/proofing/state.py
@@ -70,7 +70,7 @@ class ProofingState:
         res["_id"] = res.pop("id")
         res["eduPersonPrincipalName"] = res.pop("eppn")
         if res["modified_ts"] is True:
-            res["modified_ts"] = datetime.datetime.utcnow()
+            res["modified_ts"] = utc_now()
         return TUserDbDocument(res)
 
     def __str__(self) -> str:

--- a/src/eduid/userdb/reset_password/element.py
+++ b/src/eduid/userdb/reset_password/element.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 from eduid.common.misc.timeutil import utc_now
@@ -72,7 +72,7 @@ class CodeElement(Element):
             return cls(
                 created_by=data.get("created_by", application),
                 code=data["code"],
-                created_ts=data.get("created_ts", datetime.utcnow()),
+                created_ts=data.get("created_ts", utc_now()),
                 is_verified=data.get("verified", False),
             )
         if isinstance(code_or_element, CodeElement):

--- a/src/eduid/userdb/reset_password/element.py
+++ b/src/eduid/userdb/reset_password/element.py
@@ -4,8 +4,8 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.element import Element, ElementKey
-from eduid.userdb.util import utc_now
 
 
 class CodeElement(Element):

--- a/src/eduid/userdb/scimapi/common.py
+++ b/src/eduid/userdb/scimapi/common.py
@@ -9,8 +9,8 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import EmailType, PhoneNumberType, WeakVersion
-from eduid.userdb.util import utc_now
 
 __author__ = "lundberg"
 

--- a/src/eduid/userdb/scimapi/groupdb.py
+++ b/src/eduid/userdb/scimapi/groupdb.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 from bson import ObjectId
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.graphdb.groupdb import Group as GraphGroup
 from eduid.graphdb.groupdb import GroupDB
 from eduid.graphdb.groupdb import User as GraphUser
@@ -137,7 +138,7 @@ class ScimApiGroupDB(ScimApiBaseDB):
         }
         # update the version number and last_modified timestamp
         group_dict["version"] = ObjectId()
-        group_dict["last_modified"] = datetime.utcnow()
+        group_dict["last_modified"] = utc_now()
         result = self._coll.replace_one(test_doc, group_dict, upsert=False)
         if result.modified_count == 0:
             db_group = self._coll.find_one({"_id": group.group_id})

--- a/src/eduid/userdb/scimapi/invitedb.py
+++ b/src/eduid/userdb/scimapi/invitedb.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from bson import ObjectId
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.scimapi.utils import filter_none
 from eduid.userdb.db import TUserDbDocument
 from eduid.userdb.scimapi.basedb import ScimApiBaseDB
@@ -88,7 +89,7 @@ class ScimApiInviteDB(ScimApiBaseDB):
         }
         # update the version number and last_modified timestamp
         invite_dict["version"] = ObjectId()
-        invite_dict["last_modified"] = datetime.utcnow()
+        invite_dict["last_modified"] = utc_now()
         result = self._coll.replace_one(test_doc, invite_dict, upsert=False)
         if result.modified_count == 0:
             db_invite = self._coll.find_one({"_id": invite.invite_id})

--- a/src/eduid/userdb/scimapi/userdb.py
+++ b/src/eduid/userdb/scimapi/userdb.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from bson import ObjectId
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb import User, UserDB
 from eduid.userdb.db import TUserDbDocument
 from eduid.userdb.exceptions import DocumentOutOfSync
@@ -108,7 +109,7 @@ class ScimApiUserDB(ScimApiBaseDB):
         }
         # update the version number and last_modified timestamp
         user_dict["version"] = ObjectId()
-        user_dict["last_modified"] = datetime.utcnow()
+        user_dict["last_modified"] = utc_now()
         # Save existing user
         result = self._coll.replace_one(test_doc, user_dict, upsert=False)
         if result.modified_count == 0:

--- a/src/eduid/userdb/signup/invite.py
+++ b/src/eduid/userdb/signup/invite.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from bson import ObjectId
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import TUserDbDocument
 
 __author__ = "lundberg"
@@ -66,7 +67,7 @@ class Invite(_InviteRequired):
     preferred_language: str = field(default="sv")
     finish_url: str | None = field(default=None)
     completed_ts: datetime | None = field(default=None)
-    created_ts: datetime = field(default_factory=datetime.utcnow)
+    created_ts: datetime = field(default_factory=utc_now)
     modified_ts: datetime | None = field(default=None)
 
     def get_primary_mail_address(self) -> str | None:

--- a/src/eduid/userdb/signup/invitedb.py
+++ b/src/eduid/userdb/signup/invitedb.py
@@ -1,8 +1,8 @@
-import datetime
 import logging
 from dataclasses import replace
 from typing import Any
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import SaveResult
 from eduid.userdb.exceptions import MultipleDocumentsReturned
 from eduid.userdb.signup import Invite, SCIMReference
@@ -53,6 +53,6 @@ class SignupInviteDB(BaseDB):
         spec: dict[str, Any] = {"_id": invite.invite_id}
 
         result = self._save(invite.to_dict(), spec, is_in_database=is_in_database)
-        invite = replace(invite, modified_ts=datetime.datetime.utcnow())  # update to current time
+        invite = replace(invite, modified_ts=utc_now())  # update to current time
 
         return result

--- a/src/eduid/userdb/testing/temp_instance.py
+++ b/src/eduid/userdb/testing/temp_instance.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Any
 
-from eduid.userdb.util import utc_now
+from eduid.common.misc.timeutil import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/userdb/tests/test_credentials.py
+++ b/src/eduid/userdb/tests/test_credentials.py
@@ -18,7 +18,7 @@ __author__ = "lundberg"
 #    'id': password_id,                         # noqa: ERA001
 #    'salt': salt,                              # noqa: ERA001
 #    'source': 'signup',                        # noqa: ERA001
-#    'created_ts': datetime.datetime.utcnow(),  # noqa: ERA001
+#    'created_ts': utc_now(),                   # noqa: ERA001
 # }}                                            # noqa: ERA001
 from eduid.userdb.credentials.password import Password
 

--- a/src/eduid/userdb/tests/test_element.py
+++ b/src/eduid/userdb/tests/test_element.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from unittest import TestCase
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.element import Element, PrimaryElement, PrimaryElementViolation, VerifiedElement
 
 
@@ -13,7 +14,7 @@ class TestElements(TestCase):
         assert isinstance(elem.modified_ts, datetime)
 
     def test_create_element_with_created_ts(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
         elem = Element(created_by="test", created_ts=now)
 
         assert elem.created_by == "test"
@@ -21,7 +22,7 @@ class TestElements(TestCase):
         assert isinstance(elem.modified_ts, datetime)
 
     def test_create_element_with_modified_ts(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
         elem = Element(created_by="test", modified_ts=now)
 
         assert elem.created_by == "test"
@@ -29,7 +30,7 @@ class TestElements(TestCase):
         assert isinstance(elem.modified_ts, datetime)
 
     def test_create_element_with_created_and_modified_ts(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
         elem = Element(created_by="test", modified_ts=now, created_ts=now)
 
         assert elem.created_by == "test"
@@ -37,10 +38,10 @@ class TestElements(TestCase):
         assert elem.modified_ts == now
 
     def test_element_reset_modified_ts(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
         elem = Element(created_by="test", modified_ts=now, created_ts=now)
 
-        then = datetime.utcnow()
+        then = utc_now()
         elem.modified_ts = then
 
         assert elem.modified_ts == then
@@ -60,7 +61,7 @@ class TestVerifiedElements(TestCase):
 
     def test_modify_verified_element(self) -> None:
         elem = VerifiedElement(created_by="test")
-        now = datetime.utcnow()
+        now = utc_now()
 
         elem.is_verified = True
         elem.verified_by = "test"
@@ -75,7 +76,7 @@ class TestVerifiedElements(TestCase):
         assert elem.verified_ts == now
 
     def test_create_full_verified_element(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
 
         elem = VerifiedElement(
             created_by="test", created_ts=now, modified_ts=now, is_verified=True, verified_by="test", verified_ts=now
@@ -106,7 +107,7 @@ class TestPrimaryElements(TestCase):
 
     def test_modify_primary_element(self) -> None:
         elem = PrimaryElement(created_by="test")
-        now = datetime.utcnow()
+        now = utc_now()
 
         elem.is_verified = True
         elem.verified_by = "test"
@@ -125,7 +126,7 @@ class TestPrimaryElements(TestCase):
         assert elem.is_primary is True
 
     def test_create_full_primary_element(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
 
         elem = PrimaryElement(
             created_by="test",
@@ -148,7 +149,7 @@ class TestPrimaryElements(TestCase):
         assert elem.is_primary is True
 
     def test_unverify_primary_element(self) -> None:
-        now = datetime.utcnow()
+        now = utc_now()
 
         elem = PrimaryElement(
             created_by="test",

--- a/src/eduid/userdb/tests/test_nin.py
+++ b/src/eduid/userdb/tests/test_nin.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import ValidationError
 
 import eduid.userdb.exceptions
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.testing_base import normalised_data
 from eduid.userdb import PhoneNumber
 from eduid.userdb.element import ElementKey
@@ -250,7 +251,7 @@ class TestNin(TestCase):
     def test_modify_verified_ts(self) -> None:
         this = self.three.find("197803033456")
         assert this
-        now = datetime.datetime.utcnow()
+        now = utc_now()
         this.verified_ts = now
         self.assertEqual(this.verified_ts, now)
 

--- a/src/eduid/userdb/tests/test_signup_invite.py
+++ b/src/eduid/userdb/tests/test_signup_invite.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest import TestCase
 from uuid import uuid4
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.signup import Invite, InviteMailAddress, InvitePhoneNumber, InviteType, SCIMReference
 
 
@@ -20,7 +21,7 @@ class TestSignupInvite(TestCase):
             send_email=True,
             finish_url="https://example.com/finish",
             completed_ts=None,
-            expires_at=datetime.utcnow() + timedelta(days=180),
+            expires_at=utc_now() + timedelta(days=180),
         )
         invite_dict = invite.to_dict()
         assert invite == Invite.from_dict(invite_dict)

--- a/src/eduid/userdb/tests/test_tou.py
+++ b/src/eduid/userdb/tests/test_tou.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import bson
 from pydantic import ValidationError
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.actions.tou import ToUUser
 from eduid.userdb.credentials import CredentialList
 from eduid.userdb.db.base import TUserDbDocument
@@ -14,7 +15,6 @@ from eduid.userdb.exceptions import UserMissingData
 from eduid.userdb.fixtures.users import UserFixtures
 from eduid.userdb.tou import ToUEvent, ToUList
 from eduid.userdb.user import User
-from eduid.userdb.util import utc_now
 
 __author__ = "ft"
 

--- a/src/eduid/userdb/tests/test_u2f.py
+++ b/src/eduid/userdb/tests/test_u2f.py
@@ -15,7 +15,7 @@ __author__ = "lundberg"
 #    'id': password_id,                         # noqa: ERA001
 #    'salt': salt,                              # noqa: ERA001
 #    'source': 'signup',                        # noqa: ERA001
-#    'created_ts': datetime.datetime.utcnow(),  # noqa: ERA001
+#    'created_ts': utc_now(),                   # noqa: ERA001
 # }}                                            # noqa: ERA001
 
 _one_dict = {

--- a/src/eduid/userdb/tests/test_user.py
+++ b/src/eduid/userdb/tests/test_user.py
@@ -6,6 +6,7 @@ import pytest
 from bson import ObjectId
 from pydantic import ValidationError
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb import NinIdentity, OidcAuthorization, OidcIdToken, Orcid
 from eduid.userdb.credentials import U2F, CredentialList, CredentialProofingMethod, Password
 from eduid.userdb.db.base import TUserDbDocument
@@ -18,7 +19,6 @@ from eduid.userdb.phone import PhoneNumber, PhoneNumberList
 from eduid.userdb.profile import Profile, ProfileList
 from eduid.userdb.tou import ToUList
 from eduid.userdb.user import SubjectType, User
-from eduid.userdb.util import utc_now
 
 __author__ = "ft"
 

--- a/src/eduid/userdb/tests/test_user.py
+++ b/src/eduid/userdb/tests/test_user.py
@@ -443,11 +443,11 @@ class TestNewUser(unittest.TestCase):
         _time1 = self.user1.modified_ts
         assert _time1 is None
         # update to current time
-        self.user1.modified_ts = datetime.utcnow()
+        self.user1.modified_ts = utc_now()
         _time2 = self.user1.modified_ts
         self.assertNotEqual(_time1, _time2)
         # set to a datetime instance
-        self.user1.modified_ts = datetime.utcnow()
+        self.user1.modified_ts = utc_now()
         self.assertNotEqual(_time2, self.user1.modified_ts)
 
     def test_two_unverified_non_primary_phones(self) -> None:

--- a/src/eduid/userdb/tou.py
+++ b/src/eduid/userdb/tou.py
@@ -6,9 +6,9 @@ from typing import Any
 from bson import ObjectId
 from pydantic import field_validator
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.event import Event, EventList
 from eduid.userdb.exceptions import UserDBValueError
-from eduid.userdb.util import utc_now
 
 
 class ToUEvent(Event):

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -5,11 +5,10 @@ import logging
 from datetime import datetime
 from enum import Enum, unique
 from operator import itemgetter
-from typing import Any, TypeVar, cast
+from typing import Any, Self, TypeVar, cast
 
 import bson
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from typing_extensions import Self
 
 from eduid.userdb.credentials import CredentialList
 from eduid.userdb.db import BaseDB, TUserDbDocument

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 from datetime import datetime
-from enum import Enum, unique
+from enum import StrEnum, unique
 from operator import itemgetter
 from typing import Any, Self, TypeVar, cast
 
@@ -31,7 +31,7 @@ TUserSubclass = TypeVar("TUserSubclass", bound="User")
 
 
 @unique
-class SubjectType(str, Enum):
+class SubjectType(StrEnum):
     PERSON = "physical person"
 
 

--- a/src/eduid/userdb/util.py
+++ b/src/eduid/userdb/util.py
@@ -29,7 +29,7 @@ class UTC(datetime.tzinfo):
 # TODO: check this as it is in eduid.common.misc.timeutil
 def utc_now() -> datetime.datetime:
     """Return current time with tz=UTC"""
-    return datetime.datetime.now(tz=datetime.timezone.utc)
+    return datetime.datetime.now(tz=datetime.UTC)
 
 
 def objectid_str() -> str:

--- a/src/eduid/userdb/util.py
+++ b/src/eduid/userdb/util.py
@@ -24,14 +24,6 @@ class UTC(datetime.tzinfo):
         return datetime.timedelta(0)
 
 
-# NOTE: This function is copied from eduid.webapp.common.misc.timeutil
-# because eduid-userdb can't import eduid.webapp.common
-# TODO: check this as it is in eduid.common.misc.timeutil
-def utc_now() -> datetime.datetime:
-    """Return current time with tz=UTC"""
-    return datetime.datetime.now(tz=datetime.UTC)
-
-
 def objectid_str() -> str:
     return str(ObjectId())
 

--- a/src/eduid/vccs/server/db.py
+++ b/src/eduid/vccs/server/db.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import builtins
 from collections.abc import Mapping
 from dataclasses import asdict, field
-from enum import Enum, unique
+from enum import Enum, StrEnum, unique
 from typing import Any, cast
 
 from bson import ObjectId
@@ -15,22 +15,22 @@ from eduid.userdb.db import BaseDB, TUserDbDocument
 
 
 @unique
-class Status(str, Enum):
+class Status(StrEnum):
     ACTIVE: str = "active"
     DISABLED: str = "disabled"
 
 
 @unique
-class Version(str, Enum):
+class Version(StrEnum):
     NDNv1: str = "NDNv1"
 
 
 @unique
-class KDF(str, Enum):
+class KDF(StrEnum):
     PBKDF2_HMAC_SHA512: str = "PBKDF2-HMAC-SHA512"
 
 
-class CredType(str, Enum):
+class CredType(StrEnum):
     PASSWORD: str = "password"
     REVOKED: str = "revoked"
 

--- a/src/eduid/vccs/server/endpoints/misc.py
+++ b/src/eduid/vccs/server/endpoints/misc.py
@@ -1,4 +1,4 @@
-from enum import Enum, unique
+from enum import StrEnum, unique
 
 from fastapi import APIRouter, Request
 from pydantic.main import BaseModel
@@ -7,7 +7,7 @@ misc_router = APIRouter()
 
 
 @unique
-class Status(str, Enum):
+class Status(StrEnum):
     # STATUS_x_ is less ambiguous when pattern matching than just 'x'
     OK: str = "STATUS_OK_"
     FAIL: str = "STATUS_FAIL_"

--- a/src/eduid/webapp/common/api/checks.py
+++ b/src/eduid/webapp/common/api/checks.py
@@ -10,6 +10,7 @@ import redis
 from flask import current_app as flask_current_app
 
 from eduid.common.config.base import EduIDBaseAppConfig, RedisConfigMixin, VCCSConfigMixin
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.rpc.am_relay import AmRelay
 from eduid.common.rpc.lookup_mobile_relay import LookupMobileRelay
 from eduid.common.rpc.mail_relay import MailRelay
@@ -55,7 +56,7 @@ def log_failure_info(key: str, msg: str, exc: Exception | None = None) -> None:
     current_app = get_current_app()
 
     if key not in current_app.failure_info:
-        current_app.failure_info[key] = FailCountItem(first_failure=datetime.utcnow())
+        current_app.failure_info[key] = FailCountItem(first_failure=utc_now())
     current_app.failure_info[key].count += 1
     current_app.logger.warning(f"{msg} {current_app.failure_info[key]}: {exc}")
 
@@ -80,12 +81,12 @@ def check_restart(key: str, restart: int, terminate: int) -> bool:
         info = replace(info, restart_at=info.first_failure + timedelta(seconds=restart))
     if terminate and not info.exit_at:
         info = replace(info, exit_at=info.first_failure + timedelta(seconds=terminate))
-    if info.exit_at and datetime.utcnow() >= info.exit_at:
+    if info.exit_at and utc_now() >= info.exit_at:
         # Exit application and rely on something else restarting it
         current_app.logger.warning(f"Max failure time reached, terminating {current_app.name}")
         sys.exit(1)
-    if info.restart_at and datetime.utcnow() >= info.restart_at:
-        info = replace(info, restart_at=datetime.utcnow() + timedelta(seconds=restart))
+    if info.restart_at and utc_now() >= info.restart_at:
+        info = replace(info, restart_at=utc_now() + timedelta(seconds=restart))
         # Try to restart/reinitialize the failing functionality
         res = True
     current_app.failure_info[key] = info

--- a/src/eduid/webapp/common/api/debug.py
+++ b/src/eduid/webapp/common/api/debug.py
@@ -5,11 +5,9 @@ from collections.abc import Callable, Iterable
 from dataclasses import asdict
 from typing import Any
 from urllib import parse
+from wsgiref.types import StartResponse, WSGIEnvironment
 
 from flask import Flask, url_for
-
-# TODO: in python >= 3.11 import from wsgiref.types
-from eduid.webapp.common.wsgi import StartResponse, WSGIEnvironment
 
 __author__ = "lundberg"
 

--- a/src/eduid/webapp/common/api/errors.py
+++ b/src/eduid/webapp/common/api/errors.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from flask import redirect
 from werkzeug.wrappers import Response as WerkzeugResponse
@@ -7,7 +7,7 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 from eduid.common.misc.timeutil import utc_now
 
 
-class EduidErrorsContext(str, Enum):
+class EduidErrorsContext(StrEnum):
     SAML_RESPONSE_FAIL = "saml_response_fail"
     SAML_REQUEST_MISSING_IDP = "saml_request_missing_idp"
     SAML_MISSING_ATTRIBUTE = "saml_missing_attribute"

--- a/src/eduid/webapp/common/api/middleware.py
+++ b/src/eduid/webapp/common/api/middleware.py
@@ -2,9 +2,7 @@ __author__ = "lundberg"
 
 from collections.abc import Callable, Iterable
 from typing import Any
-
-# TODO: in python >= 3.11 import from wsgiref.types
-from eduid.webapp.common.wsgi import StartResponse, WSGIEnvironment
+from wsgiref.types import StartResponse, WSGIEnvironment
 
 
 # Copied from https://stackoverflow.com/questions/18967441/add-a-prefix-to-all-flask-routes/36033627#36033627

--- a/src/eduid/webapp/common/api/oidc.py
+++ b/src/eduid/webapp/common/api/oidc.py
@@ -4,11 +4,9 @@ from sys import exit
 from time import sleep
 from typing import Any
 
-import requests
 from oic.oic import Client
 from oic.oic.message import RegistrationRequest
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
-from oic.utils.settings import OicClientSettings
 from requests.exceptions import ConnectionError
 
 __author__ = "lundberg"
@@ -17,9 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def init_client(client_registration_info: Mapping[str, Any], provider_configuration_info: Mapping[str, Any]) -> Client:
-    # Workaround for client_cert=None not being accepted with Python 3.11 (and oic==1.4.0)
-    workaround_settings = OicClientSettings(client_cert="", requests_session=requests.Session())
-    oidc_client = Client(client_authn_method=CLIENT_AUTHN_METHOD, settings=workaround_settings)
+    oidc_client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
     oidc_client.store_registration_info(RegistrationRequest(**client_registration_info))
     provider = provider_configuration_info["issuer"]
     try:

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -81,7 +81,7 @@ def update_modified_ts(user: User) -> None:
         return None
 
     if private_user.modified_ts is None:
-        private_user.modified_ts = datetime.utcnow()  # use current time
+        private_user.modified_ts = utc_now()  # use current time
         logger.debug(f"Updating user {private_user} with new modified_ts: {private_user.modified_ts}")
         _private_userdb.save(private_user)
 

--- a/src/eduid/webapp/common/api/views/status.py
+++ b/src/eduid/webapp/common/api/views/status.py
@@ -9,6 +9,7 @@ from flask import current_app as flask_current_app
 from flask.wrappers import Response
 
 from eduid.common.config.base import EduIDBaseAppConfig
+from eduid.common.misc.timeutil import utc_now
 from eduid.webapp.common.api.checks import CheckResult
 from eduid.webapp.common.api.utils import get_from_current_app
 
@@ -43,7 +44,7 @@ def cached_json_response(key: str, data: Literal[None]) -> Response | None: ...
 
 def cached_json_response(key: str, data: dict[str, Any] | None = None) -> Response | None:
     cache_for_seconds = get_from_current_app("conf", EduIDBaseAppConfig).status_cache_seconds
-    now = datetime.utcnow()
+    now = utc_now()
     if SIMPLE_CACHE.get(key) is not None:
         if now < SIMPLE_CACHE[key].expire_time:
             if get_from_current_app("debug", bool):

--- a/src/eduid/webapp/common/authn/acs_enums.py
+++ b/src/eduid/webapp/common/authn/acs_enums.py
@@ -1,10 +1,10 @@
 # Solve circular imports of these by having them in a 'leaf' file :/
 
-from enum import Enum, unique
+from enum import StrEnum, unique
 
 
 @unique
-class AuthnAcsAction(str, Enum):
+class AuthnAcsAction(StrEnum):
     login = "login-action"
     change_password = "change-password-action"
     terminate_account = "terminate-account-action"
@@ -12,14 +12,14 @@ class AuthnAcsAction(str, Enum):
 
 
 @unique
-class EidasAcsAction(str, Enum):
+class EidasAcsAction(StrEnum):
     verify_identity = "verify-identity-action"
     verify_credential = "verify-credential-action"
     mfa_authenticate = "mfa-authenticate-action"
 
 
 @unique
-class BankIDAcsAction(str, Enum):
+class BankIDAcsAction(StrEnum):
     verify_identity = "verify-identity-action"
     verify_credential = "verify-credential-action"
     mfa_authenticate = "mfa-authenticate-action"

--- a/src/eduid/webapp/common/authn/middleware.py
+++ b/src/eduid/webapp/common/authn/middleware.py
@@ -5,6 +5,7 @@ from abc import ABCMeta
 from collections.abc import Iterable, Mapping
 from typing import Any, cast
 from urllib.parse import urlparse
+from wsgiref.types import StartResponse, WSGIEnvironment
 
 from flask import Request, current_app
 from flask_cors.core import get_cors_headers, get_cors_options
@@ -16,9 +17,6 @@ from eduid.webapp.common.api.messages import error_response
 from eduid.webapp.common.api.schemas.base import FluxStandardAction
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.redis_session import NoSessionDataFoundException
-
-# TODO: in python >= 3.11 import from wsgiref.types
-from eduid.webapp.common.wsgi import StartResponse, WSGIEnvironment
 
 no_context_logger = logging.getLogger(__name__)
 

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -5,7 +5,7 @@ from abc import ABC
 from collections.abc import Mapping
 from copy import deepcopy
 from datetime import datetime
-from enum import Enum, unique
+from enum import StrEnum, unique
 from typing import Any, NewType, TypeVar, cast
 from uuid import uuid4
 
@@ -64,7 +64,7 @@ TSessionNSSubclass = TypeVar("TSessionNSSubclass", bound=SessionNSBase)
 
 
 @unique
-class LoginApplication(str, Enum):
+class LoginApplication(StrEnum):
     idp = "idp"
     authn = "authn"
     signup = "signup"
@@ -184,7 +184,7 @@ class Phone(SessionNSBase):
 RequestRef = NewType("RequestRef", str)
 
 
-class OnetimeCredType(str, Enum):
+class OnetimeCredType(StrEnum):
     external_mfa = "ext_mfa"
 
 

--- a/src/eduid/webapp/freja_eid/callback_enums.py
+++ b/src/eduid/webapp/freja_eid/callback_enums.py
@@ -1,8 +1,8 @@
-from enum import Enum, unique
+from enum import StrEnum, unique
 
 __author__ = "lundberg"
 
 
 @unique
-class FrejaEIDAction(str, Enum):
+class FrejaEIDAction(StrEnum):
     verify_identity = "verify-identity-action"

--- a/src/eduid/webapp/idp/assurance_data.py
+++ b/src/eduid/webapp/idp/assurance_data.py
@@ -3,7 +3,7 @@ Some data structures that causes import loops if they are defined in assurance.p
 """
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
@@ -12,7 +12,7 @@ from eduid.common.models.saml2 import EduidAuthnContextClass
 from eduid.userdb.element import ElementKey
 
 
-class SwamidAssurance(str, Enum):
+class SwamidAssurance(StrEnum):
     SWAMID_AL1 = "http://www.swamid.se/policy/assurance/al1"
     SWAMID_AL2 = "http://www.swamid.se/policy/assurance/al2"
     SWAMID_AL3 = "http://www.swamid.se/policy/assurance/al3"
@@ -26,7 +26,7 @@ class SwamidAssurance(str, Enum):
     REFEDS_PROFILE_ESPRESSO = "https://refeds.org/assurance/profile/espresso"
 
 
-class SwedenConnectAssurance(str, Enum):
+class SwedenConnectAssurance(StrEnum):
     LOA2 = "http://id.elegnamnden.se/loa/1.0/loa2"
     LOA3 = "http://id.elegnamnden.se/loa/1.0/loa3"
     UNCERTIFIED_LOA3 = "http://id.swedenconnect.se/loa/1.0/uncertified-loa3"
@@ -46,7 +46,7 @@ class AuthnInfo(BaseModel):
         )
 
 
-class UsedWhere(str, Enum):
+class UsedWhere(StrEnum):
     REQUEST = "request"
     SSO = "SSO session"
 

--- a/src/eduid/webapp/idp/helpers.py
+++ b/src/eduid/webapp/idp/helpers.py
@@ -1,4 +1,4 @@
-from enum import Enum, unique
+from enum import StrEnum, unique
 from typing import Any
 
 from saml2 import BINDING_HTTP_POST
@@ -46,7 +46,7 @@ class IdPMsg(str, TranslatableMsg):
 
 
 @unique
-class IdPAction(str, Enum):
+class IdPAction(StrEnum):
     NEW_DEVICE = "NEW_DEVICE"
     OTHER_DEVICE = "OTHER_DEVICE"
     PWAUTH = "USERNAMEPASSWORD"

--- a/src/eduid/webapp/idp/known_device.py
+++ b/src/eduid/webapp/idp/known_device.py
@@ -15,8 +15,8 @@ from bson import ObjectId
 from nacl.secret import SecretBox
 from pydantic import BaseModel, ConfigDict, Field
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import BaseDB
-from eduid.userdb.util import utc_now
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/webapp/idp/mischttp.py
+++ b/src/eduid/webapp/idp/mischttp.py
@@ -65,13 +65,12 @@ import logging
 import pprint
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Self
 
 import user_agents
 from bleach import clean
 from flask import make_response, redirect, request
 from saml2 import BINDING_HTTP_REDIRECT
-from typing_extensions import Self
 from user_agents.parsers import UserAgent
 from werkzeug.exceptions import BadRequest, InternalServerError
 from werkzeug.wrappers import Response as WerkzeugResponse

--- a/src/eduid/webapp/idp/other_device/data.py
+++ b/src/eduid/webapp/idp/other_device/data.py
@@ -2,11 +2,11 @@
 Some data structures that causes import loops if they are defined in db.py.
 """
 
-from enum import Enum
+from enum import StrEnum
 from typing import NewType
 
 
-class OtherDeviceState(str, Enum):
+class OtherDeviceState(StrEnum):
     NEW = "NEW"  # only used device #1 so far
     IN_PROGRESS = "IN_PROGRESS"  # device #2 has 'grabbed' the request
     AUTHENTICATED = "AUTHENTICATED"  # device #2 is finished with the request (successfully)

--- a/src/eduid/webapp/idp/sso_cache.py
+++ b/src/eduid/webapp/idp/sso_cache.py
@@ -115,7 +115,7 @@ class ExpiringCacheMem:
     # use quote annotations on lock for now until python 3.13 is released
     # threading.Lock is not a class but a factory function, see:
     # https://github.com/python/cpython/pull/114479
-    def __init__(self, name: str, logger: logging.Logger | None, ttl: int, lock: "Lock" | None = None) -> None:
+    def __init__(self, name: str, logger: logging.Logger | None, ttl: int, lock: "Lock | None" = None) -> None:
         self.logger = logger
         self.ttl = ttl
         self.name = name

--- a/src/eduid/webapp/idp/sso_cache.py
+++ b/src/eduid/webapp/idp/sso_cache.py
@@ -115,7 +115,7 @@ class ExpiringCacheMem:
     # use quote annotations on lock for now until python 3.13 is released
     # threading.Lock is not a class but a factory function, see:
     # https://github.com/python/cpython/pull/114479
-    def __init__(self, name: str, logger: logging.Logger | None, ttl: int, lock: "Lock | None" = None) -> None:
+    def __init__(self, name: str, logger: logging.Logger | None, ttl: int, lock: "Lock" | None = None) -> None:
         self.logger = logger
         self.ttl = ttl
         self.name = name

--- a/src/eduid/webapp/idp/tests/test_SSOSession.py
+++ b/src/eduid/webapp/idp/tests/test_SSOSession.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from bson import ObjectId
 
@@ -57,9 +57,9 @@ class test_SSOSession(IdPAPITests):
         assert session2.to_dict() == self.data
 
     def test_only_store_newest_credential_use(self) -> None:
-        pw = AuthnData(cred_id=ElementKey("password"), timestamp=datetime.fromtimestamp(10, tz=timezone.utc))
-        older = AuthnData(cred_id=ElementKey("token"), timestamp=datetime.fromtimestamp(20, tz=timezone.utc))
-        newer = AuthnData(cred_id=ElementKey("token"), timestamp=datetime.fromtimestamp(30, tz=timezone.utc))
+        pw = AuthnData(cred_id=ElementKey("password"), timestamp=datetime.fromtimestamp(10, tz=UTC))
+        older = AuthnData(cred_id=ElementKey("token"), timestamp=datetime.fromtimestamp(20, tz=UTC))
+        newer = AuthnData(cred_id=ElementKey("token"), timestamp=datetime.fromtimestamp(30, tz=UTC))
 
         _data = dict(self.data)
         _data["authn_credentials"] = []

--- a/src/eduid/webapp/idp/tests/test_known_device.py
+++ b/src/eduid/webapp/idp/tests/test_known_device.py
@@ -8,7 +8,7 @@ import nacl.utils
 from bson import ObjectId
 from nacl.secret import SecretBox
 
-from eduid.userdb.util import utc_now
+from eduid.common.misc.timeutil import utc_now
 from eduid.webapp.idp.app import IdPApp
 from eduid.webapp.idp.known_device import BrowserDeviceInfo, KnownDevice, KnownDeviceData, KnownDeviceId
 from eduid.webapp.idp.tests.test_api import IdPAPITests

--- a/src/eduid/webapp/idp/util.py
+++ b/src/eduid/webapp/idp/util.py
@@ -3,7 +3,7 @@
 import base64
 import ipaddress
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from eduid.userdb.idp import IdPUser
 
@@ -47,7 +47,7 @@ def maybe_xml_to_string(message: str | bytes) -> str:
         return message
 
 
-class IPProximity(str, Enum):
+class IPProximity(StrEnum):
     SAME = "SAME"
     NEAR = "NEAR"
     FAR = "FAR"

--- a/src/eduid/webapp/letter_proofing/ekopost.py
+++ b/src/eduid/webapp/letter_proofing/ekopost.py
@@ -1,10 +1,10 @@
 import base64
 import json
-from datetime import datetime
 from io import BytesIO
 
 from hammock import Hammock
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.webapp.letter_proofing.settings.common import LetterProofingConfig
 
 __author__ = "john"
@@ -35,7 +35,7 @@ class Ekopost:
 
         # Output date is set it to current time since
         # we want to send the letter as soon as possible.
-        output_date = str(datetime.utcnow())
+        output_date = str(utc_now())
 
         # An easily identifiable name for the campaign and envelope
         letter_id = eppn + "+" + output_date

--- a/src/eduid/webapp/letter_proofing/tests/test_pdf.py
+++ b/src/eduid/webapp/letter_proofing/tests/test_pdf.py
@@ -1,11 +1,11 @@
 import unittest
 from collections import OrderedDict
-from datetime import datetime
 from io import BytesIO, StringIO
 from typing import Any
 
 from pypdf import PdfReader
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.rpc.msg_relay import FullPostalAddress
 from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.letter_proofing import pdf
@@ -184,7 +184,7 @@ class CreatePDFTest(EduidAPITestCase):
                 pdf_document = pdf.create_pdf(
                     recipient,
                     verification_code="bogus code",
-                    created_timestamp=datetime.utcnow(),
+                    created_timestamp=utc_now(),
                     primary_mail_address="test@example.org",
                     letter_wait_time_hours=336,
                 )

--- a/src/eduid/webapp/lookup_mobile_proofing/helpers.py
+++ b/src/eduid/webapp/lookup_mobile_proofing/helpers.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 from enum import unique
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.common.rpc.exceptions import LookupMobileTaskFailed
 from eduid.common.rpc.msg_relay import FullPostalAddress
 from eduid.userdb import User
 from eduid.userdb.logs import TeleAdressProofing
 from eduid.userdb.proofing.element import NinProofingElement
 from eduid.userdb.proofing.state import NinProofingState
-from eduid.userdb.util import utc_now
 from eduid.webapp.common.api.helpers import check_magic_cookie, get_proofing_log_navet_data
 from eduid.webapp.common.api.messages import TranslatableMsg
 from eduid.webapp.lookup_mobile_proofing.app import current_mobilep_app as current_app

--- a/src/eduid/webapp/reset_password/tests/test_app.py
+++ b/src/eduid/webapp/reset_password/tests/test_app.py
@@ -574,9 +574,7 @@ class ResetPasswordTests(EduidAPITestCase[ResetPasswordApp]):
         state1 = self.app.password_reset_state_db.get_state_by_eppn(self.test_user.eppn)
         assert state1
         # Set created time 5 minutes before email_code_timeout
-        state1.email_code.created_ts = datetime.datetime.utcnow() - (
-            self.app.conf.email_code_timeout + datetime.timedelta(minutes=5)
-        )
+        state1.email_code.created_ts = utc_now() - (self.app.conf.email_code_timeout + datetime.timedelta(minutes=5))
         self.app.password_reset_state_db.save(state1)
 
         response2 = self._post_email_address()

--- a/src/eduid/webapp/security/webauthn_proofing.py
+++ b/src/eduid/webapp/security/webauthn_proofing.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
-from enum import Enum
+from enum import StrEnum
 from uuid import UUID
 
 from fido2.utils import websafe_decode
@@ -16,7 +16,7 @@ from eduid.webapp.security.app import current_security_app as current_app
 __author__ = "lundberg"
 
 
-class OtherAuthenticatorStatus(str, Enum):
+class OtherAuthenticatorStatus(StrEnum):
     APPLE = "APPLE"
     MAGIC_COOKIE = "MAGIC_COOKIE"
 

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -2,7 +2,7 @@ import os
 import struct
 from dataclasses import replace
 from datetime import datetime
-from enum import Enum, unique
+from enum import StrEnum, unique
 
 import proquint
 from flask import abort
@@ -89,7 +89,7 @@ class SignupMsg(TranslatableMsg):
 
 
 @unique
-class EmailStatus(str, Enum):
+class EmailStatus(StrEnum):
     ADDRESS_USED = "address_used"
     RESEND_CODE = "resend_code"
     NEW = "new"

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -626,7 +626,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
             surname="Invitesson",
             nin="190102031234",
             finish_url="https://example.com/finish",
-            expires_at=datetime(1970, 1, 1, 0, 0, 0, 0, timezone.utc),
+            expires_at=datetime(1970, 1, 1, 0, 0, 0, 0, UTC),
         )
         self.app.invite_db.save(invite=invite, is_in_database=False)
         return invite

--- a/src/eduid/webapp/svipe_id/callback_enums.py
+++ b/src/eduid/webapp/svipe_id/callback_enums.py
@@ -1,8 +1,8 @@
-from enum import Enum, unique
+from enum import StrEnum, unique
 
 __author__ = "lundberg"
 
 
 @unique
-class SvipeIDAction(str, Enum):
+class SvipeIDAction(StrEnum):
     verify_identity = "verify-identity-action"

--- a/src/eduid/workers/am/testing.py
+++ b/src/eduid/workers/am/testing.py
@@ -6,7 +6,7 @@ __author__ = "leifj"
 
 import logging
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -51,8 +51,8 @@ USER_DATA = TUserDbDocument(
                 "identity_type": IdentityType.NIN.value,
                 "number": "123456781235",
                 "verified": True,
-                "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
             }
         ],
         "orcid": {
@@ -81,13 +81,13 @@ USER_DATA = TUserDbDocument(
             "created_by": "orcid",
         },
         "ladok": {
-            "created_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
-            "modified_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
+            "created_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=UTC),
+            "modified_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=UTC),
             "verified_by": "eduid-ladok",
             "external_id": UUID("9555f3de-dd32-4bed-8e36-72ef00fb4df2"),
             "university": {
-                "created_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
-                "modified_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=timezone.utc),
+                "created_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=UTC),
+                "modified_ts": datetime(2022, 2, 23, 17, 39, 32, 303000, tzinfo=UTC),
                 "ladok_name": "ab",
                 "name": {"sv": "Lärosätesnamn", "en": "University Name"},
             },

--- a/src/eduid/workers/am/tests/test_proofing_fetchers.py
+++ b/src/eduid/workers/am/tests/test_proofing_fetchers.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import UUID
 
 import bson
@@ -62,8 +62,8 @@ class AttributeFetcherNINProofingTests(ProofingTestCase):
                         "identity_type": IdentityType.NIN.value,
                         "number": "123456781235",
                         "verified": True,
-                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
                     }
                 ],
                 "letter_proofing_data": [
@@ -142,8 +142,8 @@ class AttributeFetcherNINProofingTests(ProofingTestCase):
                         "identity_type": IdentityType.NIN.value,
                         "number": "123456781235",
                         "verified": True,
-                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
                     }
                 ],
                 "letter_proofing_data": [
@@ -240,8 +240,8 @@ class AttributeFetcherEmailProofingTests(ProofingTestCase):
                         "identity_type": IdentityType.NIN.value,
                         "number": "123456781235",
                         "verified": True,
-                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
                     }
                 ],
             }
@@ -357,8 +357,8 @@ class AttributeFetcherSecurityTests(ProofingTestCase):
                         "identity_type": IdentityType.NIN.value,
                         "number": "123456781235",
                         "verified": True,
-                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
                     }
                 ],
                 "phone": [{"number": "+46700011336", "primary": True, "verified": True}],
@@ -397,8 +397,8 @@ class AttributeFetcherSecurityTests(ProofingTestCase):
                         "identity_type": IdentityType.NIN.value,
                         "number": "123456781235",
                         "verified": True,
-                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
                     }
                 ],
                 "phone": [{"number": "+46700011336", "primary": True, "verified": True}],
@@ -435,8 +435,8 @@ class AttributeFetcherResetPasswordTests(ProofingTestCase):
                         "identity_type": IdentityType.NIN.value,
                         "number": "123456781235",
                         "verified": True,
-                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
                     }
                 ],
                 "phone": [{"number": "+46700011336", "primary": True, "verified": True}],
@@ -471,8 +471,8 @@ class AttributeFetcherResetPasswordTests(ProofingTestCase):
                         "identity_type": IdentityType.NIN.value,
                         "number": "123456781235",
                         "verified": True,
-                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 5, 18, 16, 36, 16, tzinfo=UTC),
                     }
                 ],
                 "phone": [{"number": "+46700011336", "primary": True, "verified": True}],
@@ -553,13 +553,13 @@ class AttributeFetcherLadokTests(ProofingTestCase):
         expected = {
             "$set": {
                 "ladok": {
-                    "created_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=timezone.utc),
-                    "modified_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=timezone.utc),
+                    "created_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=UTC),
+                    "modified_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=UTC),
                     "verified_by": "eduid-ladok",
                     "external_id": UUID("9555f3de-dd32-4bed-8e36-72ef00fb4df2"),
                     "university": {
-                        "created_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=timezone.utc),
-                        "modified_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=timezone.utc),
+                        "created_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=UTC),
+                        "modified_ts": datetime(2022, 2, 23, 17, 39, 32, tzinfo=UTC),
                         "ladok_name": "ab",
                         "name": {"sv": "Lärosätesnamn", "en": "University Name"},
                     },

--- a/src/eduid/workers/amapi/config.py
+++ b/src/eduid/workers/amapi/config.py
@@ -1,5 +1,5 @@
 import logging
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import NewType
 
@@ -10,7 +10,7 @@ from eduid.common.config.base import LoggingConfigMixin, RootConfig
 logger = logging.getLogger(__name__)
 
 
-class SupportedMethod(str, Enum):
+class SupportedMethod(StrEnum):
     DELETE = "delete"
     PUT = "put"
     GET = "get"

--- a/src/eduid/workers/amapi/routers/utils/status.py
+++ b/src/eduid/workers/amapi/routers/utils/status.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from fastapi import Response
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.workers.amapi.context_request import ContextRequest
 
 __author__ = "masv"
@@ -35,7 +36,7 @@ FAILURE_INFO: dict[str, FailCountItem] = dict()
 
 def log_failure_info(ctx: ContextRequest, key: str, msg: str, exc: Exception | None = None) -> None:
     if key not in FAILURE_INFO:
-        FAILURE_INFO[key] = FailCountItem(first_failure=datetime.utcnow())
+        FAILURE_INFO[key] = FailCountItem(first_failure=utc_now())
     FAILURE_INFO[key].count += 1
     ctx.app.context.logger.warning(f"{msg} {FAILURE_INFO[key]}: {exc}")
 
@@ -56,11 +57,11 @@ def check_restart(key: str, restart: int, terminate: int) -> bool:
         info = replace(info, restart_at=info.first_failure + timedelta(seconds=restart))
     if terminate and not info.exit_at:
         info = replace(info, exit_at=info.first_failure + timedelta(seconds=terminate))
-    if info.exit_at and datetime.utcnow() >= info.exit_at:
+    if info.exit_at and utc_now() >= info.exit_at:
         # Exit application and rely on something else restarting it
         sys.exit(1)
-    if info.restart_at and datetime.utcnow() >= info.restart_at:
-        info = replace(info, restart_at=datetime.utcnow() + timedelta(seconds=restart))
+    if info.restart_at and utc_now() >= info.restart_at:
+        info = replace(info, restart_at=utc_now() + timedelta(seconds=restart))
         # Try to restart/reinitialize the failing functionality
         res = True
     FAILURE_INFO[key] = info
@@ -71,7 +72,7 @@ def get_cached_response(ctx: ContextRequest, resp: Response, key: str) -> Mappin
     cache_for_seconds = ctx.app.config.status_cache_seconds
     resp.headers["Cache-Control"] = f"public,max-age={cache_for_seconds}"
 
-    now = datetime.utcnow()
+    now = utc_now()
     if SIMPLE_CACHE.get(key) is not None:
         if now < SIMPLE_CACHE[key].expire_time:
             if ctx.app.context.config.debug:
@@ -85,7 +86,7 @@ def get_cached_response(ctx: ContextRequest, resp: Response, key: str) -> Mappin
 
 def set_cached_response(ctx: ContextRequest, resp: Response, key: str, data: Mapping) -> None:
     cache_for_seconds = ctx.app.config.status_cache_seconds
-    now = datetime.utcnow()
+    now = utc_now()
     expires = now + timedelta(seconds=cache_for_seconds)
     resp.headers["Expires"] = expires.strftime("%a, %d %b %Y %H:%M:%S UTC")
     SIMPLE_CACHE[key] = SimpleCacheItem(expire_time=expires, data=data)

--- a/src/eduid/workers/job_runner/config.py
+++ b/src/eduid/workers/job_runner/config.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from eduid.common.clients.gnap_client.base import GNAPClientAuthData
 from eduid.common.config.base import AmConfigMixin, LoggingConfigMixin, MsgConfigMixin, RootConfig, StatsConfigMixin
-from eduid.common.utils import removesuffix
 
 logger = logging.getLogger(__name__)
 
@@ -63,5 +62,5 @@ class JobRunnerConfig(RootConfig, LoggingConfigMixin, StatsConfigMixin, MsgConfi
     def application_root_must_not_end_with_slash(cls, v: str) -> str:
         if v.endswith("/"):
             logger.warning(f"application_root should not end with slash ({v})")
-            v = removesuffix(v, "/")
+            v = v.removesuffix("/")
         return v

--- a/src/eduid/workers/lookup_mobile/decorators.py
+++ b/src/eduid/workers/lookup_mobile/decorators.py
@@ -6,12 +6,12 @@ __author__ = "lundberg"
 #
 
 from collections.abc import Callable
-from datetime import datetime
 from inspect import isclass
 from typing import Any
 
 from pymongo.collection import Collection
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import MongoDB
 from eduid.userdb.db.base import TUserDbDocument
 
@@ -42,7 +42,7 @@ class TransactionAudit:
                     db = MongoDB(db_uri=self.db_uri, db_name=self.db_name)
                     self.collection = db.get_collection(self.collection_name)
                 if not isclass(ret):  # we can't save class objects in mongodb
-                    date = datetime.utcnow()
+                    date = utc_now()
                     doc = TUserDbDocument(
                         {
                             "function": f.__name__,

--- a/src/eduid/workers/msg/cache.py
+++ b/src/eduid/workers/msg/cache.py
@@ -2,8 +2,8 @@ from typing import Any
 
 from pymongo.results import DeleteResult
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import BaseDB, TUserDbDocument
-from eduid.userdb.util import utc_now
 
 
 class CacheMDB(BaseDB):

--- a/src/eduid/workers/msg/decorators.py
+++ b/src/eduid/workers/msg/decorators.py
@@ -1,10 +1,10 @@
 from collections.abc import Callable
-from datetime import datetime
 from inspect import isclass
 from typing import Any
 
 from pymongo.collection import Collection
 
+from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import MongoDB
 from eduid.userdb.db.base import TUserDbDocument
 
@@ -26,7 +26,7 @@ class TransactionAudit:
         def audit(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
             ret = f(*args, **kwargs)
             if not isclass(ret):  # we can't save class objects in mongodb
-                date = datetime.utcnow()
+                date = utc_now()
                 doc = TUserDbDocument(
                     {
                         "function": f.__name__,

--- a/src/eduid/workers/msg/tasks.py
+++ b/src/eduid/workers/msg/tasks.py
@@ -12,7 +12,6 @@ from smscom import SMSClient
 
 from eduid.common.config.base import EduidEnvironment
 from eduid.common.decorators import deprecated
-from eduid.common.utils import removeprefix
 from eduid.userdb.exceptions import ConnectionError
 from eduid.workers.msg.cache import CacheMDB
 from eduid.workers.msg.common import MsgCelerySingleton
@@ -373,7 +372,7 @@ class MessageSender(Task):
         #  0701740605-0701740699 is a unused range from PTS
         #  https://www.pts.se/sv/bransch/telefoni/nummer-och-adressering/
         #  telefonnummer-for-anvandning-i-bocker-och-filmer-etc/
-        if recipient.startswith("+467017406") and 5 <= int(removeprefix(recipient, "+467017406")) <= 99:
+        if recipient.startswith("+467017406") and 5 <= int(recipient.removeprefix("+467017406")) <= 99:
             logger.debug("sendsms task:")
             logger.debug(f"\nType: sms\nReference: {reference}\nRecipient: {recipient}\nMessage:\n{message}")
             return "no_op_number"


### PR DESCRIPTION
* consolidate to one timezone aware utc_now helper function and replace naive datetime.utcnow where it was used
* revert a workaround for oic 1.4.0 as it was fixed in 1.5.0
* use imports from new wsgiref.types
* replace util funtions removeprefix and removesuffix with string builtins
* update all classes inheriting str and Enum to inherit StrEnum as  string representation of the former construction has changed