### PR TITLE
Simplify type parameter names

### DIFF
--- a/src/eduid/common/config/parsers/__init__.py
+++ b/src/eduid/common/config/parsers/__init__.py
@@ -15,12 +15,7 @@ from eduid.common.config.parsers.base import BaseConfigParser
 from eduid.common.config.parsers.exceptions import ParserException
 
 
-def load_config[TRootConfigSubclass: RootConfig](
-    typ: type[TRootConfigSubclass],
-    ns: str,
-    app_name: str,
-    test_config: Mapping[str, Any] | None = None,
-) -> TRootConfigSubclass:
+def load_config[T: RootConfig](typ: type[T], ns: str, app_name: str, test_config: Mapping[str, Any] | None = None) -> T:
     """Figure out where to load configuration from, and do it."""
     print("loading config...", file=sys.stderr)
     app_path = os.environ.get("EDUID_CONFIG_NS", f"/eduid/{ns}/{app_name}/")

--- a/src/eduid/common/proofing_utils.py
+++ b/src/eduid/common/proofing_utils.py
@@ -51,9 +51,7 @@ def get_marked_given_name(given_name: str, given_name_marking: str | None) -> st
         return " ".join(_marked_names)
 
 
-def set_user_names_from_official_address[TUserSubclass: User](
-    user: TUserSubclass, proofing_log_entry: NinNavetProofingLogElement
-) -> TUserSubclass:
+def set_user_names_from_official_address[T: User](user: T, proofing_log_entry: NinNavetProofingLogElement) -> T:
     """
     :param user: Proofing app private userdb user
     :param proofing_log_entry: Proofing log entry element

--- a/src/eduid/common/rpc/worker.py
+++ b/src/eduid/common/rpc/worker.py
@@ -3,9 +3,7 @@ from eduid.common.config.parsers import load_config
 from eduid.common.config.workers import WorkerConfig
 
 
-def get_worker_config[TWorkerConfigSubclass: WorkerConfig](
-    name: str, config_class: type[TWorkerConfigSubclass]
-) -> TWorkerConfigSubclass:
+def get_worker_config[T: WorkerConfig](name: str, config_class: type[T]) -> T:
     """
     Load configuration for a worker.
 

--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -295,9 +295,7 @@ class ElementList[ListElement: Element](BaseModel, ABC):
         return values
 
     @classmethod
-    def from_list_of_dicts[TElementList: ElementList](
-        cls: type[TElementList], items: list[dict[str, Any]]
-    ) -> TElementList:
+    def from_list_of_dicts[T: ElementList](cls: type[T], items: list[dict[str, Any]]) -> T:
         # must be implemented by subclass to get correct type information
         raise NotImplementedError()
 

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -246,7 +246,7 @@ class User(BaseModel):
         return data
 
     @classmethod
-    def from_user[TUserSubclass: User](cls: type[TUserSubclass], user: User, private_userdb: BaseDB) -> TUserSubclass:
+    def from_user[T: User](cls: type[T], user: User, private_userdb: BaseDB) -> T:
         """
         This function is only expected to be used with subclasses of User.
 
@@ -258,7 +258,7 @@ class User(BaseModel):
         # We cast here to avoid importing UserDB at the module level thus creating a circular import
         from eduid.userdb import UserDB
 
-        private_userdb = cast(UserDB[TUserSubclass], private_userdb)
+        private_userdb = cast(UserDB[T], private_userdb)
 
         try:
             private_user = private_userdb.get_user_by_eppn(user.eppn)

--- a/src/eduid/webapp/common/api/decorators.py
+++ b/src/eduid/webapp/common/api/decorators.py
@@ -79,7 +79,7 @@ def require_not_logged_in(f: EduidRouteCallable) -> EduidRouteCallable:
     return require_eppn_decorator
 
 
-def require_user[TRequireUserResult](f: Callable[..., TRequireUserResult]) -> Callable[..., TRequireUserResult]:
+def require_user[T](f: Callable[..., T]) -> Callable[..., T]:
     """
     Decorator for functions that require a *logged in* user.
 
@@ -89,7 +89,7 @@ def require_user[TRequireUserResult](f: Callable[..., TRequireUserResult]) -> Ca
     """
 
     @wraps(f)
-    def require_user_decorator(*args: Any, **kwargs: Any) -> TRequireUserResult:
+    def require_user_decorator(*args: Any, **kwargs: Any) -> T:
         user = get_user()
         kwargs["user"] = user
         return f(*args, **kwargs)

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -28,10 +28,10 @@ from eduid.webapp.common.api.utils import get_from_current_app, get_reference_ni
 __author__ = "lundberg"
 
 
-def set_user_names_from_nin_proofing[TUserSubclass: User](
-    user: TUserSubclass,
+def set_user_names_from_nin_proofing[T: User](
+    user: T,
     proofing_log_entry: NinProofingLogElement,
-) -> TUserSubclass:
+) -> T:
     if isinstance(proofing_log_entry, NinNavetProofingLogElement):
         user = set_user_names_from_official_address(user, proofing_log_entry)
     elif isinstance(proofing_log_entry, NinEIDProofingLogElement):
@@ -41,9 +41,7 @@ def set_user_names_from_nin_proofing[TUserSubclass: User](
     return user
 
 
-def set_user_names_from_nin_eid_proofing[TUserSubclass: User](
-    user: TUserSubclass, proofing_log_entry: NinEIDProofingLogElement
-) -> TUserSubclass:
+def set_user_names_from_nin_eid_proofing[T: User](user: T, proofing_log_entry: NinEIDProofingLogElement) -> T:
     user.given_name = proofing_log_entry.given_name
     user.surname = proofing_log_entry.surname
     user.legal_name = f"{proofing_log_entry.given_name} {proofing_log_entry.surname}"
@@ -52,9 +50,7 @@ def set_user_names_from_nin_eid_proofing[TUserSubclass: User](
     return user
 
 
-def set_user_names_from_foreign_id[TUserSubclass: User](
-    user: TUserSubclass, proofing_log_entry: ForeignIdProofingLogElement
-) -> TUserSubclass:
+def set_user_names_from_foreign_id[T: User](user: T, proofing_log_entry: ForeignIdProofingLogElement) -> T:
     """
     :param user: Proofing app private userdb user
     :param proofing_log_entry: Proofing log entry element
