### PR TITLE
Attributes in pysaml2 are expected to be lists

### DIFF
--- a/src/eduid/satosa/scimapi/pairwiseid.py
+++ b/src/eduid/satosa/scimapi/pairwiseid.py
@@ -58,6 +58,6 @@ class GeneratePairwiseId(ResponseMicroService):
         ).hexdigest()
 
         logger.debug(f"Pairwise-id for {subject_id} and {relying_party}: {pairwise_hash}@{user_scope}")
-        data.attributes["pairwise-id"] = f"{pairwise_hash}@{user_scope}"
+        data.attributes["pairwise-id"] = [f"{pairwise_hash}@{user_scope}"]
 
         return super().process(context, data)


### PR DESCRIPTION
Specificly in this case we couldn't [0] use the generated pairwise id with AddSyntheticAttributes micro service.

[0] https://github.com/IdentityPython/SATOSA/blob/f519bc62b67065946f4b75319c9a180e4e4d3517/src/satosa/micro_services/attribute_generation.py#L134