### PR TITLE
Enable updating nin

### DIFF
--- a/src/eduid/satosa/scimapi/static_attributes.py
+++ b/src/eduid/satosa/scimapi/static_attributes.py
@@ -78,7 +78,6 @@ class AddStaticAttributesForVirtualIdp(ResponseMicroService):
                 else:
                     static_attributes[attr_name] = fmt
 
-
                 logger.debug(f"Appending static attribute {attr_name}: {fmt} for requester {requester} or {vidp}")
 
         return static_attributes

--- a/src/eduid/userdb/proofing/user.py
+++ b/src/eduid/userdb/proofing/user.py
@@ -5,5 +5,5 @@ __author__ = "lundberg"
 
 
 class ProofingUser(User):
-    replace_lock: IdentityType | None = None
+    replace_locked: IdentityType | None = None
     pass

--- a/src/eduid/userdb/proofing/user.py
+++ b/src/eduid/userdb/proofing/user.py
@@ -1,7 +1,9 @@
 from eduid.userdb import User
+from eduid.userdb.identity import IdentityType
 
 __author__ = "lundberg"
 
 
 class ProofingUser(User):
+    replace_lock: IdentityType | None = None
     pass

--- a/src/eduid/webapp/bankid/tests/test_app.py
+++ b/src/eduid/webapp/bankid/tests/test_app.py
@@ -535,9 +535,13 @@ class BankIDTests(ProofingTests[BankIDApp]):
 
         self._verify_user_parameters(eppn, identity=nin, identity_present=False)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_mfa_token_verify_no_verified_nin(self, mock_request_user_sync: MagicMock) -> None:
+    def test_mfa_token_verify_no_verified_nin(
+        self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock
+    ) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         nin = self.test_user_nin
@@ -691,9 +695,11 @@ class BankIDTests(ProofingTests[BankIDApp]):
 
         self._verify_user_parameters(eppn, identity=nin, identity_verified=True, token_verified=True, num_proofings=2)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_nin_verify(self, mock_request_user_sync: MagicMock) -> None:
