### PR TITLE
Replace pkg_resources with pathlib and importlib.resources

### DIFF
--- a/src/eduid/maccapi/testing.py
+++ b/src/eduid/maccapi/testing.py
@@ -1,8 +1,8 @@
 import os
 import unittest
+from pathlib import Path
 from typing import Any, cast
 
-import pkg_resources
 from starlette.testclient import TestClient
 
 from eduid.common.config.parsers import load_config
@@ -59,7 +59,7 @@ class MAccApiTestCase(BaseDBTestCase):
         if "EDUID_CONFIG_YAML" not in os.environ:
             os.environ["EDUID_CONFIG_YAML"] = "YAML_CONFIG_NOT_USED"
 
-        self.datadir = pkg_resources.resource_filename(__name__, "tests/data")
+        self.datadir = str(Path(__file__).parent / "tests/data")
         self.test_config = self._get_config()
         config = load_config(typ=MAccApiConfig, app_name="maccapi", ns="api", test_config=self.test_config)
         self.context = Context(config=config)

--- a/src/eduid/scimapi/testing.py
+++ b/src/eduid/scimapi/testing.py
@@ -4,9 +4,9 @@ import uuid
 from collections.abc import Mapping
 from dataclasses import asdict
 from json import JSONDecodeError
+from pathlib import Path
 from typing import Any
 
-import pkg_resources
 from bson import ObjectId
 from httpx import Response
 from starlette.testclient import TestClient
@@ -98,7 +98,7 @@ class ScimApiTestCase(MongoNeoTestCase):
         if "EDUID_CONFIG_YAML" not in os.environ:
             os.environ["EDUID_CONFIG_YAML"] = "YAML_CONFIG_NOT_USED"
 
-        self.datadir = pkg_resources.resource_filename(__name__, "tests/data")
+        self.datadir = str(Path(__file__).parent / "tests/data")
         self.test_config = self._get_config()
         config = load_config(typ=ScimApiConfig, app_name="scimapi", ns="api", test_config=self.test_config)
         self.context = Context(config=config)

--- a/src/eduid/webapp/common/api/translation.py
+++ b/src/eduid/webapp/common/api/translation.py
@@ -1,4 +1,5 @@
-import pkg_resources
+from importlib.resources import files
+
 from flask import current_app, request
 from flask_babel import Babel
 
@@ -35,7 +36,7 @@ def init_babel(app: EduIDBaseApp) -> Babel:
     assert isinstance(_conf, EduIDBaseAppConfig)
     conf_translations_dirs = ";".join(_conf.flask.babel_translation_directories)
     # Add pkg_resource path to translation directory as the default location does not work
-    pkg_translations_dir = pkg_resources.resource_filename("eduid.webapp", "translations")
+    pkg_translations_dir = str(files("eduid.webapp") / "translations")
     translations_directories = f"{conf_translations_dirs};{pkg_translations_dir}"
     app.logger.info(f"Translation directories: {[path for path in translations_directories.split(';')]}")
     app.config["BABEL_TRANSLATION_DIRECTORIES"] = translations_directories

--- a/src/eduid/workers/amapi/testing.py
+++ b/src/eduid/workers/amapi/testing.py
@@ -1,7 +1,7 @@
 import json
+from pathlib import Path
 from typing import Any
 
-import pkg_resources
 from fastapi.testclient import TestClient
 
 from eduid.common.models.amapi_user import Reason, Source
@@ -15,7 +15,7 @@ class TestAMBase(CommonTestCase):
     def setUp(self, config: SetupConfig | None = None) -> None:
         super().setUp(config=config)
 
-        self.path = pkg_resources.resource_filename(__name__, "tests/data")
+        self.path = str(Path(__file__).parent / "tests/data")
         self.test_config = self._get_config()
         self.test_singing_key = "testing-amapi-2106210000"
 

--- a/src/eduid/workers/job_runner/testing.py
+++ b/src/eduid/workers/job_runner/testing.py
@@ -1,7 +1,6 @@
 import os
 import unittest
-
-import pkg_resources
+from pathlib import Path
 
 from eduid.userdb.testing import MongoTemporaryInstance
 from eduid.userdb.user_cleaner.db import CleanerQueueDB
@@ -34,7 +33,7 @@ class CleanerQueueTestCase(BaseDBTestCase):
         if "EDUID_CONFIG_YAML" not in os.environ:
             os.environ["EDUID_CONFIG_YAML"] = "YAML_CONFIG_NOT_USED"
 
-        self.datadir = pkg_resources.resource_filename(__name__, "tests/data")
+        self.datadir = str(Path(__file__).parent / "tests/data")
 
         self.cleaner_queue_db = CleanerQueueDB(db_uri=self.mongo_uri)
 


### PR DESCRIPTION
Refactor the code to eliminate the use of `pkg_resources` by replacing it with `pathlib` and `importlib.resources`.