### PR TITLE
Remove type: ignore comments and simplify type annotations

### DIFF
--- a/src/eduid/scimapi/utils.py
+++ b/src/eduid/scimapi/utils.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import time
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from jwcrypto import jwk
@@ -38,9 +38,9 @@ def filter_none[Filtered](x: Filtered) -> Filtered:
     Recursively removes key, value pairs or items that is None.
     """
     if isinstance(x, dict):
-        return {k: filter_none(v) for k, v in x.items() if v is not None}  # type: ignore[return-value]
+        return cast(Filtered, {k: filter_none(v) for k, v in x.items() if v is not None})
     elif isinstance(x, list):
-        return [filter_none(i) for i in x if x is not None]  # type: ignore[return-value]
+        return cast(Filtered, [filter_none(i) for i in x if x is not None])
 
     return x
 


### PR DESCRIPTION
# Description

This PR removes `type: ignore[return-value]` comments from two files by fixing the underlying type issues, and simplifies the type annotations in the decorators module.

## Changes

### 1. `src/eduid/webapp/common/api/decorators.py`

**Problem:** The `unmarshal_decorator` function had a `type: ignore[return-value]` comment with a note about not knowing how to check for `Awaitable[FluxData]`.

**Root cause:** Investigation revealed that no async views exist in the codebase. The `Awaitable` types were added speculatively when Flask 2.0 introduced async support, but were never used. This caused unnecessary type complexity and the type mismatch.

**Solution:**

1. **Removed `Awaitable` from type definitions** - Since there are no async views, the `Awaitable` variants were unnecessary

2. **Simplified type aliases:**
   - Removed intermediate `EduidViewResult` type alias  
   - Simplified `EduidViewReturnType` from complex union with `Awaitable` variants to just `FluxData | ResponseReturnValue`

3. **Removed import aliases** - Used direct imports since there are no name collisions:
   - `from flask.typing import ResponseReturnValue` (was aliased as `FlaskResponseReturnValue`)
   - `from werkzeug.wrappers import Response` (was aliased as `WerkzeugResponse`)
   - Removed `from flask.wrappers import Response as FlaskResponse` (redundant - `ResponseReturnValue` already covers all Response types via the sansio base class)

4. **Updated return types:**
   - `marshal_decorator` returns `Response`
   - `unmarshal_decorator` returns `ResponseReturnValue`

5. **Simplified isinstance check** - `isinstance(ret, Response)` instead of `isinstance(ret, WerkzeugResponse | FlaskResponse)`

6. **Removed workaround variable** - The `error_response: FlaskResponse = jsonify(...)` intermediate variable is no longer needed

### 2. `src/eduid/scimapi/utils.py`

**Problem:** The `filter_none` function uses a generic type parameter `Filtered`, but returning dict/list comprehensions wasn't recognized as returning `Filtered` by the type checker.

**Solution:** Use explicit `cast(Filtered, ...)` to tell the type checker that the comprehension results match the input type.