+    def test_nin_verify(self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=False)
@@ -754,9 +760,11 @@ class BankIDTests(ProofingTests[BankIDApp]):
 
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=False, num_proofings=0)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_mfa_login_unverified_nin(self, mock_request_user_sync: MagicMock) -> None:
+    def test_mfa_login_unverified_nin(self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         eppn = self.test_unverified_user_eppn
 
         # Add locked nin to user

--- a/src/eduid/webapp/bankid/tests/test_app.py
+++ b/src/eduid/webapp/bankid/tests/test_app.py
@@ -776,9 +776,11 @@ class BankIDTests(ProofingTests[BankIDApp]):
         assert doc["given_name"] == "Ûlla"
         assert doc["surname"] == "Älm"
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_nin_verify_signup_auth(self, mock_request_user_sync: MagicMock) -> None:
+    def test_nin_verify_signup_auth(self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=False)

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -280,7 +280,7 @@ def verify_nin_for_user(
         and proofing_user.locked_identity.nin is not None
         and proofing_user.locked_identity.nin.number == reference_nin
     ):
-        proofing_user.replace_lock = IdentityType.NIN
+        proofing_user.replace_locked = IdentityType.NIN
 
     # Update users name
     proofing_user = set_user_names_from_nin_proofing(user=proofing_user, proofing_log_entry=proofing_log_entry)

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -239,18 +239,19 @@ def verify_nin_for_user(
     if reference_nin is not None:
         current_app.logger.debug(f"verified nin has reference_nin: {reference_nin}")
 
+    if (
+        proofing_user.locked_identity.nin is not None
+        and proofing_user.locked_identity.nin.number != proofing_state.nin.number
+        and proofing_user.locked_identity.nin.number != reference_nin
+    ):
+        raise LockedIdentityViolation("users locked nin does not match verified nin or reference nin")
+
     # check if the users current nin is the same as the one just verified
     # if there is no locked nin identity or the locked nin identity matches we can replace the current nin identity
     # with the one just verified
     if proofing_user.identities.nin.number != proofing_state.nin.number:
         current_app.logger.info("users current nin does not match the nin just verified")
         current_app.logger.debug(f"{proofing_user.identities.nin.number} != {proofing_state.nin.number}")
-        if (
-            proofing_user.locked_identity.nin is not None
-            and proofing_user.locked_identity.nin.number != proofing_state.nin.number
-            and proofing_user.locked_identity.nin.number != reference_nin
-        ):
-            raise LockedIdentityViolation("users locked nin does not match verified nin or reference nin")
 
         # user has no locked nin identity or the user has previously verified the nin
         # replace the never verified nin with the one just verified
@@ -279,7 +280,7 @@ def verify_nin_for_user(
         and proofing_user.locked_identity.nin is not None
         and proofing_user.locked_identity.nin.number == reference_nin
     ):
-        proofing_user.locked_identity.replace(element=nin_identity)
+        proofing_user.replace_lock = IdentityType.NIN
 
     # Update users name
     proofing_user = set_user_names_from_nin_proofing(user=proofing_user, proofing_log_entry=proofing_log_entry)

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -24,6 +24,7 @@ from eduid.userdb.credentials import U2F, Webauthn
 from eduid.userdb.db import BaseDB
 from eduid.userdb.element import ElementKey
 from eduid.userdb.fixtures.users import UserFixtures
+from eduid.userdb.identity import IdentityType
 from eduid.userdb.logs.db import ProofingLog
 from eduid.userdb.proofing.state import NinProofingState
 from eduid.userdb.testing import MongoTemporaryInstance, SetupConfig
@@ -271,9 +272,14 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
 
         central_user = self.app.central_userdb.get_user_by_id(private_user.user_id)
         private_user_dict = private_user.to_dict()
+        replace_lock: IdentityType | None = None
         # fix signup_user data
         if "proofing_reference" in private_user_dict:
             del private_user_dict["proofing_reference"]
+
+        if "replace_lock" in private_user_dict:
+            replace_lock = private_user_dict["replace_lock"]
+            del private_user_dict["replace_lock"]
 
         if central_user is None:
             # This is a new user, create a new user in the central db
@@ -303,6 +309,11 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
                     identity.created_by = "test"
                 user.locked_identity.add(identity)
                 continue
+            if replace_lock is locked_identity.identity_type:
+                # replace the locked identity with the new verified identity
+                if identity.created_by is None:
+                    identity.created_by = "test"
+                user.locked_identity.replace(identity)
 
         # Restore metadata that is necessary for the consistency checks in the save() function
         user.modified_ts = central_user.modified_ts

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -272,14 +272,14 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
 
         central_user = self.app.central_userdb.get_user_by_id(private_user.user_id)
         private_user_dict = private_user.to_dict()
-        replace_lock: IdentityType | None = None
+        replace_locked: IdentityType | None = None
         # fix signup_user data
         if "proofing_reference" in private_user_dict:
             del private_user_dict["proofing_reference"]
 
-        if "replace_lock" in private_user_dict:
-            replace_lock = private_user_dict["replace_lock"]
-            del private_user_dict["replace_lock"]
+        if "replace_locked" in private_user_dict:
+            replace_locked = private_user_dict["replace_locked"]
+            del private_user_dict["replace_locked"]
 
         if central_user is None:
             # This is a new user, create a new user in the central db
@@ -309,7 +309,7 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
                     identity.created_by = "test"
                 user.locked_identity.add(identity)
                 continue
-            if replace_lock is locked_identity.identity_type:
+            if replace_locked is locked_identity.identity_type:
                 # replace the locked identity with the new verified identity
                 if identity.created_by is None:
                     identity.created_by = "test"

--- a/src/eduid/webapp/common/api/tests/test_nin_helpers.py
+++ b/src/eduid/webapp/common/api/tests/test_nin_helpers.py
@@ -392,7 +392,7 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
         assert user.identities.nin is not None
         assert user.identities.nin.number == self.test_user_nin
         # NIN should be updated by am when saving to main DB
-        assert user.replace_lock is IdentityType.NIN
+        assert user.replace_locked is IdentityType.NIN
 
     def test_verify_nin_for_user_existing_verified(self) -> None:
         user = self.insert_verified_user()

--- a/src/eduid/webapp/common/api/tests/test_nin_helpers.py
+++ b/src/eduid/webapp/common/api/tests/test_nin_helpers.py
@@ -12,7 +12,8 @@ from eduid.common.testing_base import normalised_data
 from eduid.userdb import NinIdentity, User
 from eduid.userdb.exceptions import LockedIdentityViolation, UserDoesNotExist
 from eduid.userdb.fixtures.users import UserFixtures
-from eduid.userdb.identity import IdentityList
+from eduid.userdb.identity import IdentityList, IdentityType
+from eduid.userdb.locked_identity import LockedIdentityList
 from eduid.userdb.logs import ProofingLog
 from eduid.userdb.logs.element import (
     ForeignIdProofingLogElement,
@@ -106,10 +107,28 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
         self.app.central_userdb.save(user)
         return self.app.central_userdb.get_user_by_eppn(user.eppn)
 
+    def insert_not_verified_not_locked_user(self, nin: str | None = None) -> User:
+        user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
+        user.identities = IdentityList()
+        if nin is None:
+            nin = self.test_user_nin
+        nin_element = NinIdentity.from_dict(
+            dict(
+                number=nin,
+                created_by="AlreadyAddedNinHelpersTest",
+                verified=False,
+            )
+        )
+        user.identities.add(nin_element)
+        user.locked_identity = LockedIdentityList()
+        self.app.central_userdb.save(user)
+        return self.app.central_userdb.get_user_by_eppn(user.eppn)
+
     def insert_no_nins_user(self) -> User:
         # Replace user with one without previous proofings
         user = self.app.central_userdb.get_user_by_eppn(self.test_user.eppn)
         user.identities = IdentityList()
+        user.locked_identity = LockedIdentityList()
         self.app.central_userdb.save(user)
         return self.app.central_userdb.get_user_by_eppn(user.eppn)
 
@@ -292,7 +311,7 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
     @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     def test_verify_nin_for_user_existing_not_verified(self, mock_reference_nin: MagicMock) -> None:
         mock_reference_nin.return_value = None
-        user = self.insert_not_verified_user()
+        user = self.insert_not_verified_not_locked_user()
         nin_element = NinProofingElement.from_dict(
             dict(number=self.test_user_nin, created_by="NinHelpersTest", verified=False)
         )
@@ -307,6 +326,29 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
 
         self._check_nin_verified_ok(
             user=user, proofing_state=proofing_state, number=self.test_user_nin, created_by="AlreadyAddedNinHelpersTest"
+        )
+
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
+    def test_verify_nin_for_user_existing_locked_not_verified(self, mock_reference_nin: MagicMock) -> None:
+        mock_reference_nin.return_value = None
+        user = self.insert_not_verified_user()
+        nin_element = NinProofingElement.from_dict(
+            dict(number=self.locked_test_user_nin, created_by="NinHelpersTest", verified=False)
+        )
+        proofing_state = NinProofingState.from_dict({"eduPersonPrincipalName": user.eppn, "nin": nin_element.to_dict()})
+        assert nin_element.created_by is not None
+        proofing_log_entry = self._get_nin_eid_proofing_log_entry(
+            user=user, created_by=nin_element.created_by, nin=nin_element.number
+        )
+        with self.app.app_context():
+            assert verify_nin_for_user(user, proofing_state, proofing_log_entry) is True
+        user = self.app.private_userdb.get_user_by_eppn(user.eppn)
+
+        self._check_nin_verified_ok(
+            user=user,
+            proofing_state=proofing_state,
+            number=self.locked_test_user_nin,
+            created_by="NinHelpersTest",
         )
 
     @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
@@ -349,8 +391,8 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
         # user should be updated with updated nin as it references old locked nin
         assert user.identities.nin is not None
         assert user.identities.nin.number == self.test_user_nin
-        assert user.locked_identity.nin is not None
-        assert user.locked_identity.nin.number == self.test_user_nin
+        # NIN should be updated by am when saving to main DB
+        assert user.replace_lock is IdentityType.NIN
 
     def test_verify_nin_for_user_existing_verified(self) -> None:
         user = self.insert_verified_user()

--- a/src/eduid/webapp/common/api/tests/test_nin_helpers.py
+++ b/src/eduid/webapp/common/api/tests/test_nin_helpers.py
@@ -233,7 +233,9 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
         with pytest.raises(UserDoesNotExist):
             self.app.private_userdb.get_user_by_eppn(user.eppn)
 
-    def test_verify_nin_for_user_navet(self) -> None:
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
+    def test_verify_nin_for_user_navet(self, mock_reference_nin: MagicMock) -> None:
+        mock_reference_nin.return_value = self.test_user_nin
         user = self.insert_no_nins_user()
         nin_element = NinProofingElement.from_dict(
             dict(number=self.test_user_nin, created_by="NinHelpersTest", verified=False)
@@ -244,7 +246,9 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
         )
         self._test_verify_nin_for_user(user=user, nin_element=nin_element, proofing_log_entry=proofing_log_entry)
 
-    def test_verify_nin_for_user_eid(self) -> None:
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
+    def test_verify_nin_for_user_eid(self, mock_reference_nin: MagicMock) -> None:
+        mock_reference_nin.return_value = None
         user = self.insert_no_nins_user()
         nin_element = NinProofingElement.from_dict(
             dict(number=self.test_user_nin, created_by="NinHelpersTest", verified=False)
@@ -255,7 +259,9 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
         )
         self._test_verify_nin_for_user(user=user, nin_element=nin_element, proofing_log_entry=proofing_log_entry)
 
-    def test_verify_nin_for_proofing_user_navet(self) -> None:
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
+    def test_verify_nin_for_proofing_user_navet(self, mock_reference_nin: MagicMock) -> None:
+        mock_reference_nin.return_value = None
         user = self.insert_no_nins_user()
         nin_element = NinProofingElement.from_dict(
             dict(number=self.test_user_nin, created_by="NinHelpersTest", verified=False)
@@ -268,7 +274,9 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
             user=user, nin_element=nin_element, proofing_log_entry=proofing_log_entry
         )
 
-    def test_verify_nin_for_proofing_user_eid(self) -> None:
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
+    def test_verify_nin_for_proofing_user_eid(self, mock_reference_nin: MagicMock) -> None:
+        mock_reference_nin.return_value = None
         user = self.insert_no_nins_user()
         nin_element = NinProofingElement.from_dict(
             dict(number=self.test_user_nin, created_by="NinHelpersTest", verified=False)
@@ -281,7 +289,9 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
             user=user, nin_element=nin_element, proofing_log_entry=proofing_log_entry
         )
 
-    def test_verify_nin_for_user_existing_not_verified(self) -> None:
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
+    def test_verify_nin_for_user_existing_not_verified(self, mock_reference_nin: MagicMock) -> None:
+        mock_reference_nin.return_value = None
         user = self.insert_not_verified_user()
         nin_element = NinProofingElement.from_dict(
             dict(number=self.test_user_nin, created_by="NinHelpersTest", verified=False)
@@ -299,7 +309,9 @@ class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
             user=user, proofing_state=proofing_state, number=self.test_user_nin, created_by="AlreadyAddedNinHelpersTest"
         )
 
-    def test_verify_wrong_nin_for_user_existing_not_verified(self) -> None:
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
+    def test_verify_wrong_nin_for_user_existing_not_verified(self, mock_reference_nin: MagicMock) -> None:
+        mock_reference_nin.return_value = None
         user = self.insert_not_verified_user()
         nin_element = NinProofingElement.from_dict(
             dict(number=self.wrong_test_user_nin, created_by="NinHelpersTest", verified=False)

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -13,6 +13,7 @@ from flask.wrappers import Request
 
 from eduid.common.config.base import EduIDBaseAppConfig, Pysaml2SPConfigMixin
 from eduid.common.misc.timeutil import utc_now
+from eduid.common.rpc.msg_relay import MsgRelay
 from eduid.userdb import User, UserDB
 from eduid.userdb.exceptions import MultipleUsersReturned, UserDBValueError, UserDoesNotExist
 from eduid.webapp.common.api.exceptions import ApiException
@@ -294,3 +295,16 @@ def is_throttled(ts: datetime, min_wait: timedelta) -> bool:
 
 def is_expired(ts: datetime, max_age: timedelta) -> bool:
     return utc_now() - ts > max_age
+
+
+def get_reference_nin_from_navet_data(nin: str) -> str | None:
+    """
+    Check if the NIN has changed in Navet data.
+    """
+    msg_relay = get_from_current_app("msg_relay", MsgRelay)
+
+    navet_data = msg_relay.get_all_navet_data(nin=nin)
+    if navet_data.person.reference_national_identity_number:
+        return navet_data.person.reference_national_identity_number
+    else:
+        return None

--- a/src/eduid/webapp/eidas/proofing.py
+++ b/src/eduid/webapp/eidas/proofing.py
@@ -274,7 +274,7 @@ class EidasProofingFunctions(SwedenConnectProofingFunctions[ForeignEidSessionInf
                 return VerifyUserResult(error=CommonMsg.locked_identity_not_matching)
             # replace the locked identity as the users asserted prid has changed,
             # and we are sure enough that it is the same person
-            proofing_user.locked_identity.replace(element=new_identity)
+            proofing_user.replace_lock = new_identity.identity_type
 
         # the existing identity is not verified, just remove it
         if existing_identity is not None:

--- a/src/eduid/webapp/eidas/proofing.py
+++ b/src/eduid/webapp/eidas/proofing.py
@@ -274,7 +274,7 @@ class EidasProofingFunctions(SwedenConnectProofingFunctions[ForeignEidSessionInf
                 return VerifyUserResult(error=CommonMsg.locked_identity_not_matching)
             # replace the locked identity as the users asserted prid has changed,
             # and we are sure enough that it is the same person
-            proofing_user.replace_lock = new_identity.identity_type
+            proofing_user.replace_locked = new_identity.identity_type
 
         # the existing identity is not verified, just remove it
         if existing_identity is not None:

--- a/src/eduid/webapp/eidas/tests/test_app.py
+++ b/src/eduid/webapp/eidas/tests/test_app.py
@@ -864,9 +864,11 @@ class EidasTests(ProofingTests[EidasApp]):
         assert doc["given_name"] == "Ûlla"
         assert doc["surname"] == "Älm"
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_nin_verify_signup_auth(self, mock_request_user_sync: MagicMock) -> None:
+    def test_nin_verify_signup_auth(self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=False)

--- a/src/eduid/webapp/eidas/tests/test_app.py
+++ b/src/eduid/webapp/eidas/tests/test_app.py
@@ -608,13 +608,15 @@ class EidasTests(ProofingTests[EidasApp]):
 
         self._verify_user_parameters(eppn, identity=nin, identity_present=False)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_mfa_token_verify_no_verified_nin(
-        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock, mock_reference_nin: MagicMock
     ) -> None:
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         nin = self.test_user_nin
@@ -743,9 +745,13 @@ class EidasTests(ProofingTests[EidasApp]):
 
         self._verify_user_parameters(eppn)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_webauthn_token_verify_backdoor(self, mock_request_user_sync: MagicMock) -> None:
+    def test_webauthn_token_verify_backdoor(
+        self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock
+    ) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         nin = self.test_backdoor_nin
@@ -768,11 +774,15 @@ class EidasTests(ProofingTests[EidasApp]):
 
         self._verify_user_parameters(eppn, identity=nin, identity_verified=True, token_verified=True, num_proofings=2)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_nin_verify(self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock) -> None:
+    def test_nin_verify(
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock, mock_reference_nin: MagicMock
+    ) -> None:
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=False)
@@ -835,13 +845,15 @@ class EidasTests(ProofingTests[EidasApp]):
 
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=False, num_proofings=0)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_mfa_login_unverified_nin(
-        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock, mock_reference_nin: MagicMock
     ) -> None:
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         eppn = self.test_unverified_user_eppn
 
         # Add locked nin to user
@@ -1100,9 +1112,11 @@ class EidasTests(ProofingTests[EidasApp]):
 
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=True, num_proofings=0)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_nin_verify_backdoor(self, mock_request_user_sync: MagicMock) -> None:
+    def test_nin_verify_backdoor(self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         nin = self.test_backdoor_nin
@@ -1122,13 +1136,15 @@ class EidasTests(ProofingTests[EidasApp]):
 
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity=nin, identity_verified=True, num_proofings=1)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_nin_verify_no_backdoor_in_pro(
-        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock, mock_reference_nin: MagicMock
     ) -> None:
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         nin = self.test_backdoor_nin
@@ -1153,13 +1169,15 @@ class EidasTests(ProofingTests[EidasApp]):
             eppn, identity=self.test_user_nin, num_mfa_tokens=0, num_proofings=1, identity_verified=True
         )
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_nin_verify_no_backdoor_misconfigured(
-        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock, mock_reference_nin: MagicMock
     ) -> None:
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         nin = self.test_backdoor_nin
@@ -1252,13 +1270,15 @@ class EidasTests(ProofingTests[EidasApp]):
             identity=self.test_user_wrong_nin,
         )
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_nin_staging_remap_verify(
-        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock, mock_reference_nin: MagicMock
     ) -> None:
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.test_unverified_user_eppn
         remapped_nin = NinIdentity(number="190102031234")

--- a/src/eduid/webapp/freja_eid/proofing.py
+++ b/src/eduid/webapp/freja_eid/proofing.py
@@ -124,7 +124,7 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
                 return VerifyUserResult(error=CommonMsg.locked_identity_not_matching)
             # replace the locked identity as the users asserted prid has changed,
             # and we are sure enough that it is the same person
-            proofing_user.replace_lock = new_identity.identity_type
+            proofing_user.replace_locked = new_identity.identity_type
 
         # the existing identity is not verified, just remove it
         if existing_identity is not None:

--- a/src/eduid/webapp/freja_eid/proofing.py
+++ b/src/eduid/webapp/freja_eid/proofing.py
@@ -124,7 +124,7 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
                 return VerifyUserResult(error=CommonMsg.locked_identity_not_matching)
             # replace the locked identity as the users asserted prid has changed,
             # and we are sure enough that it is the same person
-            proofing_user.locked_identity.replace(element=new_identity)
+            proofing_user.replace_lock = new_identity.identity_type
 
         # the existing identity is not verified, just remove it
         if existing_identity is not None:

--- a/src/eduid/webapp/freja_eid/tests/test_app.py
+++ b/src/eduid/webapp/freja_eid/tests/test_app.py
@@ -335,9 +335,11 @@ class FrejaEIDTests(ProofingTests[FrejaEIDApp]):
         ], f"{query['scope']} != {[' '.join(self.app.conf.freja_eid_client.scopes)]}"
         assert query["code_challenge_method"] == ["S256"]
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_verify_nin_identity(self, mock_request_user_sync: MagicMock) -> None:
+    def test_verify_nin_identity(self, mock_request_user_sync: MagicMock, mock_reference_nin: MagicMock) -> None:
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.unverified_test_user.eppn
         country = countries.get("Sweden")

--- a/src/eduid/webapp/lookup_mobile_proofing/tests/test_app.py
+++ b/src/eduid/webapp/lookup_mobile_proofing/tests/test_app.py
@@ -173,15 +173,21 @@ class LookupMobileProofingTests(EduidAPITestCase[MobileProofingApp]):
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
         self._check_nin_not_verified_no_proofing_state(user=user)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.lookup_mobile_relay.LookupMobileRelay.find_nin_by_mobile")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_postal_address")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_proofing_flow_no_match_backdoor(
-        self, mock_request_user_sync: MagicMock, mock_get_postal_address: MagicMock, mock_find_nin_by_mobile: MagicMock
+        self,
+        mock_request_user_sync: MagicMock,
+        mock_get_postal_address: MagicMock,
+        mock_find_nin_by_mobile: MagicMock,
+        mock_reference_nin: MagicMock,
     ) -> None:
         mock_find_nin_by_mobile.return_value = None
         mock_get_postal_address.return_value = None
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         self.app.conf.magic_cookie = "magic-cookie"
         self.app.conf.magic_cookie_name = "magic-cookie"

--- a/src/eduid/webapp/oidc_proofing/tests/test_app.py
+++ b/src/eduid/webapp/oidc_proofing/tests/test_app.py
@@ -176,15 +176,21 @@ class OidcProofingTests(EduidAPITestCase):
         self.assertEqual(response_json["type"], "POST_OIDC_PROOFING_FREJA_PROOFING_FAIL")
         self.assertEqual(response_json["payload"]["error"]["csrf_token"], ["CSRF failed to validate"])
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_postal_address")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_seleg_flow(
-        self, mock_request_user_sync: MagicMock, mock_get_postal_address: MagicMock, mock_oidc_call: MagicMock
+        self,
+        mock_request_user_sync: MagicMock,
+        mock_get_postal_address: MagicMock,
+        mock_oidc_call: MagicMock,
+        mock_reference_nin: MagicMock,
     ) -> None:
         mock_oidc_call.return_value = True
         mock_get_postal_address.return_value = self.mock_address
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:
@@ -270,15 +276,21 @@ class OidcProofingTests(EduidAPITestCase):
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
         self._check_nin_not_verified(user=user, number=self.test_user_nin)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_postal_address")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_seleg_flow_previously_added_nin(
