### PR TITLE
Replace HttpUrlStr with HttpUrl

### DIFF
--- a/src/eduid/common/models/generic.py
+++ b/src/eduid/common/models/generic.py
@@ -1,16 +1,15 @@
-from typing import Annotated, Any
+from typing import Any
 
 from bson import ObjectId
 from jwcrypto.common import JWException
 from jwcrypto.jwk import JWK
-from pydantic import AnyUrl, GetCoreSchemaHandler, GetJsonSchemaHandler, HttpUrl
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, HttpUrl, TypeAdapter
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 
 __author__ = "lundberg"
 
-AnyUrlStr = Annotated[str, AnyUrl]
-HttpUrlStr = Annotated[str, HttpUrl]
+HttpUrlAdapter = TypeAdapter(HttpUrl)
 
 
 # https://docs.pydantic.dev/2.6/concepts/types/#handling-third-party-types

--- a/src/eduid/webapp/authn/settings/common.py
+++ b/src/eduid/webapp/authn/settings/common.py
@@ -1,5 +1,7 @@
+from pydantic import HttpUrl
+
 from eduid.common.config.base import EduIDBaseAppConfig, ErrorsConfigMixin, FrontendActionMixin, Pysaml2SPConfigMixin
-from eduid.common.models.generic import HttpUrlStr
+from eduid.common.models.generic import HttpUrlAdapter
 
 
 class AuthnConfig(EduIDBaseAppConfig, ErrorsConfigMixin, Pysaml2SPConfigMixin, FrontendActionMixin):
