### PR TITLE
Add MsgRelay to more apps that need it

### DIFF
--- a/src/eduid/webapp/bankid/app.py
+++ b/src/eduid/webapp/bankid/app.py
@@ -5,6 +5,7 @@ from flask import current_app
 
 from eduid.common.config.parsers import load_config
 from eduid.common.rpc.am_relay import AmRelay
+from eduid.common.rpc.msg_relay import MsgRelay
 from eduid.userdb.logs.db import ProofingLog
 from eduid.userdb.proofing.db import BankIDProofingUserDB
 from eduid.webapp.bankid.settings.common import BankIDConfig
@@ -28,6 +29,7 @@ class BankIDApp(AuthnBaseApp):
 
         # Init celery
         self.am_relay = AmRelay(config)
+        self.msg_relay = MsgRelay(config)
 
 
 current_bankid_app: BankIDApp = cast(BankIDApp, current_app)

--- a/src/eduid/webapp/bankid/settings/common.py
+++ b/src/eduid/webapp/bankid/settings/common.py
@@ -10,6 +10,7 @@ from eduid.common.config.base import (
     ErrorsConfigMixin,
     FrontendActionMixin,
     MagicCookieMixin,
+    MsgConfigMixin,
     ProofingConfigMixin,
     Pysaml2SPConfigMixin,
 )
@@ -23,6 +24,7 @@ class BankIDConfig(
     ProofingConfigMixin,
     Pysaml2SPConfigMixin,
     FrontendActionMixin,
+    MsgConfigMixin,
 ):
     """
     Configuration for the eidas app

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -301,7 +301,14 @@ def get_reference_nin_from_navet_data(nin: str) -> str | None:
     """
     Check if the NIN has changed in Navet data.
     """
-    msg_relay = get_from_current_app("msg_relay", MsgRelay)
+    try:
+        msg_relay = get_from_current_app("msg_relay", MsgRelay)
+    except AttributeError:
+        # If for some reason the msg_relay is not in the current app, return None.
+        # This should not happen, but if it does, we don't want to crash the service.
+        # Instead, we log the error and return None.
+        logger.error("Could not get msg_relay from current app")
+        return None
 
     navet_data = msg_relay.get_all_navet_data(nin=nin)
     if navet_data.person.reference_national_identity_number:

--- a/src/eduid/webapp/eidas/app.py
+++ b/src/eduid/webapp/eidas/app.py
@@ -5,6 +5,7 @@ from flask import current_app
 
 from eduid.common.config.parsers import load_config
 from eduid.common.rpc.am_relay import AmRelay
+from eduid.common.rpc.msg_relay import MsgRelay
 from eduid.userdb.logs.db import ProofingLog
 from eduid.userdb.proofing.db import EidasProofingUserDB
 from eduid.webapp.common.authn.middleware import AuthnBaseApp
@@ -28,6 +29,7 @@ class EidasApp(AuthnBaseApp):
 
         # Init celery
         self.am_relay = AmRelay(config)
+        self.msg_relay = MsgRelay(config)
 
 
 current_eidas_app: EidasApp = cast(EidasApp, current_app)

--- a/src/eduid/webapp/eidas/settings/common.py
+++ b/src/eduid/webapp/eidas/settings/common.py
@@ -12,6 +12,7 @@ from eduid.common.config.base import (
     ErrorsConfigMixin,
     FrontendActionMixin,
     MagicCookieMixin,
+    MsgConfigMixin,
     ProofingConfigMixin,
     Pysaml2SPConfigMixin,
 )
@@ -25,6 +26,7 @@ class EidasConfig(
     ProofingConfigMixin,
     Pysaml2SPConfigMixin,
     FrontendActionMixin,
+    MsgConfigMixin,
 ):
     """
     Configuration for the eidas app

--- a/src/eduid/webapp/freja_eid/app.py
+++ b/src/eduid/webapp/freja_eid/app.py
@@ -6,6 +6,7 @@ from flask import current_app
 
 from eduid.common.config.parsers import load_config
 from eduid.common.rpc.am_relay import AmRelay
+from eduid.common.rpc.msg_relay import MsgRelay
 from eduid.userdb.logs import ProofingLog
 from eduid.userdb.proofing.db import FrejaEIDProofingUserDB
 from eduid.webapp.common.authn.middleware import AuthnBaseApp
@@ -25,6 +26,7 @@ class FrejaEIDApp(AuthnBaseApp):
         self.proofing_log = ProofingLog(config.mongo_uri)
         # Init celery
         self.am_relay = AmRelay(config)
+        self.msg_relay = MsgRelay(config)
 
         # Initialize the oidc_client
         self.oidc_client = OAuth(self, cache=SessionOAuthCache())

--- a/src/eduid/webapp/freja_eid/settings/common.py
+++ b/src/eduid/webapp/freja_eid/settings/common.py
@@ -7,6 +7,7 @@ from eduid.common.config.base import (
     ErrorsConfigMixin,
     FrontendActionMixin,
     MagicCookieMixin,
+    MsgConfigMixin,
     ProofingConfigMixin,
 )
 
@@ -37,6 +38,7 @@ class FrejaEIDConfig(
     ErrorsConfigMixin,
     MagicCookieMixin,
     FrontendActionMixin,
+    MsgConfigMixin,
 ):
     """
     Configuration for the svipe_id app


### PR DESCRIPTION
Some more apps need MsgRelay to be able to check correctness of NIN-changes