### PR TITLE
Alex improve test docker 1

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,38 @@
+"""
+Root conftest.py - cleans up Docker test containers.
+
+Handles two scenarios:
+1. Session start: removes orphaned containers from previous interrupted runs.
+2. Keyboard interrupt (Ctrl+C / VS Code stop): immediately kills containers before the process exits.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def _remove_test_containers() -> None:
+    """Find and forcefully remove all test_* Docker containers."""
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "-a", "--filter", "name=test_", "--format", "{{.Names}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            containers = [c.strip() for c in result.stdout.strip().split("\n") if c.strip()]
+            if containers:
+                subprocess.run(["docker", "rm", "-f", *containers], capture_output=True, timeout=10)
+    except Exception:
+        pass
+
+
+def pytest_sessionstart(session):  # noqa: ANN001, ANN201
+    """Remove any orphaned test Docker containers from previous runs."""
+    _remove_test_containers()
+
+
+def pytest_keyboard_interrupt(excinfo):  # noqa: ANN001, ANN201
+    """Called on Ctrl+C / VS Code stop — immediately kill all test containers."""
+    _remove_test_containers()

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -16,6 +16,7 @@ def _remove_test_containers() -> None:
     try:
         result = subprocess.run(
             ["docker", "ps", "-a", "--filter", "name=test_", "--format", "{{.Names}}"],
+            check=False,
             capture_output=True,
             text=True,
             timeout=5,
@@ -23,7 +24,7 @@ def _remove_test_containers() -> None:
         if result.returncode == 0 and result.stdout.strip():
             containers = [c.strip() for c in result.stdout.strip().split("\n") if c.strip()]
             if containers:
-                subprocess.run(["docker", "rm", "-f", *containers], capture_output=True, timeout=10)
+                subprocess.run(["docker", "rm", "-f", *containers], check=False, capture_output=True, timeout=10)
     except Exception:
         pass
 

--- a/src/eduid/graphdb/testing.py
+++ b/src/eduid/graphdb/testing.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import random
 import unittest
 from collections.abc import Sequence
 from os import environ
@@ -10,6 +9,7 @@ from neo4j.exceptions import ServiceUnavailable
 
 from eduid.graphdb.db import Neo4jDB
 from eduid.userdb.testing import EduidTemporaryInstance
+from eduid.userdb.testing.temp_instance import _random_available_port
 
 __author__ = "lundberg"
 
@@ -39,9 +39,9 @@ class Neo4jTemporaryInstance(EduidTemporaryInstance):
     DEFAULT_PASSWORD = "testingtesting"
 
     def __init__(self, max_retry_seconds: int = 60, neo4j_version: str = NEO4J_VERSION) -> None:
-        self._http_port = random.randint(40000, 43000)
-        self._https_port = random.randint(44000, 46000)
-        self._bolt_port = random.randint(47000, 50000)
+        self._http_port = _random_available_port(40000, 43000)
+        self._https_port = _random_available_port(44000, 46000)
+        self._bolt_port = _random_available_port(47000, 50000)
         self._docker_name = f"test_neo4j_{self.bolt_port}"
         self._neo4j_version = neo4j_version
         self._host = "localhost"
@@ -53,7 +53,7 @@ class Neo4jTemporaryInstance(EduidTemporaryInstance):
         return [
             "docker",
             "run",
-            "--rm",
+            "--restart=always",
             "--name",
             f"{self._docker_name}",
             "-p",

--- a/src/eduid/queue/testing.py
+++ b/src/eduid/queue/testing.py
@@ -38,7 +38,7 @@ class MongoTemporaryInstanceReplicaSet(MongoTemporaryInstance):
         return [
             "docker",
             "run",
-            "--rm",
+            "--restart=always",
             "-p",
             f"{self.port}:{self.port}",
             "-e",
@@ -90,7 +90,7 @@ class SMPTDFixTemporaryInstance(EduidTemporaryInstance):
         return [
             "docker",
             "run",
-            "--rm",
+            "--restart=always",
             "-p",
             f"{self.port}:8025",
             "--name",

--- a/src/eduid/userdb/testing/__init__.py
+++ b/src/eduid/userdb/testing/__init__.py
@@ -35,7 +35,7 @@ class MongoTemporaryInstance(EduidTemporaryInstance):
         return [
             "docker",
             "run",
-            "--rm",
+            "--restart=always",
             "-p",
             f"{self.port}:27017",
             "--name",

--- a/src/eduid/userdb/testing/temp_instance.py
+++ b/src/eduid/userdb/testing/temp_instance.py
@@ -4,6 +4,7 @@ import atexit
 import logging
 import random
 import shutil
+import socket
 import subprocess
 import tempfile
 import time
@@ -14,6 +15,29 @@ from typing import Any, Self
 from eduid.common.misc.timeutil import utc_now
 
 logger = logging.getLogger(__name__)
+
+# Track all ports reserved by EduidTemporaryInstance subclasses to avoid collisions
+_reserved_ports: set[int] = set()
+
+
+def _is_port_free(port: int) -> bool:
+    """Check if a port is actually available for binding."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", port))
+            return True
+    except OSError:
+        return False
+
+
+def _random_available_port(low: int = 40000, high: int = 65535) -> int:
+    """Pick a random port that hasn't been reserved by another temporary instance and is free on the system."""
+    for _ in range(100):
+        port = random.randint(low, high)
+        if port not in _reserved_ports and _is_port_free(port):
+            _reserved_ports.add(port)
+            return port
+    raise RuntimeError(f"Could not find an available port in range {low}-{high} after 100 attempts")
 
 
 class EduidTemporaryInstance(ABC):
@@ -28,7 +52,7 @@ class EduidTemporaryInstance(ABC):
     def __init__(self, max_retry_seconds: int) -> None:
         self._conn: Any | None = None  # self._conn should be initialised by subclasses in `setup_conn'
         self._tmpdir = tempfile.mkdtemp()
-        self._port = random.randint(40000, 65535)
+        self._port = _random_available_port()
         self._logfile = open(f"/tmp/{self.__class__.__name__}-{self.port}.log", "w")  # noqa: SIM115
 
         start_time = utc_now()
@@ -118,15 +142,15 @@ class EduidTemporaryInstance(ABC):
                     break
 
             if container_name:
-                # Stop the container - docker stop handles graceful shutdown with SIGTERM
-                subprocess.run(["docker", "stop", container_name], check=False, capture_output=True)
+                # Force-remove the container immediately (don't wait for graceful shutdown)
+                subprocess.run(["docker", "rm", "-f", container_name], check=False, capture_output=True, timeout=5)
 
-                # Wait for the docker run process to exit (it should exit when container stops)
+                # Wait for the docker run process to exit
                 try:
-                    self._process.wait(timeout=10)
+                    self._process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     logger.warning("Docker run process didn't exit, terminating it")
-                    self._process.terminate()
+                    self._process.kill()
                     self._process.wait()
 
         # Flush the logfile but don't close it - closing it causes "ValueError: I/O operation on closed file"

--- a/src/eduid/webapp/common/session/testing.py
+++ b/src/eduid/webapp/common/session/testing.py
@@ -21,7 +21,7 @@ class RedisTemporaryInstance(EduidTemporaryInstance):
         return [
             "docker",
             "run",
-            "--rm",
+            "--restart=always",
             "-p",
             f"{self.port!s}:6379",
             "--name",


### PR DESCRIPTION
- pytest_sessionstart() and pytest_keyboard_interrupt() hooks remove any orphaned test Docker containers from previous runs
- _random_available_port() pick a random port that hasn't been reserved by another temporary instance and is free on the system
- docker restart=always
