### PR TITLE
Force reauth when Loa2 is requested in AuthnContextClass

### DIFF
--- a/src/eduid/common/models/saml2.py
+++ b/src/eduid/common/models/saml2.py
@@ -6,6 +6,7 @@ __author__ = "lundberg"
 @unique
 class EduidAuthnContextClass(StrEnum):
     DIGG_LOA2 = "http://id.elegnamnden.se/loa/1.0/loa2"
+    DIGG_UNCERTIFIED_LOA2 = "http://id.swedenconnect.se/loa/1.0/uncertified-loa2"
     REFEDS_MFA = "https://refeds.org/profile/mfa"
     REFEDS_SFA = "https://refeds.org/profile/sfa"
     FIDO_U2F = "https://www.swamid.se/specs/id-fido-u2f-ce-transports"

--- a/src/eduid/common/models/saml2.py
+++ b/src/eduid/common/models/saml2.py
@@ -6,7 +6,6 @@ __author__ = "lundberg"
 @unique
 class EduidAuthnContextClass(StrEnum):
     DIGG_LOA2 = "http://id.elegnamnden.se/loa/1.0/loa2"
-    DIGG_UNCERTIFIED_LOA2 = "http://id.swedenconnect.se/loa/1.0/uncertified-loa2"
     REFEDS_MFA = "https://refeds.org/profile/mfa"
     REFEDS_SFA = "https://refeds.org/profile/sfa"
     FIDO_U2F = "https://www.swamid.se/specs/id-fido-u2f-ce-transports"

--- a/src/eduid/webapp/idp/assurance.py
+++ b/src/eduid/webapp/idp/assurance.py
@@ -214,7 +214,7 @@ class AuthnState:
         return self._credentials
 
 
-def response_authn(authn: AuthnState, ticket: LoginContext, user: IdPUser, sso_session: SSOSession) -> AuthnInfo:
+def response_authn(authn: AuthnState, ticket: LoginContext, user: IdPUser) -> AuthnInfo:
     """
     Figure out what AuthnContext to assert in a SAML response,
     given the RequestedAuthnContext from the SAML request.

--- a/src/eduid/webapp/idp/assurance.py
+++ b/src/eduid/webapp/idp/assurance.py
@@ -150,7 +150,8 @@ class AuthnState:
         _used_request = [x for x in _used_credentials.values() if x.source == UsedWhere.REQUEST]
         logger.debug(f"Number of credentials used with this very request: {len(_used_request)}")
 
-        if ticket.reauthn_required:
+        req_authn_ctx = ticket.get_requested_authn_context()
+        if ticket.reauthn_required or req_authn_ctx is EduidAuthnContextClass.DIGG_LOA2:
             logger.debug("Request requires authentication, not even considering credentials from the SSO session")
             return list(_used_credentials.values())
 

--- a/src/eduid/webapp/idp/login.py
+++ b/src/eduid/webapp/idp/login.py
@@ -197,7 +197,7 @@ def login_next_step(ticket: LoginContext, sso_session: SSOSession | None) -> Nex
 
     try:
         authn_state = AuthnState(user, sso_session, ticket)
-        authn_info = assurance.response_authn(authn_state, ticket, user, sso_session)
+        authn_info = assurance.response_authn(authn_state, ticket, user)
         res = NextResult(message=IdPMsg.proceed, authn_info=authn_info, authn_state=authn_state)
     except MissingPasswordFactor:
         res = NextResult(message=IdPMsg.must_authenticate)


### PR DESCRIPTION
- add control on `EduidAuthnContextClass.DIGG_LOA2` at the same level as `ticket.reauthn_required` in `_gather_credentials()`
- removed unused `sso_session` parameter in `response_authn()`
- in IdPAPITests fixed add_test_user_external_mfa_cred()
- in TestSSO created external_mfa with add_test_user_external_mfa_cred() and AuthnData, added test_get_login_digg_loa2_only_sso_force_reauth()