### PR TITLE
Fewer request against the SCIM database

### DIFF
--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -111,6 +111,7 @@ class ScimAttributes(ResponseMicroService):
         # This is the easiest way I can come up with without needing duplicated configuration
         # regarding the database for different micro_services or refactor the database connection/calls
         # to a shared class.
+        # Make sure to delete from `data` before handing the request to satosa due to serialization problems.
         if self.config.only_configure_and_expose_scim:
             data.update({"scim_class_from_ScimAttributes": self})
             data.update({"data_owner": data_owner})

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -109,7 +109,7 @@ class ScimAttributes(ResponseMicroService):
         data_owner = self._get_data_owner(data, scopes, frontend_name)
 
         # This is the easiest way I can come up with without needing duplicated configuration
-        # regarding the database for diffrent micro_services or refactor the database connection/calls
+        # regarding the database for different micro_services or refactor the database connection/calls
         # to a shared class.
         if self.config.only_configure_and_expose_scim:
             data.update({"scim_class_from_ScimAttributes": self})

--- a/src/eduid/satosa/scimapi/stepup.py
+++ b/src/eduid/satosa/scimapi/stepup.py
@@ -285,10 +285,6 @@ class StepUp(ResponseMicroService):
             logger.info(f"Requester {params.requester} did not ask for a specific LoA")
             return super().process(context, data)
 
-        if AuthnContext.idp_sent_loa(context):
-            logger.info("IDP already sent a LoA")
-            return super().process(context, data)
-
         store_params(data, params)
 
         name_id = NameID(format=NAMEID_FORMAT_UNSPECIFIED, text=linked_account.identifier)

--- a/src/eduid/satosa/scimapi/stepup.py
+++ b/src/eduid/satosa/scimapi/stepup.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     from eduid.satosa.scimapi.common import fetch_mfa_stepup_accounts, get_internal_attribute_name, get_metadata
 
+
 import satosa.context
 import satosa.internal
 import satosa.response
@@ -236,15 +237,30 @@ class StepUp(ResponseMicroService):
         context: satosa.context.Context,
         data: satosa.internal.InternalData,
     ) -> ProcessReturnType:
+        if not AuthnContext.sp_wants_mfa(context):
+            logger.info("Requesting SP did not ask for MFA")
+            return super().process(context, data)
+
+        if AuthnContext.idp_sent_loa(context):
+            logger.info("IDP already sent a LoA")
+            return super().process(context, data)
+
+        if "scim_class_from_ScimAttributes" in data:
+            scim = data.scim_class_from_ScimAttributes
+        else:
+            raise StepUpError("Configuration error - No scim class provided throught data")
+
+        user = scim._get_user(data, data.data_owner)
+        if user:
+            logger.debug(f"Found user: {user}")
+            data = scim._process_user(user=user, data=data)
+
         linked_accounts = fetch_mfa_stepup_accounts(data)
         if not linked_accounts:
-            logger.info("No linked accounts for this user")
-            if AuthnContext.sp_wants_mfa(context=context) and not AuthnContext.idp_sent_loa(context=context):
-                logger.info("Requesting SP did ask for MFA but and user has no linked accounts")
-                raise SATOSAAuthenticationError(
-                    context.state, "Requesting SP did ask for MFA but didn't get it and the user has no linked account"
-                )
-            return super().process(context, data)
+            logger.info("Requesting SP did ask for MFA but and user has no linked accounts")
+            raise SATOSAAuthenticationError(
+                context.state, "Requesting SP did ask for MFA but didn't get it and the user has no linked account"
+            )
 
         logger.debug(f"Linked accounts: {linked_accounts}")
         linked_account = linked_accounts[0]
@@ -255,10 +271,6 @@ class StepUp(ResponseMicroService):
 
         if not linked_account.identifier:
             logger.info("No account identifier for this account")
-            return super().process(context, data)
-
-        if not AuthnContext.sp_wants_mfa(context):
-            logger.info("Requesting SP did not ask for MFA")
             return super().process(context, data)
 
         params = self._get_params(context, data)

--- a/src/eduid/satosa/scimapi/stepup.py
+++ b/src/eduid/satosa/scimapi/stepup.py
@@ -255,6 +255,10 @@ class StepUp(ResponseMicroService):
             logger.debug(f"Found user: {user}")
             data = scim._process_user(user=user, data=data)
 
+        # Prevent future serialization problems
+        if "scim_class_from_ScimAttributes" in data:
+            del data["scim_class_from_ScimAttributes"]
+
         linked_accounts = fetch_mfa_stepup_accounts(data)
         if not linked_accounts:
             logger.info("Requesting SP did ask for MFA but and user has no linked accounts")


### PR DESCRIPTION
For some proxies e.g stepup, we only need to check users in the SCIM if MFA is asked for and not already provided.