-        self, mock_request_user_sync: MagicMock, mock_get_postal_address: MagicMock, mock_oidc_call: MagicMock
+        self,
+        mock_request_user_sync: MagicMock,
+        mock_get_postal_address: MagicMock,
+        mock_oidc_call: MagicMock,
+        mock_reference_nin: MagicMock,
     ) -> None:
         mock_oidc_call.return_value = True
         mock_get_postal_address.return_value = self.mock_address
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         not_verified_nin = NinIdentity(number=self.test_user_nin, created_by="test", is_verified=False)
@@ -320,15 +332,21 @@ class OidcProofingTests(EduidAPITestCase):
             user=user, proofing_state=proofing_state, number=self.test_user_nin, created_by=not_verified_nin.created_by
         )
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_postal_address")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_seleg_flow_previously_added_wrong_nin(
-        self, mock_request_user_sync: MagicMock, mock_get_postal_address: MagicMock, mock_oidc_call: MagicMock
+        self,
+        mock_request_user_sync: MagicMock,
+        mock_get_postal_address: MagicMock,
+        mock_oidc_call: MagicMock,
+        mock_reference_nin: MagicMock,
     ) -> None:
         mock_oidc_call.return_value = True
         mock_get_postal_address.return_value = self.mock_address
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         not_verified_nin = NinIdentity(number=self.test_user_wrong_nin, created_by="test", is_verified=False)
@@ -368,15 +386,21 @@ class OidcProofingTests(EduidAPITestCase):
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
         self._check_nin_verified_ok(user=user, proofing_state=proofing_state, number=self.test_user_nin)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_postal_address")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_freja_flow(
