### PR TITLE
Make sure that the request NameID is returned

### DIFF
--- a/src/eduid/satosa/scimapi/nameid.py
+++ b/src/eduid/satosa/scimapi/nameid.py
@@ -1,0 +1,86 @@
+import logging
+import uuid
+from collections.abc import Mapping
+from typing import Any, TypeAlias
+
+import satosa.internal
+import satosa.response
+from saml2.saml import (
+    NAMEID_FORMAT_EMAILADDRESS,
+    NAMEID_FORMAT_PERSISTENT,
+    NAMEID_FORMAT_TRANSIENT,
+    NAMEID_FORMAT_UNSPECIFIED,
+)
+from satosa.exception import SATOSAAuthenticationError
+from satosa.micro_services.base import RequestMicroService, ResponseMicroService
+
+logger = logging.getLogger(__name__)
+ProcessReturnType: TypeAlias = satosa.internal.InternalData | satosa.response.Response
+ALLOWED_NAMEIDS = (
+    NAMEID_FORMAT_UNSPECIFIED,
+    NAMEID_FORMAT_EMAILADDRESS,
+    NAMEID_FORMAT_PERSISTENT,
+    NAMEID_FORMAT_TRANSIENT,
+)
+
+
+class request(RequestMicroService):
+    def __init__(
+        self,
+        config: Mapping[str, Any],
+        internal_attributes: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+    def process(self, context: satosa.context.Context, data: satosa.internal.InternalData) -> ProcessReturnType:
+        if data.subject_type:
+            if data.subject_type not in ALLOWED_NAMEIDS:
+                raise SATOSAAuthenticationError(context.state, "Unsupported NameID")
+        else:
+            raise SATOSAAuthenticationError(context.state, "No NameID")
+
+        logger.info(f"Saving requested NameID for later use: {data.subject_type}")
+        context.state["subject_type"] = data.subject_type
+
+        return super().process(context, data)
+
+
+class response(ResponseMicroService):
+    def __init__(
+        self,
+        config: Mapping[str, Any],
+        internal_attributes: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+    def process(self, context: satosa.context.Context, data: satosa.internal.InternalData) -> ProcessReturnType:
+        subject_type = context.state.get("subject_type")
+        if not subject_type:
+            raise SATOSAAuthenticationError(context.state, "No NameID from saved state")
+
+        logger.info(f"Requested (by SP) NameID type from state: {subject_type}")
+
+        if subject_type == NAMEID_FORMAT_TRANSIENT or subject_type == NAMEID_FORMAT_UNSPECIFIED:
+            data.subject_id = str(uuid.uuid1())
+        elif subject_type == NAMEID_FORMAT_PERSISTENT:
+            pairwise = data.attributes.get("pairwise-id")[0]
+            if not pairwise:
+                raise SATOSAAuthenticationError(context.state, "No pairwise ID to use as persistant NameID")
+            data.subject_id = pairwise.split("@")[0]
+        elif subject_type == NAMEID_FORMAT_EMAILADDRESS:
+            mail = data.attributes.get("mail")[0]
+            if not mail:
+                raise SATOSAAuthenticationError(context.state, "No mail to use as NameID")
+            data.subject_id = mail
+        else:
+            # This should not even be possible
+            raise SATOSAAuthenticationError(context.state, "Unknown NameID")
+
+        data.subject_type = subject_type
+
+        logger.debug(f"Returning NameID ({subject_type}): {data.subject_id}")
+        return super().process(context, data)


### PR DESCRIPTION
Without these microservices the NameID returned from eduID will be passed on to the SP.

Adding this as a Draft since I would like @btmattsson to review the "business logic" before we try it out in staging.

(Hopefully) later when in staging we need to test the code with as many "strange" SPs we can find since my local test only invoke a Shibboleth SP (with at-least all allowed NameID's).