### PR TITLE
Update python to 3.13 in environments and fix upgrade issues

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:0-3.11
+FROM mcr.microsoft.com/devcontainers/python:1-3.13
 
 ARG NONROOT_USER=vscode
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.13"]
     env:
       PIP_INDEX_URL: https://pypi.sunet.se/simple/
       NEO4J_VERSION: 4.4-enterprise
@@ -52,10 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Set up Python 3.11"
+      - name: "Set up Python 3.13"
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -74,7 +74,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -70,16 +70,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Python
-        uses: actions/setup-python@v5
+      - uses: astral-sh/ruff-action@v3
         with:
-          python-version: "3.13"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff
-      # Update output format to enable automatic inline annotations.
-      - name: Run Ruff
-        run: ruff check --output-format=github .
+          version: "<0.12.0"
 

--- a/.jenkins.yaml
+++ b/.jenkins.yaml
@@ -14,7 +14,7 @@ pre_build_script:
 environment_variables:
   NEO4J_VERSION: "4.4-enterprise"
 script:
-  - "python3.11 -m venv venv"
+  - "python3.13 -m venv venv"
   - ". venv/bin/activate"
   - "pip install -U pip setuptools wheel mypy"
   - "pip install --index-url https://pypi.sunet.se -r requirements/test_requirements.txt"
@@ -31,7 +31,7 @@ extra_jobs:
       github_push: false
       cron: "@daily"
     script:
-      - "python3.11 -m venv venv"
+      - "python3.13 -m venv venv"
       - ". venv/bin/activate"
       - "pip install -U pip setuptools wheel pip-tools mypy uv"
       - "touch requirements/*in"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 # Set the maximum line length to 120.
 line-length = 120