-        self, mock_request_user_sync: MagicMock, mock_get_postal_address: MagicMock, mock_oidc_call: MagicMock
+        self,
+        mock_request_user_sync: MagicMock,
+        mock_get_postal_address: MagicMock,
+        mock_oidc_call: MagicMock,
+        mock_reference_nin: MagicMock,
     ) -> None:
         mock_oidc_call.return_value = True
         mock_get_postal_address.return_value = self.mock_address
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:
             response = json.loads(browser.get("/freja/proofing").data)
@@ -415,15 +439,21 @@ class OidcProofingTests(EduidAPITestCase):
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
         self._check_nin_verified_ok(user=user, proofing_state=proofing_state, number=self.test_user_nin)
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_postal_address")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_freja_flow_previously_added_nin(
-        self, mock_request_user_sync: MagicMock, mock_get_postal_address: MagicMock, mock_oidc_call: MagicMock
+        self,
+        mock_request_user_sync: MagicMock,
+        mock_get_postal_address: MagicMock,
+        mock_oidc_call: MagicMock,
+        mock_reference_nin: MagicMock,
     ) -> None:
         mock_oidc_call.return_value = True
         mock_get_postal_address.return_value = self.mock_address
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         not_verified_nin = NinIdentity(number=self.test_user_nin, created_by="test", is_verified=False)
@@ -463,15 +493,21 @@ class OidcProofingTests(EduidAPITestCase):
             user=user, proofing_state=proofing_state, number=self.test_user_nin, created_by=not_verified_nin.created_by
         )
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_postal_address")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
     def test_freja_flow_previously_added_wrong_nin(
-        self, mock_request_user_sync: MagicMock, mock_get_postal_address: MagicMock, mock_oidc_call: MagicMock
+        self,
+        mock_request_user_sync: MagicMock,
+        mock_get_postal_address: MagicMock,
+        mock_oidc_call: MagicMock,
+        mock_reference_nin: MagicMock,
     ) -> None:
         mock_oidc_call.return_value = True
         mock_get_postal_address.return_value = self.mock_address
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         not_verified_nin = NinIdentity(number=self.test_user_wrong_nin, created_by="test", is_verified=False)
@@ -541,11 +577,15 @@ class OidcProofingTests(EduidAPITestCase):
         # Check that the expired proofing state was removed
         assert not self.app.proofing_statedb.get_state_by_eppn(self.test_user_eppn)
 
