### PR TITLE
Fix session typing

### DIFF
--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import pprint
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -66,7 +66,7 @@ class EduidNamespaces(BaseModel):
     freja_eid: FrejaEIDNamespace | None = None
 
 
-class EduidSession[VT](SessionMixin, MutableMapping[str, VT]):
+class EduidSession(SessionMixin):
     """
     Session implementing the flask.sessions.SessionMixin interface.
 
@@ -131,10 +131,10 @@ class EduidSession[VT](SessionMixin, MutableMapping[str, VT]):
             f"modified={self.modified}, cookie={self.short_id}>"
         )
 
-    def __getitem__(self, key: str) -> VT | str | None:
+    def __getitem__(self, key: str) -> object:
         return self._session.__getitem__(key)
 
-    def __setitem__(self, key: str, value: VT | str | None) -> None:
+    def __setitem__(self, key: str, value: object) -> None:
         if key not in self._session or self._session[key] != value:
             self._session[key] = value
             logger.debug(f"SET {self}[{key}] = {value}")

--- a/src/eduid/webapp/common/session/redis_session.py
+++ b/src/eduid/webapp/common/session/redis_session.py
@@ -154,7 +154,7 @@ class SessionOutOfSync(Exception):
     pass
 
 
-class RedisEncryptedSession[VT](typing.MutableMapping[str, VT]):
+class RedisEncryptedSession(typing.MutableMapping[str, Any]):
     """
     Session objects that keep their data in a redis db.
     """
@@ -199,18 +199,18 @@ class RedisEncryptedSession[VT](typing.MutableMapping[str, VT]):
 
         self.secret_box = nacl.secret.SecretBox(encryption_key)
 
-        self._data: dict[str, VT] = {}
+        self._data: dict[str, Any] = {}
 
     def __str__(self) -> str:
         # Include hex(id(self)) for now to troubleshoot clobbered sessions
         return f"<{self.__class__.__name__} at {hex(id(self))}: db_key={self.short_id}>"
 
-    def __getitem__(self, key: str) -> VT:
+    def __getitem__(self, key: str) -> object:
         if key in self._data:
             return self._data[key]
         raise KeyError(f"Key {repr(key)} not present in session")
 
-    def __setitem__(self, key: str, value: VT) -> None:
+    def __setitem__(self, key: str, value: object) -> None:
         if self.whitelist and key not in self.whitelist:
             if self.raise_on_unknown:
                 raise ValueError(f"Key {repr(key)} not allowed in session")


### PR DESCRIPTION
# Fix session typing to resolve Liskov Substitution Principle violation

## Problem

The `ty` type checker reported an `invalid-method-override` error:

```
error[invalid-method-override]: Invalid override of method `__getitem__`
    --> src/eduid/webapp/common/session/eduid_session.py:134:9

    def __getitem__(self, key: str) -> VT | str | None:
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Mapping.__getitem__`

info: This violates the Liskov Substitution Principle
```

The issue was that `EduidSession[VT]` inherited from `MutableMapping[str, VT]`, but its `__getitem__` method returned `VT | str | None` instead of just `VT`, violating the Liskov Substitution Principle.

## Solution

### Changes to `EduidSession`

- **Removed explicit `MutableMapping[str, VT]` from inheritance** — `SessionMixin` already inherits from `MutableMapping` (as of recent Flask versions), so the explicit inheritance is no longer needed
- **Removed the generic type parameter `[VT]`** — The generic wasn't providing real type safety since session data is heterogeneous JSON, and the return type `VT | str | None` was incompatible with `MutableMapping`'s expected `VT`
- **Changed `__getitem__` and `__setitem__` types to `object`** — This is more type-safe than `Any` while being honest about the dynamic nature of session data

### Changes to `RedisEncryptedSession`

- **Removed the generic type parameter `[VT]`** — Aligned with `EduidSession` changes
- **Changed to `MutableMapping[str, Any]`** — The internal storage uses `Any` since data comes from JSON deserialization
- **Changed `__getitem__` return type to `object`** — Matches the public interface

## Why `object` instead of `Any`?

- `object` is type-safe (top of the type hierarchy) while `Any` opts out of type checking
- Callers must narrow the type before using the value, which is appropriate since direct `__getitem__` access should be rare
- The typed namespace properties (`.idp`, `.authn`, `.common`, etc.) provide properly typed access for normal usage
- Both `mypy` and `ty` pass with no errors, confirming all existing code handles this correctly

## Files Changed

- `src/eduid/webapp/common/session/eduid_session.py`
- `src/eduid/webapp/common/session/redis_session.py`