-target-version = "py311"
+target-version = "py313"
 
 [lint]
 select = [

--- a/src/eduid/queue/testing.py
+++ b/src/eduid/queue/testing.py
@@ -6,7 +6,7 @@ import time
 from asyncio import Task
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import Any, cast
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import patch
 
@@ -19,12 +19,6 @@ from eduid.queue.db.worker import AsyncQueueDB
 from eduid.queue.workers.base import QueueWorker
 from eduid.userdb.db import TUserDbDocument
 from eduid.userdb.testing import EduidTemporaryInstance, MongoTemporaryInstance
-
-# type checking shenanigans for mypy
-if TYPE_CHECKING:
-    MixinBase: TypeAlias = QueueWorker
-else:
-    MixinBase = object
 
 __author__ = "lundberg"
 
@@ -207,7 +201,7 @@ class QueueAsyncioTest(EduidQueueTestCase, IsolatedAsyncioTestCase):
         assert fetched is None
 
 
-class IsolatedWorkerDBMixin(MixinBase):
+class IsolatedWorkerDBMixin(QueueWorker):
     # override run so we can mock cache of database clients
     async def run(self) -> None:
         # Init db in the correct loop

--- a/src/eduid/satosa/scimapi/accr.py
+++ b/src/eduid/satosa/scimapi/accr.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping
 from copy import deepcopy
-from typing import Any, TypeAlias
+from typing import Any
 
 import satosa.internal
 import satosa.response
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 SupportedACCRsSortedByPrioConfig = list[str]
 LowestAcceptedACCRForVirtualIdpConfig = dict[str, str]
 InternalACCRRewriteMap = Mapping[str, str]
-ProcessReturnType: TypeAlias = satosa.internal.InternalData | satosa.response.Response
+type ProcessReturnType = satosa.internal.InternalData | satosa.response.Response
 
 
 class request(RequestMicroService):

--- a/src/eduid/satosa/scimapi/common.py
+++ b/src/eduid/satosa/scimapi/common.py
@@ -30,7 +30,7 @@ def fetch_mfa_stepup_accounts(data: satosa.internal.InternalData) -> list[MfaSte
     return [MfaStepupAccount.model_validate(x) for x in data.mfa_stepup_accounts]
 
 
-def get_metadata(context: satosa.context.Context) -> Generator[MetaData, None, None]:
+def get_metadata(context: satosa.context.Context) -> Generator[MetaData]:
     for _md_name, _metadata in context.internal_data[context.KEY_METADATA_STORE].metadata.items():
         if not isinstance(_metadata, MetaData):
             logger.debug(f"Element {_md_name} was not MetaData ({type(_metadata)})")

--- a/src/eduid/satosa/scimapi/nameid.py
+++ b/src/eduid/satosa/scimapi/nameid.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from collections.abc import Mapping
-from typing import Any, TypeAlias
+from typing import Any
 
 from saml2.saml import (
     NAMEID_FORMAT_EMAILADDRESS,
@@ -15,7 +15,7 @@ from satosa.internal import InternalData
 from satosa.micro_services.base import RequestMicroService, ResponseMicroService
 from satosa.response import Response
 
-ProcessReturnType: TypeAlias = InternalData | Response
+type ProcessReturnType = InternalData | Response
 
 ALLOWED_NAMEIDS = (
     NAMEID_FORMAT_UNSPECIFIED,

--- a/src/eduid/satosa/scimapi/stepup.py
+++ b/src/eduid/satosa/scimapi/stepup.py
@@ -4,7 +4,7 @@ import functools
 import json
 import logging
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, NewType, TypeAlias
+from typing import Any, NewType
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, ValidationError
@@ -50,8 +50,8 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # TODO: Remove when https://github.com/IdentityPython/SATOSA/pull/435 has been accepted
-ProcessReturnType: TypeAlias = satosa.internal.InternalData | satosa.response.Response
-CallbackReturnType: TypeAlias = satosa.response.Response
+type ProcessReturnType = satosa.internal.InternalData | satosa.response.Response
+type CallbackReturnType = satosa.response.Response
 CallbackCallSignature = Callable[[satosa.context.Context, Any], CallbackReturnType]
 # end todo
 

--- a/src/eduid/userdb/admin/__init__.py
+++ b/src/eduid/userdb/admin/__init__.py
@@ -50,7 +50,7 @@ class RawDb:
         self._backupbase: str = backupbase
         self._file_num: int = 0
 
-    def find(self, db: str, collection: str, search_filter: object) -> Generator[RawData, None, None]:
+    def find(self, db: str, collection: str, search_filter: object) -> Generator[RawData]:
         """
         Look for documents matching search_filter in the specified database and collection.
 

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -200,7 +200,7 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
         logged_in: bool = True,
         domain: str | None = None,
         **kwargs: Any,
-    ) -> Generator[CSRFTestClient, None, None]:
+    ) -> Generator[CSRFTestClient]:
         if domain is None:
             domain = self.test_domain
         with client.session_transaction(**kwargs) as sess:
@@ -214,7 +214,7 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
         yield client
 
     @contextmanager
-    def session_cookie_anon(self, client: CSRFTestClient, **kwargs: Any) -> Generator[CSRFTestClient, None, None]:
+    def session_cookie_anon(self, client: CSRFTestClient, **kwargs: Any) -> Generator[CSRFTestClient]:
         with self.session_cookie(client=client, eppn=None, **kwargs) as _client:
             yield _client
 
@@ -228,7 +228,7 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
         magic_cookie_name: str | None = None,
         magic_cookie_value: str | None = None,
         **kwargs: Any,
-    ) -> Generator[CSRFTestClient, None, None]:
+    ) -> Generator[CSRFTestClient]:
         if domain is None:
             domain = self.test_domain
         assert isinstance(self.app, EduIDBaseApp)
@@ -251,7 +251,7 @@ class EduidAPITestCase(CommonTestCase, Generic[TTestAppVar]):
         magic_cookie_name: str | None = None,
         magic_cookie_value: str | None = None,
         **kwargs: Any,
-    ) -> Generator[CSRFTestClient, None, None]:
+    ) -> Generator[CSRFTestClient]:
         with self.session_cookie_and_magic_cookie(
             client=client,
             eppn=None,
@@ -625,7 +625,7 @@ class CSRFTestClient(FlaskClient):
         return super().get(*args, **kwargs)
 
     @contextmanager
-    def session_transaction(self, *args: Any, **kwargs: Any) -> Generator[EduidSession, None, None]:
+    def session_transaction(self, *args: Any, **kwargs: Any) -> Generator[EduidSession]:
         """
         Get typed session in tests
         """

--- a/src/eduid/webapp/idp/login_context.py
+++ b/src/eduid/webapp/idp/login_context.py
@@ -301,14 +301,11 @@ class LoginContextOtherDevice(LoginContext):
 def _pick_authn_context(accrs: Sequence[str], log_tag: str) -> EduidAuthnContextClass | None:
     if len(accrs) > 1:
         logger.warning(f"{log_tag}: More than one authnContextClassRef, using the first recognised: {accrs}")
-    # make a set of implemented EduidAuthnContextClass values
-    # TODO: in python 3.12 this can be removed and test below can be 'x in EduidAuthnContextClass'
-    implemented: set[str] = {x.value for x in EduidAuthnContextClass}
 
     # first, select the ones recognised by this IdP
     known = []
     for x in accrs:
-        if x in implemented:
+        if x in EduidAuthnContextClass:
             known += [EduidAuthnContextClass(x)]
         else:
             logger.info(f"Unknown authnContextClassRef: {x}")

--- a/src/eduid/webapp/idp/sso_cache.py
+++ b/src/eduid/webapp/idp/sso_cache.py
@@ -110,11 +110,7 @@ class ExpiringCacheMem:
     :param lock: threading.Lock compatible locking instance
     """
 
-    # TODO: fix when python 3.13 is our target environment
-    # use quote annotations on lock for now until python 3.13 is released
-    # threading.Lock is not a class but a factory function, see:
-    # https://github.com/python/cpython/pull/114479
-    def __init__(self, name: str, logger: logging.Logger | None, ttl: int, lock: "Lock | None" = None) -> None:
+    def __init__(self, name: str, logger: logging.Logger | None, ttl: int, lock: Lock | None = None) -> None:
         self.logger = logger
         self.ttl = ttl
         self.name = name


### PR DESCRIPTION
Update ruff, github and jenkins to python 3.13 as that is the default for debian trixie due to be released August 12th

Pin version of ruff in github actions to < 0.12.0 until we have time to check new rules released with version 0.12.0

Handle linting rules UPD040 and UPD043 triggered by python version upgrade

Remove workarounds not needed after upgrade