+    @patch("eduid.webapp.common.api.decorators.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_seleg_locked_identity(self, mock_request_user_sync: MagicMock, mock_oidc_call: MagicMock) -> None:
+    def test_seleg_locked_identity(
+        self, mock_request_user_sync: MagicMock, mock_oidc_call: MagicMock, mock_reference_nin: MagicMock
+    ) -> None:
         mock_oidc_call.return_value = True
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:
@@ -583,11 +623,15 @@ class OidcProofingTests(EduidAPITestCase):
             response = json.loads(response.data)
         self.assertEqual(response["type"], "POST_OIDC_PROOFING_PROOFING_FAIL")
 
+    @patch("eduid.webapp.common.api.decorators.get_reference_nin_from_navet_data")
     @patch("eduid.webapp.oidc_proofing.helpers.do_authn_request")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_freja_locked_identity(self, mock_request_user_sync: MagicMock, mock_oidc_call: MagicMock) -> None:
+    def test_freja_locked_identity(
+        self, mock_request_user_sync: MagicMock, mock_oidc_call: MagicMock, mock_reference_nin: MagicMock
+    ) -> None:
         mock_oidc_call.return_value = True
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
 
         with self.session_cookie(self.browser, self.test_user_eppn) as browser:

--- a/src/eduid/webapp/svipe_id/proofing.py
+++ b/src/eduid/webapp/svipe_id/proofing.py
@@ -113,7 +113,7 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
                 return VerifyUserResult(error=CommonMsg.locked_identity_not_matching)
             # replace the locked identity as the users asserted prid has changed,
             # and we are sure enough that it is the same person
-            proofing_user.replace_lock = new_identity.identity_type
+            proofing_user.replace_locked = new_identity.identity_type
 
         # the existing identity is not verified, just remove it
         if existing_identity is not None:

--- a/src/eduid/webapp/svipe_id/proofing.py
+++ b/src/eduid/webapp/svipe_id/proofing.py
@@ -113,7 +113,7 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
                 return VerifyUserResult(error=CommonMsg.locked_identity_not_matching)
             # replace the locked identity as the users asserted prid has changed,
             # and we are sure enough that it is the same person
-            proofing_user.locked_identity.replace(element=new_identity)
+            proofing_user.replace_lock = new_identity.identity_type
 
         # the existing identity is not verified, just remove it
         if existing_identity is not None:

--- a/src/eduid/webapp/svipe_id/tests/test_app.py
+++ b/src/eduid/webapp/svipe_id/tests/test_app.py
@@ -309,11 +309,15 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
         assert query["acr_values"] == ["face_present"]
         assert query["claims"] == [json.dumps({"userinfo": self.app.conf.svipe_client.claims_request})]
 
+    @patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
     @patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
     @patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-    def test_verify_nin_identity(self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock) -> None:
+    def test_verify_nin_identity(
+        self, mock_request_user_sync: MagicMock, mock_get_all_navet_data: MagicMock, mock_reference_nin: MagicMock
+    ) -> None:
         mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
+        mock_reference_nin.return_value = None
 
         eppn = self.unverified_test_user.eppn
         country = countries.get("Sweden")

--- a/src/eduid/workers/am/ams/common.py
+++ b/src/eduid/workers/am/ams/common.py
@@ -75,7 +75,7 @@ class AttributeFetcher(ABC):
 
         return attributes
 
-    def get_replace_lock(self, user_id: bson.ObjectId) -> IdentityType | None:
+    def get_replace_locked(self, user_id: bson.ObjectId) -> IdentityType | None:
         """
         Get the identity type of the lock to be replaced or None if no lock should be replaced.
         """
@@ -93,4 +93,4 @@ class AttributeFetcher(ABC):
             logger.debug("Not a proofing user, returning None.")
             return None
 
-        return user.replace_lock
+        return user.replace_locked

--- a/src/eduid/workers/am/ams/common.py
+++ b/src/eduid/workers/am/ams/common.py
@@ -8,6 +8,8 @@ from celery.utils.log import get_task_logger
 
 from eduid.common.config.workers import AmConfig
 from eduid.userdb.exceptions import UserDoesNotExist
+from eduid.userdb.identity import IdentityType
+from eduid.userdb.proofing.user import ProofingUser
 from eduid.userdb.user import User
 from eduid.userdb.userdb import UserDB
 from eduid.userdb.util import format_dict_for_debug
@@ -72,3 +74,23 @@ class AttributeFetcher(ABC):
             attributes["$unset"] = attributes_unset
 
         return attributes
+
+    def get_replace_lock(self, user_id: bson.ObjectId) -> IdentityType | None:
+        """
+        Get the identity type of the lock to be replaced or None if no lock should be replaced.
+        """
+
+        logger.debug(f"Trying to get user with _id: {user_id} from {self.private_db}.")
+        if not self.private_db:
+            raise RuntimeError("No database initialised")
+
+        user: User | None = self.private_db.get_user_by_id(user_id)
+        logger.debug(f"User: {user} found.")
+        if not user:
+            raise UserDoesNotExist(f"No user found with id {user_id}")
+
+        if not isinstance(user, ProofingUser):
+            logger.debug("Not a proofing user, returning None.")
+            return None
+
+        return user.replace_lock

--- a/src/eduid/workers/am/consistency_checks.py
+++ b/src/eduid/workers/am/consistency_checks.py
@@ -154,7 +154,7 @@ def unverify_identities(userdb: AmDB, user_id: ObjectId, identities: list[dict[s
 
 
 def check_locked_identity(
-    userdb: AmDB, user_id: ObjectId, attributes: dict, app_name: str, replace_lock: IdentityType | None = None
+    userdb: AmDB, user_id: ObjectId, attributes: dict, app_name: str, replace_locked: IdentityType | None = None
 ) -> dict:
     """
     :param userdb: Central userdb
@@ -187,7 +187,7 @@ def check_locked_identity(
             updated = True
             continue
 
-        if replace_lock is locked_identity.identity_type:
+        if replace_locked is locked_identity.identity_type:
             # replace the locked identity with the new verified identity
             if identity.created_by is None:
                 identity.created_by = app_name

--- a/src/eduid/workers/am/tasks.py
+++ b/src/eduid/workers/am/tasks.py
@@ -71,6 +71,7 @@ def update_attributes_keep_result(self: AttributeManager, app_name: str, user_id
 
     try:
         attributes = attribute_fetcher.fetch_attrs(_id)
+        replace_lock = attribute_fetcher.get_replace_lock(_id)
     except UserDoesNotExist as e:
         logger.error(f"The user {_id} does not exist in the database for plugin {app_name}: {e}")
         raise e
@@ -80,7 +81,7 @@ def update_attributes_keep_result(self: AttributeManager, app_name: str, user_id
 
     try:
         logger.debug(f"Checking locked identity during sync attempt from {app_name}")
-        attributes = check_locked_identity(self.userdb, _id, attributes, app_name)
+        attributes = check_locked_identity(self.userdb, _id, attributes, app_name, replace_lock)
     except LockedIdentityViolation as e:
         logger.error(e)
         raise e

--- a/src/eduid/workers/am/tasks.py
+++ b/src/eduid/workers/am/tasks.py
@@ -71,7 +71,7 @@ def update_attributes_keep_result(self: AttributeManager, app_name: str, user_id
 
     try:
         attributes = attribute_fetcher.fetch_attrs(_id)
-        replace_lock = attribute_fetcher.get_replace_lock(_id)
+        replace_locked = attribute_fetcher.get_replace_locked(_id)
     except UserDoesNotExist as e:
         logger.error(f"The user {_id} does not exist in the database for plugin {app_name}: {e}")
         raise e
@@ -81,7 +81,7 @@ def update_attributes_keep_result(self: AttributeManager, app_name: str, user_id
 
     try:
         logger.debug(f"Checking locked identity during sync attempt from {app_name}")
-        attributes = check_locked_identity(self.userdb, _id, attributes, app_name, replace_lock)
+        attributes = check_locked_identity(self.userdb, _id, attributes, app_name, replace_locked)
     except LockedIdentityViolation as e:
         logger.error(e)
         raise e

--- a/src/eduid/workers/am/tests/test_tasks.py
+++ b/src/eduid/workers/am/tests/test_tasks.py
@@ -244,7 +244,7 @@ class TestTasks(AMTestCase):
         with self.assertRaises(EduIDUserDBError):
             check_locked_identity(self.amdb, user_id, attributes, "test")
 
-    def test_check_locked_identity_replace_lock(self) -> None:
+    def test_check_locked_identity_replace_locked(self) -> None:
         user_id = ObjectId("901234567890123456789012")  # johnsmith@example.org / babba-labba
         user = self.amdb.get_user_by_id(user_id)
         assert user
@@ -255,7 +255,7 @@ class TestTasks(AMTestCase):
                 "identities": [{"identity_type": IdentityType.NIN.value, "verified": True, "number": "200506076789"}]
             }
         }
-        new_attributes = check_locked_identity(self.amdb, user_id, attributes, "test", replace_lock=IdentityType.NIN)
+        new_attributes = check_locked_identity(self.amdb, user_id, attributes, "test", replace_locked=IdentityType.NIN)
 
         # check_locked_identity should replace locked identity with new identity
         locked_nin = NinIdentity(number="200506076789", created_by="test", is_verified=True)

--- a/src/eduid/workers/msg/tasks.py
+++ b/src/eduid/workers/msg/tasks.py
@@ -153,10 +153,6 @@ class MessageSender(Task):
         :param identity_number: Swedish national identity number
         :return: dict containing name and postal address
         """
-        # Only log the message if devel_mode is enabled
-        if MsgCelerySingleton.worker_config.devel_mode is True:
-            return self.get_devel_postal_address()
-
         data = self._get_navet_data(identity_number)
         # Filter name and address from the Navet lookup results
         return navet_get_name_and_official_address(data)
@@ -187,10 +183,6 @@ class MessageSender(Task):
         :param identity_number: Swedish national identity number
         :return: dict containing name and postal address
         """
-        # Only log the message if devel_mode is enabled
-        if MsgCelerySingleton.worker_config.devel_mode is True:
-            return self.get_devel_relations()
-
         data = self._get_navet_data(identity_number)
         # Filter relations from the Navet lookup results
         return navet_get_relations(data)
@@ -229,10 +221,6 @@ class MessageSender(Task):
         return result
 
     def get_all_navet_data(self, identity_number: str) -> OrderedDict[str, Any] | None:
-        # Only log the message if devel_mode is enabled
-        if MsgCelerySingleton.worker_config.devel_mode is True:
-            return self.get_devel_all_navet_data(identity_number)
-
         data = self._get_navet_data(identity_number)
         return navet_get_all_data(data)
 


### PR DESCRIPTION
Enable updating NIN and locked NIN if the new NIN has a reference to the currently locked NIN
Use case is changing of national identity number or groinf from coordination number to national identoty number