@@ -93,9 +89,7 @@ def add_nin_to_user(user: User, proofing_state: NinProofingState) -> ProofingUse
 
 
 @overload
-def add_nin_to_user[TProofingUser: User](
-    user: User, proofing_state: NinProofingState, user_type: type[TProofingUser]
-) -> TProofingUser: ...
+def add_nin_to_user[T: User](user: User, proofing_state: NinProofingState, user_type: type[T]) -> T: ...
 
 
 def add_nin_to_user(user, proofing_state, user_type=ProofingUser):

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -88,14 +88,14 @@ TEST_CONFIG = {
 }
 
 
-class EduidAPITestCase[TTestAppVar: EduIDBaseApp](CommonTestCase):
+class EduidAPITestCase[T: EduIDBaseApp](CommonTestCase):
     """
     Base Test case for eduID APIs.
 
     See the `load_app` and `update_config` methods below before subclassing.
     """
 
-    app: TTestAppVar
+    app: T
     browser: CSRFTestClient
 
     def setUp(self, config: SetupConfig | None = None) -> None:
@@ -164,7 +164,7 @@ class EduidAPITestCase[TTestAppVar: EduIDBaseApp](CommonTestCase):
         super(CommonTestCase, self).tearDown()
         # XXX reset redis
 
-    def load_app(self, config: dict[str, Any]) -> TTestAppVar:
+    def load_app(self, config: dict[str, Any]) -> T:
         """
         Method that must be implemented by any subclass, where the
         flask app must be imported and returned.

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -30,7 +30,7 @@ else:
 logger = logging.getLogger(__name__)
 
 
-def get_from_current_app[TCurrentAppAttribute](name: str, klass: type[TCurrentAppAttribute]) -> TCurrentAppAttribute:
+def get_from_current_app[T](name: str, klass: type[T]) -> T:
     """Get a correctly typed attribute from an unknown Flask current app"""
     ret = getattr(current_app, name)
     if not isinstance(ret, klass):
@@ -38,7 +38,7 @@ def get_from_current_app[TCurrentAppAttribute](name: str, klass: type[TCurrentAp
         conf = getattr(current_app, "conf")
         if isinstance(conf, EduIDBaseAppConfig) and conf.testing:
             if isinstance(ret, MagicMock):
-                return cast(TCurrentAppAttribute, ret)
+                return cast(T, ret)
         raise TypeError(f"current_app.{name} is not of type {klass} (is {type(ret)}")
     return ret
 

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -11,7 +11,7 @@ from eduid.webapp.common.api.testing import CSRFTestClient, EduidAPITestCase, lo
 __author__ = "lundberg"
 
 
-class ProofingTests[TTestAppVar: EduIDBaseApp](EduidAPITestCase[TTestAppVar]):
+class ProofingTests[T: EduIDBaseApp](EduidAPITestCase[T]):
     def _verify_status(
         self,
         finish_url: str,

--- a/src/eduid/webapp/support/helpers.py
+++ b/src/eduid/webapp/support/helpers.py
@@ -31,11 +31,9 @@ def get_credentials_aux_data(user: User) -> list[TUserDbDocument]:
     return credentials
 
 
-def require_support_personnel[TRequireSupportPersonnelResult](
-    f: Callable[..., TRequireSupportPersonnelResult],
-) -> Callable[..., TRequireSupportPersonnelResult]:
+def require_support_personnel[T](f: Callable[..., T]) -> Callable[..., T]:
     @wraps(f)
-    def require_support_decorator(*args: Any, **kwargs: Any) -> TRequireSupportPersonnelResult:
+    def require_support_decorator(*args: Any, **kwargs: Any) -> T:
         user = get_user()
         # If the logged in user is whitelisted then we
         # pass on the request to the decorated view
@@ -50,11 +48,9 @@ def require_support_personnel[TRequireSupportPersonnelResult](
     return require_support_decorator
 
 
-def require_login_with_mfa[TRequireLoginWithMFAResult](
-    f: Callable[..., TRequireLoginWithMFAResult],
-) -> Callable[..., TRequireLoginWithMFAResult | WerkzeugResponse]:
+def require_login_with_mfa[T](f: Callable[..., T]) -> Callable[..., T | WerkzeugResponse]:
     @wraps(f)
-    def require_login_with_mfa_decorator(*args: Any, **kwargs: Any) -> TRequireLoginWithMFAResult | WerkzeugResponse:
+    def require_login_with_mfa_decorator(*args: Any, **kwargs: Any) -> T | WerkzeugResponse:
         if has_user_logged_in_with_mfa():
             return f(*args, **kwargs)
         resp = WerkzeugResponse("OK", 200)


### PR DESCRIPTION
Refactor type parameter names across various functions and classes for improved clarity and consistency. This change enhances code readability without altering functionality.