@@ -9,9 +11,9 @@ class AuthnConfig(EduIDBaseAppConfig, ErrorsConfigMixin, Pysaml2SPConfigMixin, F
 
     app_name: str = "authn"
     server_name: str = "authn"
-    signup_authn_success_redirect_url: HttpUrlStr = "https://eduid.se/profile/"
-    signup_authn_failure_redirect_url: HttpUrlStr = "https://eduid.se/profile/"
-    fallback_frontend_action_redirect_url: HttpUrlStr = "https://eduid.se/profile/"
+    signup_authn_success_redirect_url: HttpUrl = HttpUrlAdapter.validate_python("https://eduid.se/profile/")
+    signup_authn_failure_redirect_url: HttpUrl = HttpUrlAdapter.validate_python("https://eduid.se/profile/")
+    fallback_frontend_action_redirect_url: HttpUrl = HttpUrlAdapter.validate_python("https://eduid.se/profile/")
     saml2_login_redirect_url: str
     saml2_logout_redirect_url: str
     saml2_strip_saml_user_suffix: str

--- a/src/eduid/webapp/idp/login.py
+++ b/src/eduid/webapp/idp/login.py
@@ -282,7 +282,7 @@ class SSO(Service):
 
         if info.SAMLRequest:
             # redirect user to the Login javascript bundle
-            loc = urlappend(current_app.conf.login_bundle_url, ticket.request_ref)
+            loc = urlappend(str(current_app.conf.login_bundle_url), ticket.request_ref)
             current_app.logger.info(f"Redirecting user to login bundle {loc}")
             return redirect(loc)
         else:

--- a/src/eduid/webapp/idp/other_device/device1.py
+++ b/src/eduid/webapp/idp/other_device/device1.py
@@ -127,7 +127,7 @@ def device1_state_to_flux_payload(state: OtherDevice, now: datetime) -> Mapping[
     if state.state in [OtherDeviceState.NEW, OtherDeviceState.IN_PROGRESS, OtherDeviceState.AUTHENTICATED]:
         # Only add QR code when it will actually be displayed
         buf = BytesIO()
-        qr_url = urlappend(current_app.conf.other_device_url, encrypted_state_id)
+        qr_url = urlappend(str(current_app.conf.other_device_url), encrypted_state_id)
         qrcode.make(qr_url).save(buf)
         qr_b64 = base64.b64encode(buf.getvalue())
 

--- a/src/eduid/webapp/idp/settings/common.py
+++ b/src/eduid/webapp/idp/settings/common.py
@@ -4,7 +4,7 @@ Configuration (file) handling for the eduID idp app.
 
 from datetime import timedelta
 
-from pydantic import Field, field_validator
+from pydantic import Field, HttpUrl, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from eduid.common.config.base import (
@@ -14,7 +14,7 @@ from eduid.common.config.base import (
     TouConfigMixin,
     WebauthnConfigMixin2,
 )
-from eduid.common.models.generic import HttpUrlStr
+from eduid.common.models.generic import HttpUrlAdapter
 from eduid.userdb.identity import IdentityProofingMethod
 from eduid.webapp.idp.assurance_data import SwamidAssurance
 
@@ -87,8 +87,8 @@ class IdPConfig(EduIDBaseAppConfig, TouConfigMixin, WebauthnConfigMixin2, AmConf
     eduperson_targeted_id_secret_key: str = ""
     pairwise_id_secret_key: str = ""
     eduid_site_url: str
-    login_bundle_url: HttpUrlStr | None = None
-    other_device_url: HttpUrlStr | None = None
+    login_bundle_url: HttpUrl | None = None
+    other_device_url: HttpUrl | None = None
     esi_ladok_prefix: str = Field(default="urn:schac:personalUniqueCode:int:esi:ladok.se:externtstudentuid-")
     allow_other_device_logins: bool = False
     other_device_logins_ttl: timedelta = Field(default=timedelta(minutes=2))
@@ -103,7 +103,7 @@ class IdPConfig(EduIDBaseAppConfig, TouConfigMixin, WebauthnConfigMixin2, AmConf
     # secret key for encrypting personal information for geo-location service
     geo_statistics_secret_key: str | None = None
     geo_statistics_feature_enabled: bool = False
-    geo_statistics_url: HttpUrlStr | None = None
+    geo_statistics_url: HttpUrl | None = None
     swamid_assurance_profile_1: list[SwamidAssurance] = Field(
         default=[
             SwamidAssurance.SWAMID_AL1,
@@ -140,11 +140,17 @@ class IdPConfig(EduIDBaseAppConfig, TouConfigMixin, WebauthnConfigMixin2, AmConf
             SwamidAssurance.REFEDS_IAP_HIGH,
         ]
     )
-    logout_finish_url: dict[str, HttpUrlStr] = Field(
+    logout_finish_url: dict[str, HttpUrl] = Field(
         default={
-            "https://dashboard.eduid.docker/services/authn/saml2-metadata": "https://dashboard.eduid.docker/profile/",
-            "https://dashboard.dev.eduid.se/services/authn/saml2-metadata": "https://dev.eduid.se/",
-            "https://dashboard.eduid.se/services/authn/saml2-metadata": "https://eduid.se/",
+            "https://dashboard.eduid.docker/services/authn/saml2-metadata": HttpUrlAdapter.validate_python(
+                "https://dashboard.eduid.docker/profile/"
+            ),
+            "https://dashboard.dev.eduid.se/services/authn/saml2-metadata": HttpUrlAdapter.validate_python(
+                "https://dev.eduid.se/"
+            ),
+            "https://dashboard.eduid.se/services/authn/saml2-metadata": HttpUrlAdapter.validate_python(
+                "https://eduid.se/"
+            ),
         }
     )
     digg_loa2_allowed_identity_proofing_methods: list[IdentityProofingMethod] = Field(

--- a/src/eduid/webapp/idp/tests/test_login.py
+++ b/src/eduid/webapp/idp/tests/test_login.py
@@ -9,6 +9,7 @@ from requests import RequestException
 from saml2.client import Saml2Client
 
 from eduid.common.misc.timeutil import utc_now
+from eduid.common.models.generic import HttpUrlAdapter
 from eduid.common.models.saml2 import EduidAuthnContextClass
 from eduid.userdb import MailAddress
 from eduid.userdb.credentials import Password
@@ -609,7 +610,7 @@ class IdPTestLoginAPI(IdPAPITests):
 
         # enable geo statistics
         self.app.conf.geo_statistics_feature_enabled = True
-        self.app.conf.geo_statistics_url = "http://eduid.docker"
+        self.app.conf.geo_statistics_url = HttpUrlAdapter.validate_python("http://eduid.docker")
 
         # Patch the VCCSClient, so we do not need a vccs server
         with patch.object(VCCSClient, "authenticate") as mock_vccs:
@@ -648,7 +649,7 @@ class IdPTestLoginAPI(IdPAPITests):
 
         # enable geo statistics
         self.app.conf.geo_statistics_feature_enabled = True
-        self.app.conf.geo_statistics_url = "http://eduid.docker"
+        self.app.conf.geo_statistics_url = HttpUrlAdapter.validate_python("http://eduid.docker")
 
         # Patch the VCCSClient, so we do not need a vccs server
         with patch.object(VCCSClient, "authenticate") as mock_vccs:
@@ -881,7 +882,7 @@ class IdPTestLoginAPIManagedAccounts(IdPAPITests):
     def test_geo_statistics_success(self) -> None:
         # enable geo statistics
         self.app.conf.geo_statistics_feature_enabled = True
-        self.app.conf.geo_statistics_url = "http://eduid.docker"
+        self.app.conf.geo_statistics_url = HttpUrlAdapter.validate_python("http://eduid.docker")
 
         # Patch the VCCSClient, so we do not need a vccs server
         with patch.object(VCCSClient, "authenticate") as mock_vccs:
@@ -917,7 +918,7 @@ class IdPTestLoginAPIManagedAccounts(IdPAPITests):
     def test_geo_statistics_fail(self) -> None:
         # enable geo statistics
         self.app.conf.geo_statistics_feature_enabled = True
-        self.app.conf.geo_statistics_url = "http://eduid.docker"
+        self.app.conf.geo_statistics_url = HttpUrlAdapter.validate_python("http://eduid.docker")
 
         # Patch the VCCSClient, so we do not need a vccs server
         with patch.object(VCCSClient, "authenticate") as mock_vccs:

--- a/src/eduid/webapp/idp/views/next.py
+++ b/src/eduid/webapp/idp/views/next.py
@@ -435,7 +435,7 @@ def _geo_statistics(ticket: LoginContext, sso_session: SSOSession | None) -> Non
     data["user_agent"]["sophisticated"]["is_touch_capable"] = ua.parsed.is_touch_capable
 
     try:
-        resp = requests.post(current_app.conf.geo_statistics_url, json=d, timeout=1)
+        resp = requests.post(str(current_app.conf.geo_statistics_url), json=d, timeout=1)
         current_app.logger.debug(f"response from geo-statistics app: {resp.json}")
     except requests.RequestException:
         current_app.logger.exception("Failed to contact geo-statistics app")

--- a/src/eduid/webapp/jsconfig/settings/jsapps.py
+++ b/src/eduid/webapp/jsconfig/settings/jsapps.py
@@ -1,7 +1,6 @@
-from pydantic import Field
+from pydantic import Field, HttpUrl
 
 from eduid.common.config.base import EduidEnvironment, PasswordConfigMixin
-from eduid.common.models.generic import HttpUrlStr
 
 
 class JsAppsConfig(PasswordConfigMixin):
@@ -13,42 +12,42 @@ class JsAppsConfig(PasswordConfigMixin):
 
     available_languages: dict[str, str] = Field(default={"en": "English", "sv": "Svenska"})
     csrf_token: str | None = None
-    dashboard_link: HttpUrlStr
+    dashboard_link: HttpUrl
     debug: bool = False
-    eduid_site_link: HttpUrlStr = Field(default=HttpUrlStr("https://eduid.se"))
+    eduid_site_link: HttpUrl = Field(default=HttpUrl("https://eduid.se"))
     eduid_site_name: str = "eduID"
     environment: EduidEnvironment = EduidEnvironment.production
-    faq_link: HttpUrlStr
+    faq_link: HttpUrl
     # reset_password_link is used for directing a user to the reset password app
-    reset_password_link: HttpUrlStr
+    reset_password_link: HttpUrl
     sentry_dsn: str | None = None
-    signup_link: HttpUrlStr
+    signup_link: HttpUrl
     # backend endpoint urls
-    authn_service_url: HttpUrlStr
-    bankid_service_url: HttpUrlStr
-    eidas_service_url: HttpUrlStr
-    emails_service_url: HttpUrlStr
+    authn_service_url: HttpUrl
+    bankid_service_url: HttpUrl
+    eidas_service_url: HttpUrl
+    emails_service_url: HttpUrl
     # error_info_url needs to be a full URL since the backend is on the idp, not on https://eduid.se
-    error_info_url: HttpUrlStr | None = None
-    freja_eid_service_url: HttpUrlStr | None = None
-    group_mgmt_service_url: HttpUrlStr
-    ladok_service_url: HttpUrlStr
-    letter_proofing_service_url: HttpUrlStr
+    error_info_url: HttpUrl | None = None
+    freja_eid_service_url: HttpUrl | None = None
+    group_mgmt_service_url: HttpUrl
+    ladok_service_url: HttpUrl
+    letter_proofing_service_url: HttpUrl
     # login_next_url needs to be a full URL since the backend is on the idp, not on https://eduid.se
-    login_next_url: HttpUrlStr
+    login_next_url: HttpUrl
     # login_request_other_url needs to be a full URL since the backend is on the idp, not on https://eduid.se
-    login_request_other_url: HttpUrlStr | None = None
-    login_service_url: HttpUrlStr
-    lookup_mobile_proofing_service_url: HttpUrlStr
-    orcid_service_url: HttpUrlStr
-    personal_data_service_url: HttpUrlStr
-    phone_service_url: HttpUrlStr
-    reset_password_service_url: HttpUrlStr
-    security_service_url: HttpUrlStr
-    signup_service_url: HttpUrlStr
-    svipe_service_url: HttpUrlStr | None = None  # if not set the frontend component will not show
+    login_request_other_url: HttpUrl | None = None
+    login_service_url: HttpUrl
+    lookup_mobile_proofing_service_url: HttpUrl
+    orcid_service_url: HttpUrl
+    personal_data_service_url: HttpUrl
+    phone_service_url: HttpUrl
+    reset_password_service_url: HttpUrl
+    security_service_url: HttpUrl
+    signup_service_url: HttpUrl
+    svipe_service_url: HttpUrl | None = None  # if not set the frontend component will not show
     # Dashboard config
     default_country_code: int = 46
-    token_verify_idp: HttpUrlStr
+    token_verify_idp: HttpUrl
     # Signup config
     tous: dict[str, str] | None = None

--- a/src/eduid/webapp/jsconfig/views.py
+++ b/src/eduid/webapp/jsconfig/views.py
@@ -16,7 +16,7 @@ def get_config() -> FluxData:
     Configuration for the dashboard front app
     """
 
-    config_dict = current_app.conf.jsapps.model_dump()
+    config_dict = current_app.conf.jsapps.model_dump(mode="json")
     config_dict["csrf_token"] = session.get_csrf_token()
 
     return success_response(payload=config_dict)

--- a/src/eduid/webapp/ladok/client.py
+++ b/src/eduid/webapp/ladok/client.py
@@ -4,12 +4,11 @@ from datetime import datetime
 from http import HTTPStatus
 
 import requests
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, ValidationError
 
 __author__ = "lundberg"
 
 from eduid.common.config.base import EduidEnvironment
-from eduid.common.models.generic import HttpUrlStr
 from eduid.common.utils import urlappend
 
 logger = logging.getLogger(__name__)
@@ -55,7 +54,7 @@ class LadokUserInfoResponse(LadokBaseModel):
 
 
 class LadokClientConfig(LadokBaseModel):
-    url: HttpUrlStr
+    url: HttpUrl
     version: str = "v1"
     dev_universities: dict[str, UniversityName] | None = None  # used for local development
 
@@ -69,7 +68,7 @@ class LadokClient:
     def __init__(self, config: LadokClientConfig, env: EduidEnvironment) -> None:
         self.config = config
         self.env = env
-        self.base_endpoint = urlappend(self.config.url, f"/api/{self.config.version}")
+        self.base_endpoint = urlappend(str(self.config.url), f"/api/{self.config.version}")
         self.universities = self.load_universities()
 
     def load_universities(self) -> Mapping[str, University]:

--- a/src/eduid/webapp/orcid/helpers.py
+++ b/src/eduid/webapp/orcid/helpers.py
@@ -1,8 +1,7 @@
 from enum import unique
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, HttpUrl
 
-from eduid.common.models.generic import HttpUrlStr
 from eduid.webapp.common.api.messages import TranslatableMsg
 
 
@@ -28,7 +27,7 @@ class OrcidMsg(TranslatableMsg):
 
 
 class OrcidUserinfo(BaseModel):
-    orcid: HttpUrlStr = Field(alias="id")
+    orcid: HttpUrl = Field(alias="id")
     sub: str
     name: str | None = None
     family_name: str

--- a/src/eduid/webapp/signup/app.py
+++ b/src/eduid/webapp/signup/app.py
@@ -41,7 +41,9 @@ class SignupApp(EduIDBaseApp):
         if data_owner not in self.scim_clients:
             access_request = [{"type": "scim-api", "scope": data_owner}]
             client_auth_data = self.conf.gnap_auth_data.copy(update={"access": access_request})
-            self.scim_clients[data_owner] = SCIMClient(scim_api_url=self.conf.scim_api_url, auth_data=client_auth_data)
+            self.scim_clients[data_owner] = SCIMClient(
+                scim_api_url=str(self.conf.scim_api_url), auth_data=client_auth_data
+            )
         return self.scim_clients[data_owner]
 
 

--- a/src/eduid/webapp/signup/settings/common.py
+++ b/src/eduid/webapp/signup/settings/common.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from pydantic import Field
+from pydantic import AnyUrl, Field
 
 from eduid.common.clients.gnap_client.base import GNAPClientAuthData
 from eduid.common.config.base import (
@@ -12,7 +12,6 @@ from eduid.common.config.base import (
     PasswordConfigMixin,
     TouConfigMixin,
 )
-from eduid.common.models.generic import AnyUrlStr
 
 
 class SignupConfig(
@@ -43,7 +42,7 @@ class SignupConfig(
     default_finish_url: str = "https://www.eduid.se/"
     eduid_site_url: str = "https://www.eduid.se"  # TODO: Backwards compatibility, remove when no longer used
     eduid_site_name: str = "eduID"
-    scim_api_url: AnyUrlStr | None = None
+    scim_api_url: AnyUrl | None = None
     gnap_auth_data: GNAPClientAuthData | None = None
     eduid_scope: str = "eduid.se"
     private_userdb_auto_expire: timedelta | None = Field(default=timedelta(days=7))


### PR DESCRIPTION
Update the codebase to replace instances of `HttpUrlStr` with `HttpUrl`, ensuring consistency in URL handling across the application. This change enhances type safety and aligns with the latest Pydantic standards.