### PR TITLE
Add webauthn credential in signup

### DIFF
--- a/src/eduid/common/config/base.py
+++ b/src/eduid/common/config/base.py
@@ -239,13 +239,15 @@ class ProfilingConfig(BaseModel):
     filename_format: str = "{method}.{path}.{elapsed:.0f}ms.{time:.0f}.prof"
 
 
-class WebauthnConfigMixin2(BaseModel):
+class Fido2RpConfigMixin(BaseModel):
+    """FIDO2 Relying Party identity — needed by any app that verifies or registers WebAuthn credentials."""
+
     fido2_rp_id: str  # 'eduid.se'
     fido2_rp_name: str = "eduID Sweden"
 
 
-class WebauthnAppConfigMixin(BaseModel):
-    """Common webauthn application settings shared by security and signup apps."""
+class WebauthnRegistrationConfigMixin(BaseModel):
+    """WebAuthn registration and proofing settings for apps that register security keys."""
 
     webauthn_proofing_method: str = Field(default="webauthn metadata")
     webauthn_proofing_version: str = Field(default="2024v1")

--- a/src/eduid/common/config/base.py
+++ b/src/eduid/common/config/base.py
@@ -12,6 +12,12 @@ from re import Pattern
 from typing import IO, Annotated, Any
 
 import importlib_resources
+from fido2.webauthn import (
+    AttestationConveyancePreference,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+from fido_mds.models.fido_mds import AuthenticatorStatus
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field
 
 from eduid.userdb.credentials import CredentialProofingMethod
@@ -236,6 +242,26 @@ class ProfilingConfig(BaseModel):
 class WebauthnConfigMixin2(BaseModel):
     fido2_rp_id: str  # 'eduid.se'
     fido2_rp_name: str = "eduID Sweden"
+
+
+class WebauthnAppConfigMixin(BaseModel):
+    """Common webauthn application settings shared by security and signup apps."""
+
+    webauthn_proofing_method: str = Field(default="webauthn metadata")
+    webauthn_proofing_version: str = Field(default="2024v1")
+    webauthn_max_allowed_tokens: int = 10
+    webauthn_attestation: AttestationConveyancePreference | None = None
+    webauthn_user_verification: UserVerificationRequirement = UserVerificationRequirement.PREFERRED
+    webauthn_resident_key_requirement: ResidentKeyRequirement = ResidentKeyRequirement.PREFERRED
+    webauthn_disallowed_status: list[AuthenticatorStatus] = Field(
+        default=[
+            AuthenticatorStatus.USER_VERIFICATION_BYPASS,
+            AuthenticatorStatus.ATTESTATION_KEY_COMPROMISE,
+            AuthenticatorStatus.USER_KEY_REMOTE_COMPROMISE,
+            AuthenticatorStatus.USER_KEY_PHYSICAL_COMPROMISE,
+            AuthenticatorStatus.REVOKED,
+        ]
+    )
 
 
 class MagicCookieMixin(BaseModel):

--- a/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
+++ b/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
@@ -8,7 +8,7 @@ from fido2.webauthn import AuthenticationResponse
 from flask import Blueprint, current_app, request
 from pytest_mock import MockerFixture
 
-from eduid.common.config.base import EduIDBaseAppConfig, WebauthnConfigMixin2
+from eduid.common.config.base import EduIDBaseAppConfig, Fido2RpConfigMixin
 from eduid.common.config.parsers import load_config
 from eduid.userdb.fixtures.fido_credentials import u2f_credential, webauthn_credential
 from eduid.webapp.common.api.app import EduIDBaseApp
@@ -17,7 +17,7 @@ from eduid.webapp.common.authn.fido_tokens import VerificationProblem, start_tok
 from eduid.webapp.common.session.namespaces import WebauthnState
 
 
-class MockFidoConfig(EduIDBaseAppConfig, WebauthnConfigMixin2):
+class MockFidoConfig(EduIDBaseAppConfig, Fido2RpConfigMixin):
     mfa_testing: bool = True
     generate_u2f_challenges: bool = True
 

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -6,10 +6,18 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from enum import StrEnum
+from typing import Any
 from uuid import UUID
 
 from fido2.server import Fido2Server, PublicKeyCredentialRpEntity
-from fido2.webauthn import AttestationConveyancePreference, AttestationObject, AttestedCredentialData
+from fido2.webauthn import (
+    AttestationConveyancePreference,
+    AttestationObject,
+    AttestedCredentialData,
+    AuthenticatorAttachment,
+    AuthenticatorData,
+    RegistrationResponse,
+)
 from fido_mds import Attestation, FidoMetadataStore
 from fido_mds.exceptions import AttestationVerificationError, MetadataValidationError
 from fido_mds.models.fido_mds import AuthenticatorStatus
@@ -229,3 +237,82 @@ def save_webauthn_proofing_log(
     )
     logger.debug(f"webauthn mfa capability proofing element: {proofing_element}")
     return proofing_log.save(proofing_element)
+
+
+@dataclass
+class RegistrationResult:
+    credential_data: str  # base64 AttestedCredentialData
+    keyhandle: str
+    authenticator: AuthenticatorAttachment
+    authenticator_info: AuthenticatorInformation
+    mfa_approved: bool
+
+
+class RegistrationError(Exception):
+    """Raised when WebAuthn registration verification fails."""
+
+
+def verify_webauthn_registration(
+    response: dict[str, Any],
+    webauthn_state: dict[str, Any],
+    authenticator: AuthenticatorAttachment,
+    rp_id: str,
+    rp_name: str,
+    fido_mds: FidoMetadataStore,
+    fido_metadata_log: FidoMetadataLog,
+    app_name: str,
+    is_backdoor: bool = False,
+    disallowed_status: Sequence[AuthenticatorStatus] = (),
+    client_extension_results: dict[str, Any] | None = None,
+) -> RegistrationResult:
+    """
+    Verify a WebAuthn registration response and return the result.
+
+    Shared between security and signup apps. Handles:
+    - Parsing the RegistrationResponse
+    - Attestation verification via get_authenticator_information
+    - Completing registration via Fido2Server.register_complete
+    - MFA approval check
+
+    Raises RegistrationError on any verification failure.
+    """
+    if client_extension_results:
+        response["client_extension_results"] = client_extension_results
+    registration = RegistrationResponse.from_dict(response)
+
+    try:
+        authenticator_info = get_authenticator_information(
+            attestation=registration.response.attestation_object,
+            client_data=registration.response.client_data,
+            fido_mds=fido_mds,
+            fido_metadata_log=fido_metadata_log,
+            app_name=app_name,
+            is_backdoor=is_backdoor,
+        )
+    except (AttestationVerificationError, NotImplementedError, ValueError) as e:
+        logger.exception("attestation verification failed")
+        raise RegistrationError("attestation verification failed") from e
+
+    server = get_webauthn_server(rp_id=rp_id, rp_name=rp_name)
+    try:
+        auth_data: AuthenticatorData = server.register_complete(state=webauthn_state, response=registration)
+    except ValueError as e:
+        logger.exception("Webauthn registration failed")
+        raise RegistrationError("registration completion failed") from e
+
+    if auth_data.credential_data is None:
+        logger.error("Webauthn credential data is missing")
+        raise RegistrationError("credential data missing")
+
+    mfa_approved = is_authenticator_mfa_approved(
+        authenticator_info=authenticator_info,
+        disallowed_status=disallowed_status,
+    )
+
+    return RegistrationResult(
+        credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
+        keyhandle=auth_data.credential_data.credential_id.hex(),
+        authenticator=authenticator,
+        authenticator_info=authenticator_info,
+        mfa_approved=mfa_approved,
+    )

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -15,12 +15,10 @@ from fido_mds.exceptions import AttestationVerificationError, MetadataValidation
 from fido_mds.models.fido_mds import AuthenticatorStatus
 from fido_mds.models.webauthn import AttestationFormat
 
-from eduid.common.config.base import MagicCookieMixin
 from eduid.userdb.credentials import Webauthn
 from eduid.userdb.credentials.fido import U2F, FidoCredential
 from eduid.userdb.logs.db import FidoMetadataLog, ProofingLog
 from eduid.userdb.logs.element import FidoMetadataLogElement, WebauthnMfaCapabilityProofingLog
-from eduid.webapp.common.api.helpers import check_magic_cookie
 
 __author__ = "lundberg"
 
@@ -77,7 +75,7 @@ def get_authenticator_information(
     client_data: bytes,
     fido_mds: FidoMetadataStore,
     fido_metadata_log: FidoMetadataLog,
-    config: MagicCookieMixin,
+    is_backdoor: bool = False,
 ) -> AuthenticatorInformation:
     # parse attestation object
     try:
@@ -91,7 +89,7 @@ def get_authenticator_information(
     authenticator_id = att.aaguid or att.certificate_key_identifier
 
     # allow automatic tests to use any webauthn device
-    if check_magic_cookie(config):
+    if is_backdoor:
         return AuthenticatorInformation(
             attestation_format=att.fmt,
             authenticator_id=authenticator_id,

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from uuid import UUID
 
 from fido2.server import Fido2Server, PublicKeyCredentialRpEntity
-from fido2.webauthn import AttestationConveyancePreference, AttestedCredentialData, AttestationObject
+from fido2.webauthn import AttestationConveyancePreference, AttestationObject, AttestedCredentialData
 from fido_mds import Attestation, FidoMetadataStore
 from fido_mds.exceptions import AttestationVerificationError, MetadataValidationError
 from fido_mds.models.fido_mds import AuthenticatorStatus

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -1,19 +1,30 @@
+"""Shared WebAuthn helper functions for registration and proofing."""
+
+import base64
+import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from enum import StrEnum
 from uuid import UUID
 
-from fido2.webauthn import AttestationObject
-from fido_mds import Attestation
+from fido2.server import Fido2Server, PublicKeyCredentialRpEntity
+from fido2.webauthn import AttestationConveyancePreference, AttestedCredentialData, AttestationObject
+from fido_mds import Attestation, FidoMetadataStore
 from fido_mds.exceptions import AttestationVerificationError, MetadataValidationError
 from fido_mds.models.fido_mds import AuthenticatorStatus
 from fido_mds.models.webauthn import AttestationFormat
 
+from eduid.common.config.base import MagicCookieMixin
+from eduid.userdb.credentials import Webauthn
+from eduid.userdb.credentials.fido import U2F, FidoCredential
+from eduid.userdb.logs.db import FidoMetadataLog, ProofingLog
 from eduid.userdb.logs.element import FidoMetadataLogElement, WebauthnMfaCapabilityProofingLog
 from eduid.webapp.common.api.helpers import check_magic_cookie
-from eduid.webapp.security.app import current_security_app as current_app
 
 __author__ = "lundberg"
+
+logger = logging.getLogger(__name__)
 
 
 class OtherAuthenticatorStatus(StrEnum):
@@ -35,12 +46,44 @@ class AuthenticatorInformation:
     user_verification_methods: list[str] = field(default_factory=list)
 
 
-def get_authenticator_information(attestation: AttestationObject, client_data: bytes) -> AuthenticatorInformation:
+def get_webauthn_server(
+    rp_id: str, rp_name: str, attestation: AttestationConveyancePreference | None = None
+) -> Fido2Server:
+    rp = PublicKeyCredentialRpEntity(id=rp_id, name=rp_name)
+    return Fido2Server(rp, attestation=attestation)
+
+
+def make_credentials(creds: Sequence[FidoCredential]) -> list[AttestedCredentialData]:
+    credentials = []
+    for cred in creds:
+        if isinstance(cred, Webauthn):
+            cred_data = base64.urlsafe_b64decode(cred.credential_data.encode("ascii"))
+            credential_data, rest = AttestedCredentialData.unpack_from(cred_data)
+            if rest:
+                continue
+        elif isinstance(cred, U2F):
+            # cred is of type U2F (legacy registration)
+            credential_data = AttestedCredentialData.from_ctap1(
+                cred.keyhandle.encode("ascii"), cred.public_key.encode("ascii")
+            )
+        else:
+            raise ValueError(f"Unknown credential {cred!r}")
+        credentials.append(credential_data)
+    return credentials
+
+
+def get_authenticator_information(
+    attestation: AttestationObject,
+    client_data: bytes,
+    fido_mds: FidoMetadataStore,
+    fido_metadata_log: FidoMetadataLog,
+    config: MagicCookieMixin,
+) -> AuthenticatorInformation:
     # parse attestation object
     try:
         att = Attestation.from_attestation_object(attestation)
     except ValueError as e:
-        current_app.logger.exception("Failed to parse attestation object")
+        logger.exception("Failed to parse attestation object")
         raise e
 
     user_present = att.auth_data.flags.user_present
@@ -48,7 +91,7 @@ def get_authenticator_information(attestation: AttestationObject, client_data: b
     authenticator_id = att.aaguid or att.certificate_key_identifier
 
     # allow automatic tests to use any webauthn device
-    if check_magic_cookie(current_app.conf):
+    if check_magic_cookie(config):
         return AuthenticatorInformation(
             attestation_format=att.fmt,
             authenticator_id=authenticator_id,
@@ -73,18 +116,16 @@ def get_authenticator_information(attestation: AttestationObject, client_data: b
 
     # verify attestation
     try:
-        current_app.fido_mds.verify_attestation(attestation=att, client_data=client_data)
+        fido_mds.verify_attestation(attestation=att, client_data=client_data)
     except AttestationVerificationError as e:
-        current_app.logger.debug(f"attestation: {att}")
-        current_app.logger.debug(f"client_data: {client_data!r}")
-        current_app.logger.exception("Failed to get authenticator information")
+        logger.debug(f"attestation: {att}")
+        logger.debug(f"client_data: {client_data!r}")
+        logger.exception("Failed to get authenticator information")
         raise e
     except MetadataValidationError:
-        current_app.logger.debug(f"attestation: {att}")
-        current_app.logger.debug(f"client_data: {client_data!r}")
-        current_app.logger.exception(
-            "Failed to get authenticator information from metadata, continuing without metadata"
-        )
+        logger.debug(f"attestation: {att}")
+        logger.debug(f"client_data: {client_data!r}")
+        logger.exception("Failed to get authenticator information from metadata, continuing without metadata")
         # Continue even if the security key _should_ be found and validated with metadata as we have seen security keys
         # in the wild that fails
         return AuthenticatorInformation(
@@ -110,7 +151,7 @@ def get_authenticator_information(attestation: AttestationObject, client_data: b
         )
 
     # create authenticator information from attestation and metadata
-    metadata_entry = current_app.fido_mds.get_entry(authenticator_id=authenticator_id)
+    metadata_entry = fido_mds.get_entry(authenticator_id=authenticator_id)
     # mongodb does not support date
     last_status_change = metadata_entry.time_of_last_status_change
     user_verification_methods = [
@@ -118,10 +159,8 @@ def get_authenticator_information(attestation: AttestationObject, client_data: b
     ]
 
     # save current metadata entry as proof if we haven't done so before
-    if not current_app.fido_metadata_log.exists(
-        authenticator_id=authenticator_id, last_status_change=last_status_change
-    ):
-        current_app.fido_metadata_log.save(
+    if not fido_metadata_log.exists(authenticator_id=authenticator_id, last_status_change=last_status_change):
+        fido_metadata_log.save(
             FidoMetadataLogElement(
                 created_by="security",
                 authenticator_id=authenticator_id,
@@ -146,38 +185,48 @@ def get_authenticator_information(attestation: AttestationObject, client_data: b
     )
 
 
-def is_authenticator_mfa_approved(authenticator_info: AuthenticatorInformation) -> bool:
+def is_authenticator_mfa_approved(
+    authenticator_info: AuthenticatorInformation,
+    disallowed_status: Sequence[AuthenticatorStatus] = (),
+) -> bool:
     """
     This is our current policy for determine if a FIDO2 authenticator can do multi-factor authentications.
     """
     if authenticator_info.user_verified:
-        current_app.logger.info(
+        logger.info(
             f"AttestationFormat {authenticator_info.attestation_format}: user verified - authenticator is mfa capable"
         )
 
         # check status in metadata (if any) and disallow incident statuses
-        if authenticator_info.status and authenticator_info.status in current_app.conf.webauthn_disallowed_status:
-            current_app.logger.debug(f"status {authenticator_info.status} is not mfa capable")
+        if authenticator_info.status and authenticator_info.status in disallowed_status:
+            logger.debug(f"status {authenticator_info.status} is not mfa capable")
             return False
 
         return True
-    current_app.logger.info(
+    logger.info(
         f"AttestationFormat {authenticator_info.attestation_format}: user NOT verified - authenticator is not mfa "
         f"capable"
     )
     return False
 
 
-def save_webauthn_proofing_log(eppn: str, authenticator_info: AuthenticatorInformation) -> bool:
+def save_webauthn_proofing_log(
+    eppn: str,
+    authenticator_info: AuthenticatorInformation,
+    proofing_log: ProofingLog,
+    app_name: str,
+    proofing_version: str,
+    proofing_method: str,
+) -> bool:
     proofing_element = WebauthnMfaCapabilityProofingLog(
-        created_by=current_app.conf.app_name,
+        created_by=app_name,
         eppn=eppn,
-        proofing_version=current_app.conf.webauthn_proofing_version,
-        proofing_method=current_app.conf.webauthn_proofing_method,
+        proofing_version=proofing_version,
+        proofing_method=proofing_method,
         authenticator_id=authenticator_info.authenticator_id,
         attestation_format=authenticator_info.attestation_format,
         user_verification_methods=authenticator_info.user_verification_methods,
         key_protection=authenticator_info.key_protection,
     )
-    current_app.logger.debug(f"webauthn mfa capability proofing element: {proofing_element}")
-    return current_app.proofing_log.save(proofing_element)
+    logger.debug(f"webauthn mfa capability proofing element: {proofing_element}")
+    return proofing_log.save(proofing_element)

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -75,6 +75,7 @@ def get_authenticator_information(
     client_data: bytes,
     fido_mds: FidoMetadataStore,
     fido_metadata_log: FidoMetadataLog,
+    app_name: str,
     is_backdoor: bool = False,
 ) -> AuthenticatorInformation:
     # parse attestation object
@@ -160,7 +161,7 @@ def get_authenticator_information(
     if not fido_metadata_log.exists(authenticator_id=authenticator_id, last_status_change=last_status_change):
         fido_metadata_log.save(
             FidoMetadataLogElement(
-                created_by="security",
+                created_by=app_name,
                 authenticator_id=authenticator_id,
                 last_status_change=last_status_change,
                 metadata_entry=metadata_entry,

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -9,6 +9,7 @@ from enum import StrEnum, unique
 from typing import Any, NewType, Self, cast
 
 from fido2.webauthn import AuthenticatorAttachment
+from fido_mds.models.webauthn import AttestationFormat
 from pydantic import BaseModel, Field, ValidationError, field_serializer
 
 from eduid.common.config.base import FrontendAction
@@ -156,12 +157,20 @@ class Tou(SessionNSBase):
 class Credentials(SessionNSBase):
     completed: bool = False
     generated_password: str | None = None
-    webauthn: Any | None = None  # TODO: implement webauthn signup
+    webauthn_registration: WebauthnRegistration | None = None
+    webauthn_credential_data: str | None = None
+    webauthn_authenticator: AuthenticatorAttachment | None = None
+    webauthn_authenticator_id: str | None = None
+    webauthn_keyhandle: str | None = None
+    webauthn_mfa_approved: bool = False
+    webauthn_attestation_format: AttestationFormat | None = None
+    webauthn_description: str | None = None
 
 
 class Signup(TimestampedNS):
     user_created: bool = False
     user_created_at: datetime | None = None
+    eppn: str | None = None
     name: Name = Field(default_factory=Name)
     email: EmailVerification = Field(default_factory=EmailVerification)
     invite: Invite = Field(default_factory=Invite)

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -154,19 +154,28 @@ class Tou(SessionNSBase):
     version: str | None = None
 
 
+class WebauthnCredential(BaseModel):
+    """Completed WebAuthn credential data, stored between register/complete and create-user."""
+
+    credential_data: str  # base64 AttestedCredentialData
+    keyhandle: str
+    authenticator: AuthenticatorAttachment
+    authenticator_id: str | None = None
+    mfa_approved: bool = False
+    attestation_format: AttestationFormat | None = None
+    description: str = ""
+    # attestation flags for proofing log
+    user_present: bool = True
+    user_verified: bool = False
+    user_verification_methods: list[str] = Field(default_factory=list)
+    key_protection: list[str] = Field(default_factory=list)
+
+
 class Credentials(SessionNSBase):
     completed: bool = False
     generated_password: str | None = None
     webauthn_registration: WebauthnRegistration | None = None
-    webauthn_credential_data: str | None = None
-    webauthn_authenticator: AuthenticatorAttachment | None = None
-    webauthn_authenticator_id: str | None = None
-    webauthn_keyhandle: str | None = None
-    webauthn_mfa_approved: bool = False
-    webauthn_attestation_format: AttestationFormat | None = None
-    webauthn_description: str | None = None
-    webauthn_user_verification_methods: list[str] = Field(default_factory=list)
-    webauthn_key_protection: list[str] = Field(default_factory=list)
+    webauthn: WebauthnCredential | None = None
 
 
 class Signup(TimestampedNS):

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -165,6 +165,8 @@ class Credentials(SessionNSBase):
     webauthn_mfa_approved: bool = False
     webauthn_attestation_format: AttestationFormat | None = None
     webauthn_description: str | None = None
+    webauthn_user_verification_methods: list[str] = Field(default_factory=list)
+    webauthn_key_protection: list[str] = Field(default_factory=list)
 
 
 class Signup(TimestampedNS):

--- a/src/eduid/webapp/common/session/tests/test_namespaces.py
+++ b/src/eduid/webapp/common/session/tests/test_namespaces.py
@@ -59,7 +59,7 @@ class TestNamespace(TestNameSpaceBase):
                 "name": {},
                 "tou": {"completed": False},
                 "captcha": {"bad_attempts": 0, "completed": False},
-                "credentials": {"completed": False},
+                "credentials": {"completed": False, "webauthn_mfa_approved": False},
             },
             "idp": {"sso_cookie_val": "abc", "pending_requests": {}},
         }, f"Actual result: {normalised_out}"

--- a/src/eduid/webapp/common/session/tests/test_namespaces.py
+++ b/src/eduid/webapp/common/session/tests/test_namespaces.py
@@ -59,7 +59,12 @@ class TestNamespace(TestNameSpaceBase):
                 "name": {},
                 "tou": {"completed": False},
                 "captcha": {"bad_attempts": 0, "completed": False},
-                "credentials": {"completed": False, "webauthn_mfa_approved": False},
+                "credentials": {
+                    "completed": False,
+                    "webauthn_key_protection": [],
+                    "webauthn_mfa_approved": False,
+                    "webauthn_user_verification_methods": [],
+                },
             },
             "idp": {"sso_cookie_val": "abc", "pending_requests": {}},
         }, f"Actual result: {normalised_out}"

--- a/src/eduid/webapp/common/session/tests/test_namespaces.py
+++ b/src/eduid/webapp/common/session/tests/test_namespaces.py
@@ -59,12 +59,7 @@ class TestNamespace(TestNameSpaceBase):
                 "name": {},
                 "tou": {"completed": False},
                 "captcha": {"bad_attempts": 0, "completed": False},
-                "credentials": {
-                    "completed": False,
-                    "webauthn_key_protection": [],
-                    "webauthn_mfa_approved": False,
-                    "webauthn_user_verification_methods": [],
-                },
+                "credentials": {"completed": False},
             },
             "idp": {"sso_cookie_val": "abc", "pending_requests": {}},
         }, f"Actual result: {normalised_out}"

--- a/src/eduid/webapp/idp/settings/common.py
+++ b/src/eduid/webapp/idp/settings/common.py
@@ -11,16 +11,16 @@ from eduid.common.config.base import (
     AmConfigMixin,
     CookieConfig,
     EduIDBaseAppConfig,
+    Fido2RpConfigMixin,
     TouConfigMixin,
     VCCSConfigMixin,
-    WebauthnConfigMixin2,
 )
 from eduid.common.models.generic import HttpUrlStr
 from eduid.userdb.identity import IdentityProofingMethod
 from eduid.webapp.idp.assurance_data import SwamidAssurance
 
 
-class IdPConfig(EduIDBaseAppConfig, TouConfigMixin, WebauthnConfigMixin2, AmConfigMixin, VCCSConfigMixin):
+class IdPConfig(EduIDBaseAppConfig, TouConfigMixin, Fido2RpConfigMixin, AmConfigMixin, VCCSConfigMixin):
     """
     Configuration for the idp app
     """

--- a/src/eduid/webapp/idp/views/mfa_auth.py
+++ b/src/eduid/webapp/idp/views/mfa_auth.py
@@ -94,7 +94,10 @@ def mfa_auth(
         # If no external MFA was used, and no webauthn credential either, we respond with a not-finished
         # response containing a webauthn challenge if applicable.
         payload: dict[str, Any] = _create_challenge(user, ticket)
-
+        current_app.logger.debug("No MFA submitted. Sending not-finished response.")
+        current_app.logger.debug(
+            f"Will accept external MFA for login ref: {session.mfa_action.login_ref} and eppn: {session.mfa_action.eppn}"
+        )
         return success_response(payload=payload)
 
     if not result.authn_data or not result.credential:
@@ -240,9 +243,4 @@ def _create_challenge(user: User | None, ticket: LoginContext) -> dict[str, Any]
         user_verification=user_verification,
     )
     payload.update(options)
-
-    current_app.logger.debug("No MFA submitted. Sending not-finished response.")
-    current_app.logger.debug(
-        f"Will accept external MFA for login ref: {session.mfa_action.login_ref} and eppn: {session.mfa_action.eppn}"
-    )
     return payload

--- a/src/eduid/webapp/reset_password/settings/common.py
+++ b/src/eduid/webapp/reset_password/settings/common.py
@@ -10,17 +10,17 @@ from eduid.common.config.base import (
     AmConfigMixin,
     CaptchaConfigMixin,
     EduIDBaseAppConfig,
+    Fido2RpConfigMixin,
     MagicCookieMixin,
     MsgConfigMixin,
     PasswordConfigMixin,
     VCCSConfigMixin,
-    WebauthnConfigMixin2,
 )
 
 
 class ResetPasswordConfig(
     EduIDBaseAppConfig,
-    WebauthnConfigMixin2,
+    Fido2RpConfigMixin,
     MagicCookieMixin,
     AmConfigMixin,
     MsgConfigMixin,

--- a/src/eduid/webapp/security/settings/common.py
+++ b/src/eduid/webapp/security/settings/common.py
@@ -5,20 +5,20 @@ from pydantic import Field
 from eduid.common.config.base import (
     AmConfigMixin,
     EduIDBaseAppConfig,
+    Fido2RpConfigMixin,
     FrontendActionMixin,
     MagicCookieMixin,
     MsgConfigMixin,
     PasswordConfigMixin,
     VCCSConfigMixin,
-    WebauthnAppConfigMixin,
-    WebauthnConfigMixin2,
+    WebauthnRegistrationConfigMixin,
 )
 
 
 class SecurityConfig(
     EduIDBaseAppConfig,
-    WebauthnConfigMixin2,
-    WebauthnAppConfigMixin,
+    Fido2RpConfigMixin,
+    WebauthnRegistrationConfigMixin,
     MagicCookieMixin,
     AmConfigMixin,
     MsgConfigMixin,
@@ -39,7 +39,7 @@ class SecurityConfig(
     chpass_reauthn_timeout: timedelta = Field(default=timedelta(seconds=120))
     chpass_old_password_needed: bool = True
 
-    # webauthn (security-specific settings; common ones inherited from WebauthnAppConfigMixin)
+    # webauthn (security-specific settings; common ones inherited from WebauthnRegistrationConfigMixin)
     webauthn_recommended_user_verification_methods: list[str] = Field(
         default=[
             "faceprint_internal",

--- a/src/eduid/webapp/security/settings/common.py
+++ b/src/eduid/webapp/security/settings/common.py
@@ -1,11 +1,5 @@
 from datetime import timedelta
 
-from fido2.webauthn import (
-    AttestationConveyancePreference,
-    ResidentKeyRequirement,
-    UserVerificationRequirement,
-)
-from fido_mds.models.fido_mds import AuthenticatorStatus
 from pydantic import Field
 
 from eduid.common.config.base import (
@@ -16,6 +10,7 @@ from eduid.common.config.base import (
     MsgConfigMixin,
     PasswordConfigMixin,
     VCCSConfigMixin,
+    WebauthnAppConfigMixin,
     WebauthnConfigMixin2,
 )
 
@@ -23,6 +18,7 @@ from eduid.common.config.base import (
 class SecurityConfig(
     EduIDBaseAppConfig,
     WebauthnConfigMixin2,
+    WebauthnAppConfigMixin,
     MagicCookieMixin,
     AmConfigMixin,
     MsgConfigMixin,
@@ -43,13 +39,7 @@ class SecurityConfig(
     chpass_reauthn_timeout: timedelta = Field(default=timedelta(seconds=120))
     chpass_old_password_needed: bool = True
 
-    # webauthn
-    webauthn_proofing_method: str = Field(default="webauthn metadata")
-    webauthn_proofing_version: str = Field(default="2024v1")
-    webauthn_max_allowed_tokens: int = 10
-    webauthn_attestation: AttestationConveyancePreference | None = None
-    webauthn_user_verification: UserVerificationRequirement = UserVerificationRequirement.PREFERRED
-    webauthn_resident_key_requirement: ResidentKeyRequirement = ResidentKeyRequirement.PREFERRED
+    # webauthn (security-specific settings; common ones inherited from WebauthnAppConfigMixin)
     webauthn_recommended_user_verification_methods: list[str] = Field(
         default=[
             "faceprint_internal",
@@ -65,15 +55,6 @@ class SecurityConfig(
     )
     webauthn_recommended_key_protection: list[str] = Field(
         default=["remote_handle", "hardware", "secure_element", "tee", "apple"]
-    )
-    webauthn_disallowed_status: list[AuthenticatorStatus] = Field(
-        default=[
-            AuthenticatorStatus.USER_VERIFICATION_BYPASS,
-            AuthenticatorStatus.ATTESTATION_KEY_COMPROMISE,
-            AuthenticatorStatus.USER_KEY_REMOTE_COMPROMISE,
-            AuthenticatorStatus.USER_KEY_PHYSICAL_COMPROMISE,
-            AuthenticatorStatus.REVOKED,
-        ]
     )
 
     # for logging out when terminating an account

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -21,9 +21,13 @@ from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.credentials import U2F, FidoCredential, Webauthn
 from eduid.webapp.common.api.schemas.authn_status import AuthnActionStatus
 from eduid.webapp.common.api.testing import CSRFTestClient, EduidAPITestCase
+from eduid.webapp.common.authn.webauthn import (
+    get_authenticator_information,
+    get_webauthn_server,
+    is_authenticator_mfa_approved,
+)
 from eduid.webapp.common.session import EduidSession
 from eduid.webapp.common.session.namespaces import WebauthnRegistration, WebauthnState
-from eduid.webapp.common.authn.webauthn import get_authenticator_information, get_webauthn_server, is_authenticator_mfa_approved
 from eduid.webapp.security.app import SecurityApp, security_init_app
 
 __author__ = "eperez"

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -23,9 +23,8 @@ from eduid.webapp.common.api.schemas.authn_status import AuthnActionStatus
 from eduid.webapp.common.api.testing import CSRFTestClient, EduidAPITestCase
 from eduid.webapp.common.session import EduidSession
 from eduid.webapp.common.session.namespaces import WebauthnRegistration, WebauthnState
+from eduid.webapp.common.authn.webauthn import get_authenticator_information, get_webauthn_server, is_authenticator_mfa_approved
 from eduid.webapp.security.app import SecurityApp, security_init_app
-from eduid.webapp.security.views.webauthn import get_webauthn_server
-from eduid.webapp.security.webauthn_proofing import get_authenticator_information, is_authenticator_mfa_approved
 
 __author__ = "eperez"
 
@@ -639,25 +638,29 @@ class SecurityWebauthnTests(EduidAPITestCase):
         authenticators = [YUBIKEY_4, YUBIKEY_5_NFC, MICROSOFT_SURFACE_1796, NEXUS_5, IPHONE_12, NONE_ATTESTATION]
         for authenticator in authenticators:
             self.app.logger.debug(f"Testing authenticator: {authenticator}")
-            with self.app.test_request_context():
-                authenticator_info = get_authenticator_information(
-                    attestation=Attestation.from_base64(authenticator[0]).attestation_obj,
-                    client_data=websafe_decode(authenticator[1]),
-                )
+            authenticator_info = get_authenticator_information(
+                attestation=Attestation.from_base64(authenticator[0]).attestation_obj,
+                client_data=websafe_decode(authenticator[1]),
+                fido_mds=self.app.fido_mds,
+                fido_metadata_log=self.app.fido_metadata_log,
+                config=self.app.conf,
+            )
             assert authenticator_info is not None
             assert authenticator_info.authenticator_id is not None
             assert authenticator_info.attestation_format is not None
             assert authenticator_info.user_present is not None
             assert authenticator_info.user_verified is not None
 
-            with self.app.test_request_context():
-                res = is_authenticator_mfa_approved(authenticator_info=authenticator_info)
-                if authenticator in [YUBIKEY_4, YUBIKEY_5_NFC]:
-                    # Yubikey 4 does not support any user verification we accept
-                    # The test data for Yubikey 5 do not include user verification
-                    assert res is False
-                else:
-                    assert res is True
+            res = is_authenticator_mfa_approved(
+                authenticator_info=authenticator_info,
+                disallowed_status=self.app.conf.webauthn_disallowed_status,
+            )
+            if authenticator in [YUBIKEY_4, YUBIKEY_5_NFC]:
+                # Yubikey 4 does not support any user verification we accept
+                # The test data for Yubikey 5 do not include user verification
+                assert res is False
+            else:
+                assert res is True
 
             if authenticator not in [IPHONE_12, NONE_ATTESTATION]:
                 # No metadata for Apple devices or none attestation
@@ -701,11 +704,16 @@ class SecurityWebauthnTests(EduidAPITestCase):
             authenticator_info = get_authenticator_information(
                 attestation=Attestation.from_base64(attestation_object).attestation_obj,
                 client_data=websafe_decode(client_data),
+                fido_mds=self.app.fido_mds,
+                fido_metadata_log=self.app.fido_metadata_log,
+                config=self.app.conf,
             )
         assert authenticator_info is not None
 
-        with self.app.test_request_context():
-            res = is_authenticator_mfa_approved(authenticator_info=authenticator_info)
+        res = is_authenticator_mfa_approved(
+            authenticator_info=authenticator_info,
+            disallowed_status=self.app.conf.webauthn_disallowed_status,
+        )
         assert res is True
 
     def test_approved_security_keys(self) -> None:

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -13,10 +13,9 @@ from fido2.webauthn import (
 from fido_mds import FidoMetadataStore
 from future.backports.datetime import timedelta
 from pytest_mock import MockerFixture
-from werkzeug.http import dump_cookie
 from werkzeug.test import TestResponse
 
-from eduid.common.config.base import EduidEnvironment, FrontendAction
+from eduid.common.config.base import FrontendAction
 from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.credentials import U2F, FidoCredential, Webauthn
 from eduid.webapp.common.api.schemas.authn_status import AuthnActionStatus
@@ -647,7 +646,7 @@ class SecurityWebauthnTests(EduidAPITestCase):
                 client_data=websafe_decode(authenticator[1]),
                 fido_mds=self.app.fido_mds,
                 fido_metadata_log=self.app.fido_metadata_log,
-                config=self.app.conf,
+                is_backdoor=False,
             )
             assert authenticator_info is not None
             assert authenticator_info.authenticator_id is not None
@@ -678,12 +677,6 @@ class SecurityWebauthnTests(EduidAPITestCase):
                 )
 
     def test_authenticator_information_backdoor(self) -> None:
-        # setup magic cookie backdoor
-        self.app.conf.magic_cookie_name = "magic-cookie"
-        self.app.conf.magic_cookie = "magic"
-        self.app.conf.environment = EduidEnvironment.dev
-        cookie = dump_cookie(self.app.conf.magic_cookie_name, self.app.conf.magic_cookie)
-
         attestation_object = (
             "o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEYwRAIgYveunFJbAigRE3KZ0jq8Av_fVO82NPR6"
             "YLxr-PTBeb8CICzfv9hjw8Y4uln8JlROLeCt64v7HggN_I_GcQItOTGrY3g1Y4FZAd8wggHbMIIBfaAD"
@@ -704,14 +697,13 @@ class SecurityWebauthnTests(EduidAPITestCase):
             "N09EUzVXdzAtNUg0QnQweVR0dzNSYyIsIm9yaWdpbiI6Imh0dHBzOi8vZGFzaGJvYXJkLmRldi5lZHVp"
             "ZC5zZSIsImNyb3NzT3JpZ2luIjpmYWxzZX0"
         )
-        with self.app.test_request_context(headers={"Cookie": cookie}):
-            authenticator_info = get_authenticator_information(
-                attestation=Attestation.from_base64(attestation_object).attestation_obj,
-                client_data=websafe_decode(client_data),
-                fido_mds=self.app.fido_mds,
-                fido_metadata_log=self.app.fido_metadata_log,
-                config=self.app.conf,
-            )
+        authenticator_info = get_authenticator_information(
+            attestation=Attestation.from_base64(attestation_object).attestation_obj,
+            client_data=websafe_decode(client_data),
+            fido_mds=self.app.fido_mds,
+            fido_metadata_log=self.app.fido_metadata_log,
+            is_backdoor=True,
+        )
         assert authenticator_info is not None
 
         res = is_authenticator_mfa_approved(

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -646,6 +646,7 @@ class SecurityWebauthnTests(EduidAPITestCase):
                 client_data=websafe_decode(authenticator[1]),
                 fido_mds=self.app.fido_mds,
                 fido_metadata_log=self.app.fido_metadata_log,
+                app_name="testing",
                 is_backdoor=False,
             )
             assert authenticator_info is not None
@@ -702,6 +703,7 @@ class SecurityWebauthnTests(EduidAPITestCase):
             client_data=websafe_decode(client_data),
             fido_mds=self.app.fido_mds,
             fido_metadata_log=self.app.fido_metadata_log,
+            app_name="testing",
             is_backdoor=True,
         )
         assert authenticator_info is not None

--- a/src/eduid/webapp/security/views/webauthn.py
+++ b/src/eduid/webapp/security/views/webauthn.py
@@ -131,6 +131,7 @@ def registration_complete(
             client_data=registration.response.client_data,
             fido_mds=current_app.fido_mds,
             fido_metadata_log=current_app.fido_metadata_log,
+            app_name=current_app.conf.app_name,
             is_backdoor=check_magic_cookie(current_app.conf),
         )
     except (AttestationVerificationError, NotImplementedError, ValueError):

--- a/src/eduid/webapp/security/views/webauthn.py
+++ b/src/eduid/webapp/security/views/webauthn.py
@@ -1,13 +1,6 @@
-import base64
 from typing import Any
 
-from fido2.webauthn import (
-    AuthenticatorAttachment,
-    AuthenticatorData,
-    PublicKeyCredentialUserEntity,
-    RegistrationResponse,
-)
-from fido_mds.exceptions import AttestationVerificationError
+from fido2.webauthn import AuthenticatorAttachment, PublicKeyCredentialUserEntity
 from flask import Blueprint
 
 from eduid.common.config.base import FrontendAction
@@ -24,11 +17,11 @@ from eduid.webapp.common.api.utils import save_and_sync_user
 from eduid.webapp.common.authn.utils import check_reauthn, get_authn_for_action
 from eduid.webapp.common.authn.webauthn import (
     OtherAuthenticatorStatus,
-    get_authenticator_information,
+    RegistrationError,
     get_webauthn_server,
-    is_authenticator_mfa_approved,
     make_credentials,
     save_webauthn_proofing_log,
+    verify_webauthn_registration,
 )
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.namespaces import WebauthnRegistration
@@ -116,67 +109,48 @@ def registration_complete(
         return _need_reauthn
 
     security_user = SecurityUser.from_user(user, current_app.private_userdb)
-    server = get_webauthn_server(rp_id=current_app.conf.fido2_rp_id, rp_name=current_app.conf.fido2_rp_name)
-    if client_extension_results:
-        response["client_extension_results"] = client_extension_results
-    registration = RegistrationResponse.from_dict(response)
+
     if not session.security.webauthn_registration:
         current_app.logger.info("Found no webauthn registration state in the session")
         return error_response(message=SecurityMsg.missing_registration_state)
 
-    # verify attestation and gather authenticator information from metadata
-    try:
-        authenticator_info = get_authenticator_information(
-            attestation=registration.response.attestation_object,
-            client_data=registration.response.client_data,
-            fido_mds=current_app.fido_mds,
-            fido_metadata_log=current_app.fido_metadata_log,
-            app_name=current_app.conf.app_name,
-            is_backdoor=check_magic_cookie(current_app.conf),
-        )
-    except (AttestationVerificationError, NotImplementedError, ValueError):
-        current_app.logger.exception("attestation verification failed")
-        current_app.logger.info(f"registration response: {response}")
-        return error_response(message=SecurityMsg.webauthn_attestation_fail)
-
-    # Move registration state from session to local variable to let users restart if something fails
     reg_state = session.security.webauthn_registration
     session.security.webauthn_registration = None
 
     try:
-        auth_data: AuthenticatorData = server.register_complete(state=reg_state.webauthn_state, response=registration)
-    except ValueError:
-        current_app.logger.exception("Webauthn registration failed")
+        result = verify_webauthn_registration(
+            response=response,
+            webauthn_state=reg_state.webauthn_state,
+            authenticator=reg_state.authenticator,
+            rp_id=current_app.conf.fido2_rp_id,
+            rp_name=current_app.conf.fido2_rp_name,
+            fido_mds=current_app.fido_mds,
+            fido_metadata_log=current_app.fido_metadata_log,
+            app_name=current_app.conf.app_name,
+            is_backdoor=check_magic_cookie(current_app.conf),
+            disallowed_status=current_app.conf.webauthn_disallowed_status,
+            client_extension_results=client_extension_results,
+        )
+    except RegistrationError:
         return error_response(message=SecurityMsg.webauthn_registration_fail)
-    if auth_data.credential_data is None:
-        current_app.logger.error("Webauthn credential data is missing")
-        current_app.logger.debug(f"Received auth_data: {auth_data}")
-        return error_response(message=SecurityMsg.webauthn_missing_credential_data)
-
-    credential_data = base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii")
-    current_app.logger.debug(f"Processed Webauthn credential data: {credential_data}")
-    mfa_approved = is_authenticator_mfa_approved(
-        authenticator_info=authenticator_info, disallowed_status=current_app.conf.webauthn_disallowed_status
-    )
-    current_app.logger.info(f"authenticator mfa approved: {mfa_approved}")
 
     credential = Webauthn(
-        keyhandle=registration.id,
-        authenticator_id=authenticator_info.authenticator_id,
-        credential_data=credential_data,
+        keyhandle=result.keyhandle,
+        authenticator_id=result.authenticator_info.authenticator_id,
+        credential_data=result.credential_data,
         app_id=current_app.conf.fido2_rp_id,
         description=description,
-        created_by="security",
-        authenticator=reg_state.authenticator,
-        mfa_approved=mfa_approved,
+        created_by=current_app.conf.app_name,
+        authenticator=result.authenticator,
+        mfa_approved=result.mfa_approved,
         webauthn_proofing_version=current_app.conf.webauthn_proofing_version,
-        attestation_format=authenticator_info.attestation_format,
+        attestation_format=result.authenticator_info.attestation_format,
     )
     security_user.credentials.add(credential)
 
-    if mfa_approved and not save_webauthn_proofing_log(
+    if result.mfa_approved and not save_webauthn_proofing_log(
         eppn=user.eppn,
-        authenticator_info=authenticator_info,
+        authenticator_info=result.authenticator_info,
         proofing_log=current_app.proofing_log,
         app_name=current_app.conf.app_name,
         proofing_version=current_app.conf.webauthn_proofing_version,
@@ -184,7 +158,7 @@ def registration_complete(
     ):
         current_app.logger.info("Could not save webauthn proofing log")
         current_app.logger.debug(f"credential: {credential}")
-        current_app.logger.debug(f"authenticator_info: {authenticator_info}")
+        current_app.logger.debug(f"authenticator_info: {result.authenticator_info}")
         return error_response(message=CommonMsg.temp_problem)
 
     try:
@@ -194,10 +168,12 @@ def registration_complete(
         return error_response(message=CommonMsg.temp_problem)
 
     # no stats for automatic tests
-    if authenticator_info.status is not OtherAuthenticatorStatus.MAGIC_COOKIE:
-        current_app.stats.count(name=f"webauthn_attestation_format_{authenticator_info.attestation_format.value}")
+    if result.authenticator_info.status is not OtherAuthenticatorStatus.MAGIC_COOKIE:
+        current_app.stats.count(
+            name=f"webauthn_attestation_format_{result.authenticator_info.attestation_format.value}"
+        )
         current_app.stats.count(name="webauthn_register_complete")
-        if mfa_approved:
+        if result.mfa_approved:
             current_app.stats.count(name="webauthn_mfa_approved")
         else:
             current_app.stats.count(name="webauthn_not_mfa_approved")

--- a/src/eduid/webapp/security/views/webauthn.py
+++ b/src/eduid/webapp/security/views/webauthn.py
@@ -1,11 +1,7 @@
 import base64
-from collections.abc import Sequence
 from typing import Any
 
-from fido2.server import Fido2Server, PublicKeyCredentialRpEntity
 from fido2.webauthn import (
-    AttestationConveyancePreference,
-    AttestedCredentialData,
     AuthenticatorAttachment,
     AuthenticatorData,
     PublicKeyCredentialUserEntity,
@@ -18,7 +14,7 @@ from eduid.common.config.base import FrontendAction
 from eduid.common.rpc.exceptions import AmTaskFailed
 from eduid.userdb import User
 from eduid.userdb.credentials import Webauthn
-from eduid.userdb.credentials.fido import U2F, FidoCredential
+from eduid.userdb.credentials.fido import FidoCredential
 from eduid.userdb.security import SecurityUser
 from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith, require_user
 from eduid.webapp.common.api.helpers import check_magic_cookie
@@ -26,6 +22,14 @@ from eduid.webapp.common.api.messages import CommonMsg, FluxData, error_response
 from eduid.webapp.common.api.schemas.base import FluxStandardAction
 from eduid.webapp.common.api.utils import save_and_sync_user
 from eduid.webapp.common.authn.utils import check_reauthn, get_authn_for_action
+from eduid.webapp.common.authn.webauthn import (
+    OtherAuthenticatorStatus,
+    get_authenticator_information,
+    get_webauthn_server,
+    is_authenticator_mfa_approved,
+    make_credentials,
+    save_webauthn_proofing_log,
+)
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.namespaces import WebauthnRegistration
 from eduid.webapp.security.app import current_security_app as current_app
@@ -41,38 +45,6 @@ from eduid.webapp.security.schemas import (
     WebauthnRegisterBeginSchema,
     WebauthnRegisterRequestSchema,
 )
-from eduid.webapp.security.webauthn_proofing import (
-    OtherAuthenticatorStatus,
-    get_authenticator_information,
-    is_authenticator_mfa_approved,
-    save_webauthn_proofing_log,
-)
-
-
-def get_webauthn_server(
-    rp_id: str, rp_name: str, attestation: AttestationConveyancePreference | None = None
-) -> Fido2Server:
-    rp = PublicKeyCredentialRpEntity(id=rp_id, name=rp_name)
-    return Fido2Server(rp, attestation=attestation)
-
-
-def make_credentials(creds: Sequence[FidoCredential]) -> list[AttestedCredentialData]:
-    credentials = []
-    for cred in creds:
-        if isinstance(cred, Webauthn):
-            cred_data = base64.urlsafe_b64decode(cred.credential_data.encode("ascii"))
-            credential_data, rest = AttestedCredentialData.unpack_from(cred_data)
-            if rest:
-                continue
-        elif isinstance(cred, U2F):
-            # cred is of type U2F (legacy registration)
-            credential_data = AttestedCredentialData.from_ctap1(
-                cred.keyhandle.encode("ascii"), cred.public_key.encode("ascii")
-            )
-        else:
-            raise ValueError(f"Unknown credential {cred!r}")
-        credentials.append(credential_data)
-    return credentials
 
 
 webauthn_views = Blueprint("webauthn", __name__, url_prefix="/webauthn", template_folder="templates")
@@ -156,7 +128,11 @@ def registration_complete(
     # verify attestation and gather authenticator information from metadata
     try:
         authenticator_info = get_authenticator_information(
-            attestation=registration.response.attestation_object, client_data=registration.response.client_data
+            attestation=registration.response.attestation_object,
+            client_data=registration.response.client_data,
+            fido_mds=current_app.fido_mds,
+            fido_metadata_log=current_app.fido_metadata_log,
+            config=current_app.conf,
         )
     except (AttestationVerificationError, NotImplementedError, ValueError):
         current_app.logger.exception("attestation verification failed")
@@ -179,7 +155,9 @@ def registration_complete(
 
     credential_data = base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii")
     current_app.logger.debug(f"Processed Webauthn credential data: {credential_data}")
-    mfa_approved = is_authenticator_mfa_approved(authenticator_info=authenticator_info)
+    mfa_approved = is_authenticator_mfa_approved(
+        authenticator_info=authenticator_info, disallowed_status=current_app.conf.webauthn_disallowed_status
+    )
     current_app.logger.info(f"authenticator mfa approved: {mfa_approved}")
 
     credential = Webauthn(
@@ -196,7 +174,14 @@ def registration_complete(
     )
     security_user.credentials.add(credential)
 
-    if mfa_approved and not save_webauthn_proofing_log(user.eppn, authenticator_info):
+    if mfa_approved and not save_webauthn_proofing_log(
+        eppn=user.eppn,
+        authenticator_info=authenticator_info,
+        proofing_log=current_app.proofing_log,
+        app_name=current_app.conf.app_name,
+        proofing_version=current_app.conf.webauthn_proofing_version,
+        proofing_method=current_app.conf.webauthn_proofing_method,
+    ):
         current_app.logger.info("Could not save webauthn proofing log")
         current_app.logger.debug(f"credential: {credential}")
         current_app.logger.debug(f"authenticator_info: {authenticator_info}")

--- a/src/eduid/webapp/security/views/webauthn.py
+++ b/src/eduid/webapp/security/views/webauthn.py
@@ -46,7 +46,6 @@ from eduid.webapp.security.schemas import (
     WebauthnRegisterRequestSchema,
 )
 
-
 webauthn_views = Blueprint("webauthn", __name__, url_prefix="/webauthn", template_folder="templates")
 
 

--- a/src/eduid/webapp/security/views/webauthn.py
+++ b/src/eduid/webapp/security/views/webauthn.py
@@ -131,7 +131,7 @@ def registration_complete(
             client_data=registration.response.client_data,
             fido_mds=current_app.fido_mds,
             fido_metadata_log=current_app.fido_metadata_log,
-            config=current_app.conf,
+            is_backdoor=check_magic_cookie(current_app.conf),
         )
     except (AttestationVerificationError, NotImplementedError, ValueError):
         current_app.logger.exception("attestation verification failed")

--- a/src/eduid/webapp/signup/app.py
+++ b/src/eduid/webapp/signup/app.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any, cast
 
+from fido_mds import FidoMetadataStore
 from flask import current_app
 
 from eduid.common.clients import SCIMClient
@@ -9,6 +10,7 @@ from eduid.common.config.parsers import load_config
 from eduid.common.rpc.am_relay import AmRelay
 from eduid.queue.db.message import MessageDB
 from eduid.userdb.logs import ProofingLog
+from eduid.userdb.logs.db import FidoMetadataLog
 from eduid.userdb.signup import SignupInviteDB, SignupUserDB
 from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.api.captcha import init_captcha
@@ -31,6 +33,8 @@ class SignupApp(EduIDBaseApp[SignupConfig]):
         self.proofing_log = ProofingLog(config.mongo_uri)
         self.invite_db = SignupInviteDB(config.mongo_uri)
         self.messagedb = MessageDB(config.mongo_uri)
+        self.fido_mds = FidoMetadataStore()
+        self.fido_metadata_log = FidoMetadataLog(config.mongo_uri)
 
     def get_scim_client_for(self, data_owner: str) -> SCIMClient:
         if self.conf.gnap_auth_data is None or self.conf.scim_api_url is None:

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -197,7 +197,7 @@ def send_signup_mail(email: str, verification_code: str, reference: str) -> None
         current_app.logger.debug(f"Generating verification e-mail with context:\n{payload}")
 
 
-def ensure_eppn() -> str:
+def get_eppn() -> str:
     """Generate and store an eppn in the signup session if not already present."""
     if session.signup.eppn is None:
         session.signup.eppn = generate_eppn()
@@ -213,7 +213,6 @@ def create_and_sync_user(
     custom_password: str | None = None,
     webauthn: Webauthn | None = None,
     webauthn_authenticator_info: AuthenticatorInformation | None = None,
-    eppn: str | None = None,
 ) -> SignupUser:
     """
     * Create a new user in the central userdb
@@ -226,7 +225,7 @@ def create_and_sync_user(
     """
     current_app.logger.info("Creating new user")
 
-    signup_user = SignupUser(eppn=eppn or generate_eppn())
+    signup_user = SignupUser(eppn=get_eppn())
     signup_user.given_name = given_name
     signup_user.surname = surname
 

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -16,6 +16,7 @@ from eduid.common.models.scim_user import NutidUserExtensionV1, UserCreateReques
 from eduid.queue.client import init_queue_item
 from eduid.queue.db.message import EduidSignupEmail
 from eduid.userdb import MailAddress, NinIdentity, PhoneNumber, Profile, User
+from eduid.userdb.credentials import Webauthn
 from eduid.userdb.exceptions import UserDoesNotExist, UserOutOfSync
 from eduid.userdb.logs import MailAddressProofing
 from eduid.userdb.signup import Invite, InviteType, SCIMReference, SignupUser
@@ -26,6 +27,7 @@ from eduid.webapp.common.api.translation import get_user_locale
 from eduid.webapp.common.api.utils import is_throttled, save_and_sync_user, time_left
 from eduid.webapp.common.api.validation import is_valid_password
 from eduid.webapp.common.authn.vccs import add_password, revoke_passwords
+from eduid.webapp.common.authn.webauthn import AuthenticatorInformation, save_webauthn_proofing_log
 from eduid.webapp.common.session import session
 from eduid.webapp.signup.app import current_signup_app as current_app
 
@@ -193,6 +195,13 @@ def send_signup_mail(email: str, verification_code: str, reference: str) -> None
         current_app.logger.debug(f"Generating verification e-mail with context:\n{payload}")
 
 
+def ensure_eppn() -> str:
+    """Generate and store an eppn in the signup session if not already present."""
+    if session.signup.eppn is None:
+        session.signup.eppn = generate_eppn()
+    return session.signup.eppn
+
+
 def create_and_sync_user(
     given_name: str,
     surname: str,
@@ -200,6 +209,9 @@ def create_and_sync_user(
     tou_version: str,
     generated_password: str | None = None,
     custom_password: str | None = None,
+    webauthn: Webauthn | None = None,
+    webauthn_authenticator_info: AuthenticatorInformation | None = None,
+    eppn: str | None = None,
 ) -> SignupUser:
     """
     * Create a new user in the central userdb
@@ -212,7 +224,7 @@ def create_and_sync_user(
     """
     current_app.logger.info("Creating new user")
 
-    signup_user = SignupUser(eppn=generate_eppn())
+    signup_user = SignupUser(eppn=eppn or generate_eppn())
     signup_user.given_name = given_name
     signup_user.surname = surname
 
@@ -239,12 +251,27 @@ def create_and_sync_user(
             current_app.logger.debug(f"signup_user: {signup_user}")
             raise VCCSBackendFailure("Failed to add a credential to user")
 
+    if webauthn is not None:
+        signup_user.credentials.add(webauthn)
+
     try:
         save_and_sync_user(signup_user)
     except UserOutOfSync as e:
         revoke_passwords(user=signup_user, reason="UserOutOfSync during signup", application=current_app.conf.app_name)
         current_app.logger.error(f"Failed saving user {signup_user}, data out of sync")
         raise e
+
+    # Write webauthn proofing log after user is saved (eppn exists in DB)
+    if webauthn is not None and webauthn_authenticator_info is not None and webauthn.mfa_approved:
+        if not save_webauthn_proofing_log(
+            eppn=signup_user.eppn,
+            authenticator_info=webauthn_authenticator_info,
+            proofing_log=current_app.proofing_log,
+            app_name=current_app.conf.app_name,
+            proofing_version=current_app.conf.webauthn_proofing_version,
+            proofing_method=current_app.conf.webauthn_proofing_method,
+        ):
+            current_app.logger.error("Failed to save webauthn proofing log")
 
     current_app.stats.count(name="user_created")
     current_app.logger.info("Signup user created")

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -68,8 +68,10 @@ class SignupMsg(TranslatableMsg):
     password_not_generated = "signup.password-not-generated"
     # user has provided a weak custom password
     weak_custom_password = "signup.weak-custom-password"
-    # user has not registered webauthn
-    webauthn_not_registered = "signup.webauthn-not-registered"
+    # webauthn registration failed or not completed
+    webauthn_registration_failed = "signup.webauthn-registration-failed"
+    # user has not set name (given_name and surname)
+    name_not_set = "signup.name-not-set"
     # user has no credential
     credential_not_added = "signup.credential-not-added"
     # invite not found

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -111,7 +111,7 @@ class SignupStatusResponse(FluxStandardAction):
     def set_webauthn_registered(self, out_data: dict, **kwargs: Any) -> dict:
         if out_data["payload"].get("state", {}).get("credentials"):
             out_data["payload"]["state"]["credentials"]["webauthn_registered"] = bool(
-                out_data["payload"]["state"]["credentials"].get("webauthn_credential_data")
+                out_data["payload"]["state"]["credentials"].get("webauthn")
             )
         return out_data
 

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -48,7 +48,7 @@ class SignupStatusResponse(FluxStandardAction):
                 completed = fields.Boolean(required=True)
                 generated_password = fields.String(required=True, dump_default=None)
                 custom_password = fields.Boolean(required=True, dump_default=False)
-                # TODO: implement webauthn signup
+                webauthn_registered = fields.Boolean(required=True, dump_default=False)
 
             already_signed_up = fields.Boolean(required=True)
             name = fields.Nested(Name, required=True)
@@ -107,6 +107,14 @@ class SignupStatusResponse(FluxStandardAction):
             )
         return out_data
 
+    @pre_dump
+    def set_webauthn_registered(self, out_data: dict, **kwargs: Any) -> dict:
+        if out_data["payload"].get("state", {}).get("credentials"):
+            out_data["payload"]["state"]["credentials"]["webauthn_registered"] = bool(
+                out_data["payload"]["state"]["credentials"].get("webauthn_credential_data")
+            )
+        return out_data
+
 
 class AcceptTouRequest(EduidSchema, CSRFRequestMixin):
     tou_accepted = fields.Boolean(required=True)
@@ -159,3 +167,13 @@ class InviteCompletedResponse(FluxStandardAction):
         finish_url = fields.String(required=False)
 
     payload = fields.Nested(InviteCompletedSchema)
+
+
+class WebauthnRegisterBeginRequest(EduidSchema, CSRFRequestMixin):
+    authenticator = fields.String(required=True)
+
+
+class WebauthnRegisterCompleteRequest(EduidSchema, CSRFRequestMixin):
+    response = fields.Dict(required=True)
+    description = fields.String(required=True)
+    client_extension_results = fields.Dict(required=False, data_key="clientExtensionResults")

--- a/src/eduid/webapp/signup/settings/common.py
+++ b/src/eduid/webapp/signup/settings/common.py
@@ -7,12 +7,12 @@ from eduid.common.config.base import (
     AmConfigMixin,
     CaptchaConfigMixin,
     EduIDBaseAppConfig,
+    Fido2RpConfigMixin,
     MagicCookieMixin,
     PasswordConfigMixin,
     TouConfigMixin,
     VCCSConfigMixin,
-    WebauthnAppConfigMixin,
-    WebauthnConfigMixin2,
+    WebauthnRegistrationConfigMixin,
 )
 from eduid.common.models.generic import AnyUrlStr
 
@@ -25,8 +25,8 @@ class SignupConfig(
     CaptchaConfigMixin,
     PasswordConfigMixin,
     VCCSConfigMixin,
-    WebauthnConfigMixin2,
-    WebauthnAppConfigMixin,
+    Fido2RpConfigMixin,
+    WebauthnRegistrationConfigMixin,
 ):
     """
     Configuration for the signup app

--- a/src/eduid/webapp/signup/settings/common.py
+++ b/src/eduid/webapp/signup/settings/common.py
@@ -11,6 +11,8 @@ from eduid.common.config.base import (
     PasswordConfigMixin,
     TouConfigMixin,
     VCCSConfigMixin,
+    WebauthnAppConfigMixin,
+    WebauthnConfigMixin2,
 )
 from eduid.common.models.generic import AnyUrlStr
 
@@ -23,6 +25,8 @@ class SignupConfig(
     CaptchaConfigMixin,
     PasswordConfigMixin,
     VCCSConfigMixin,
+    WebauthnConfigMixin2,
+    WebauthnAppConfigMixin,
 ):
     """
     Configuration for the signup app

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -860,7 +860,12 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         assert state == {
             "already_signed_up": False,
             "captcha": {"completed": False},
-            "credentials": {"completed": False, "custom_password": False, "generated_password": None, "webauthn_registered": False},
+            "credentials": {
+                "completed": False,
+                "custom_password": False,
+                "generated_password": None,
+                "webauthn_registered": False,
+            },
             "email": {"address": None, "bad_attempts": 0, "bad_attempts_max": 3, "completed": False, "sent_at": None},
             "invite": {"completed": False, "finish_url": None, "initiated_signup": False},
             "name": {"given_name": None, "surname": None},
@@ -875,7 +880,12 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         assert state == {
             "already_signed_up": True,
             "captcha": {"completed": False},
-            "credentials": {"completed": False, "custom_password": False, "generated_password": None, "webauthn_registered": False},
+            "credentials": {
+                "completed": False,
+                "custom_password": False,
+                "generated_password": None,
+                "webauthn_registered": False,
+            },
             "email": {"address": None, "bad_attempts": 0, "bad_attempts_max": 3, "completed": False, "sent_at": None},
             "invite": {"completed": False, "finish_url": None, "initiated_signup": False},
             "name": {"given_name": None, "surname": None},
@@ -1403,7 +1413,12 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         assert normalised_data(state, exclude_keys=["expires_time_left", "throttle_time_left", "sent_at"]) == {
             "already_signed_up": False,
             "captcha": {"completed": False},
-            "credentials": {"completed": False, "custom_password": False, "generated_password": None, "webauthn_registered": False},
+            "credentials": {
+                "completed": False,
+                "custom_password": False,
+                "generated_password": None,
+                "webauthn_registered": False,
+            },
             "email": {
                 "address": "dummy@example.com",
                 "bad_attempts": 0,

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -82,6 +82,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
                 "default_finish_url": "https://www.eduid.se/",
                 "captcha_max_bad_attempts": 3,
                 "environment": "dev",
+                "fido2_rp_id": "eduid.docker",
                 "scim_api_url": "http://localhost/scim/",
                 "gnap_auth_data": {
                     "authn_server_url": "http://localhost/auth/",
@@ -859,7 +860,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         assert state == {
             "already_signed_up": False,
             "captcha": {"completed": False},
-            "credentials": {"completed": False, "custom_password": False, "generated_password": None},
+            "credentials": {"completed": False, "custom_password": False, "generated_password": None, "webauthn_registered": False},
             "email": {"address": None, "bad_attempts": 0, "bad_attempts_max": 3, "completed": False, "sent_at": None},
             "invite": {"completed": False, "finish_url": None, "initiated_signup": False},
             "name": {"given_name": None, "surname": None},
@@ -874,7 +875,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         assert state == {
             "already_signed_up": True,
             "captcha": {"completed": False},
-            "credentials": {"completed": False, "custom_password": False, "generated_password": None},
+            "credentials": {"completed": False, "custom_password": False, "generated_password": None, "webauthn_registered": False},
             "email": {"address": None, "bad_attempts": 0, "bad_attempts_max": 3, "completed": False, "sent_at": None},
             "invite": {"completed": False, "finish_url": None, "initiated_signup": False},
             "name": {"given_name": None, "surname": None},
@@ -1402,7 +1403,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         assert normalised_data(state, exclude_keys=["expires_time_left", "throttle_time_left", "sent_at"]) == {
             "already_signed_up": False,
             "captcha": {"completed": False},
-            "credentials": {"completed": False, "custom_password": False, "generated_password": None},
+            "credentials": {"completed": False, "custom_password": False, "generated_password": None, "webauthn_registered": False},
             "email": {
                 "address": "dummy@example.com",
                 "bad_attempts": 0,

--- a/src/eduid/webapp/signup/tests/test_webauthn.py
+++ b/src/eduid/webapp/signup/tests/test_webauthn.py
@@ -1,0 +1,368 @@
+import base64
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+from fido2.webauthn import AuthenticatorAttachment, RegistrationResponse
+from jwcrypto.jwk import JWK
+from pytest_mock import MockerFixture
+from werkzeug.test import TestResponse
+
+from eduid.common.config.base import EduidEnvironment
+from eduid.userdb.credentials import Password, Webauthn
+from eduid.webapp.common.api.testing import EduidAPITestCase
+from eduid.webapp.common.authn.webauthn import get_webauthn_server
+from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.namespaces import WebauthnRegistration, WebauthnState
+from eduid.webapp.signup.app import SignupApp, signup_init_app
+from eduid.webapp.signup.helpers import SignupMsg
+
+logger = logging.getLogger(__name__)
+
+# CTAP1 test data (copied from security tests)
+
+STATE = {"challenge": "u3zHzb7krB4c4wj0Uxuhsz2lCXqLnwV9ZxMhvL2lcfo", "user_verification": "discouraged"}
+
+ATTESTATION_OBJECT = (
+    b"o2NmbXRoZmlkby11MmZnYXR0U3RtdKJjc2lnWEcwRQIgPCNiKlxIO0iR5Wo9BidnNhX2lAFcAB3VwuRH"
+    b"QZbL3dwCIQDFKuPjwLTvjaDw9TbfoJeww7DMsZSlteW4ClwRivpUqWN4NWOBWQIzMIICLzCCARmgAwIB"
+    b"AgIEQvUaTTALBgkqhkiG9w0BAQswLjEsMCoGA1UEAxMjWXViaWNvIFUyRiBSb290IENBIFNlcmlhbCA0"
+    b"NTcyMDA2MzEwIBcNMTQwODAxMDAwMDAwWhgPMjA1MDA5MDQwMDAwMDBaMCoxKDAmBgNVBAMMH1l1Ymlj"
+    b"byBVMkYgRUUgU2VyaWFsIDExMjMzNTkzMDkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQphQ-PJYiZ"
+    b"jZEVHtrx5QGE3_LE1-OytZPTwzrpWBKywji_3qmg22mwmVFl32PO269TxY-yVN4jbfVf5uX0EWJWoyYw"
+    b"JDAiBgkrBgEEAYLECgIEFTEuMy42LjEuNC4xLjQxNDgyLjEuNDALBgkqhkiG9w0BAQsDggEBALSc3YwT"
+    b"RbLwXhePj_imdBOhWiqh6ssS2ONgp5tphJCHR5Agjg2VstLBRsJzyJnLgy7bGZ0QbPOyh_J0hsvgBfvj"
+    b"ByXOu1AwCW-tcoJ-pfxESojDLDn8hrFph6eWZoCtBsWMDh6vMqPENeP6grEAECWx4fTpBL9Bm7F-0Rp_"
+    b"d1_l66g4IhF_ZvuRFhY-BUK94BfivuBHpEkMwxKENTas7VkxvlVstUvPqhPHGYOq7RdF1D_THsbNY8-t"
+    b"gCTgvTziEG-bfDeY6zIz5h7bxb1rpajNVTpUDWtVYL7_w44e1KCoErqdS-kEbmmkmm7KvDE8kuyg42Fm"
+    b"b5DTMsbY2jxMlMVoYXV0aERhdGFYxNz3BHEmKmoM4iTRAmMUgSjEdNSeKZskhyDzwzPuNmHTQQAAAAAA"
+    b"AAAAAAAAAAAAAAAAAAAAAEC8lMNeMgJDZOvOHus-78SI8YvR3HVUwv2NR3PcfvBndpabw-UiQQjx4N-T"
+    b"lJZcGJFfhzzQ9oAnkvZhcwGGTdtLpQECAyYgASFYIOHIO6vueJNYEgtQUy_wdwVka6DrKYSXnsIM6nfx"
+    b"-mtgIlggkCpDejidmogF4SZ_n01JlE8dY43tFEIwAPy2qCGinzQ"
+)
+
+CLIENT_DATA_JSON = (
+    b"eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoidTN6SHpiN2tyQjRjNHdqMFV4dWhz"
+    b"ejJsQ1hxTG53VjlaeE1odkwybGNmbyIsIm9yaWdpbiI6Imh0dHBzOi8vZGFzaGJvYXJkLmVkdWlkLmRv"
+    b"Y2tlciIsImNyb3NzT3JpZ2luIjpmYWxzZX0"
+)
+
+CREDENTIAL_ID = (
+    "31f8974379e65869f9b7caaf28f0e44eead0fdd883e9c545404e351824a6c4cea738613e4ef5b9"
+    "d699fbc4d6bab05117a13cc81875b732e00058027155ced047"
+)
+
+
+class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
+    @pytest.fixture(autouse=True)
+    def setup(self, setup_api: None, mocker: MockerFixture) -> None:
+        self.mocker = mocker
+
+    def load_app(self, config: Mapping[str, Any]) -> SignupApp:
+        return signup_init_app(name="signup", test_config=config)
+
+    @pytest.fixture(scope="class")
+    def update_config(self) -> dict[str, Any]:
+        config = self._get_base_config()
+        config.update(
+            {
+                "available_languages": {"en": "English", "sv": "Svenska"},
+                "signup_url": "https://localhost/",
+                "dashboard_url": "https://localhost/",
+                "development": "DEBUG",
+                "application_root": "/",
+                "log_level": "DEBUG",
+                "password_length": 10,
+                "vccs_url": "http://turq:13085/",
+                "default_finish_url": "https://www.eduid.se/",
+                "captcha_max_bad_attempts": 3,
+                "environment": "dev",
+                "fido2_rp_id": "eduid.docker",
+                "scim_api_url": "http://localhost/scim/",
+                "gnap_auth_data": {
+                    "authn_server_url": "http://localhost/auth/",
+                    "key_name": "app_name",
+                    "client_jwk": JWK.generate(kid="testkey", kty="EC", size=256).export(as_dict=True),
+                },
+            }
+        )
+        return config
+
+    def _prepare_for_webauthn(self) -> None:
+        """Set session state as if captcha, email verify, and ToU are completed."""
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                sess.signup.captcha.completed = True
+                sess.signup.email.address = "test@example.com"
+                sess.signup.email.completed = True
+                sess.signup.email.reference = "test_ref"
+                sess.signup.tou.completed = True
+                sess.signup.tou.version = "test_tou_v1"
+                sess.signup.name.given_name = "Test"
+                sess.signup.name.surname = "Testdotter"
+
+    def _begin_register_webauthn(
+        self,
+        authenticator: str = "cross-platform",
+    ) -> TestResponse:
+        """Call POST /webauthn/register/begin with magic cookie."""
+        self.app.conf.magic_cookie = "magic-cookie"
+        self.app.conf.magic_cookie_name = "magic"
+        self.app.conf.environment = EduidEnvironment("dev")
+
+        with self.session_cookie(self.browser, eppn=None) as client:
+            client.set_cookie(domain=self.test_domain, key="magic", value="magic-cookie")
+            with client.session_transaction() as sess:
+                csrf_token = sess.get_csrf_token()
+                data = {"csrf_token": csrf_token, "authenticator": authenticator}
+            response = client.post("/webauthn/register/begin", data=json.dumps(data), content_type=self.content_type_json)
+            return response
+
+    def _complete_register_webauthn(self) -> TestResponse:
+        """Set WebauthnRegistration in session, call POST /webauthn/register/complete with magic cookie."""
+        self.app.conf.magic_cookie = "magic-cookie"
+        self.app.conf.magic_cookie_name = "magic"
+        self.app.conf.environment = EduidEnvironment("dev")
+
+        webauthn_state = WebauthnState(STATE)
+        with self.session_cookie(self.browser, eppn=None) as client:
+            client.set_cookie(domain=self.test_domain, key="magic", value="magic-cookie")
+            with client.session_transaction() as sess:
+                assert isinstance(sess, EduidSession)
+                sess.signup.credentials.webauthn_registration = WebauthnRegistration(
+                    webauthn_state=webauthn_state, authenticator=AuthenticatorAttachment.CROSS_PLATFORM
+                )
+                csrf_token = sess.get_csrf_token()
+                data = {
+                    "csrf_token": csrf_token,
+                    "response": {
+                        "credentialId": CREDENTIAL_ID,
+                        "rawId": CREDENTIAL_ID,
+                        "response": {
+                            "attestationObject": ATTESTATION_OBJECT.decode(),
+                            "clientDataJSON": CLIENT_DATA_JSON.decode(),
+                            "credentialId": CREDENTIAL_ID,
+                        },
+                    },
+                    "description": "test security key",
+                }
+            response = client.post(
+                "/webauthn/register/complete", data=json.dumps(data), content_type=self.content_type_json
+            )
+            return response
+
+    def _create_user_with_webauthn(
+        self,
+        use_suggested_password: bool = False,
+        use_webauthn: bool = True,
+        generated_password: str | None = None,
+        custom_password: str | None = None,
+    ) -> TestResponse:
+        """Call POST /create-user with webauthn flag."""
+        mock_request_user_sync = self.mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
+        mock_add_credentials = self.mocker.patch("eduid.vccs.client.VCCSClient.add_credentials")
+        mock_add_credentials.return_value = True
+        mock_request_user_sync.side_effect = self.request_user_sync
+
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                csrf_token = sess.get_csrf_token()
+                data: dict[str, Any] = {
+                    "csrf_token": csrf_token,
+                    "use_suggested_password": use_suggested_password,
+                    "use_webauthn": use_webauthn,
+                }
+                if custom_password is not None:
+                    data["custom_password"] = custom_password
+            response = client.post("/create-user", json=data)
+            return response
+
+    def _set_webauthn_credential_in_session(self) -> None:
+        """Register a webauthn credential using the test fixtures and store the result in the session."""
+        server = get_webauthn_server(rp_id=self.app.conf.fido2_rp_id, rp_name=self.app.conf.fido2_rp_name)
+        reg_response = {
+            "credentialId": CREDENTIAL_ID,
+            "rawId": CREDENTIAL_ID,
+            "response": {
+                "attestationObject": ATTESTATION_OBJECT.decode("ascii").strip("="),
+                "clientDataJSON": CLIENT_DATA_JSON.decode("ascii").strip("="),
+            },
+        }
+        registration = RegistrationResponse.from_dict(reg_response)
+        auth_data = server.register_complete(state=STATE, response=registration)
+        assert auth_data.credential_data is not None
+
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                sess.signup.credentials.webauthn_credential_data = base64.urlsafe_b64encode(
+                    auth_data.credential_data
+                ).decode("ascii")
+                sess.signup.credentials.webauthn_keyhandle = auth_data.credential_data.credential_id.hex()
+                sess.signup.credentials.webauthn_authenticator = AuthenticatorAttachment.CROSS_PLATFORM
+                sess.signup.credentials.webauthn_description = "test security key"
+                sess.signup.credentials.completed = True
+
+    # --- Tests ---
+
+    def test_webauthn_register_begin(self) -> None:
+        """Happy path: verify response type and registration_data."""
+        self._prepare_for_webauthn()
+        response = self._begin_register_webauthn()
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_WEBAUTHN_REGISTER_BEGIN_SUCCESS"
+        assert "registration_data" in data["payload"]
+        assert "csrf_token" in data["payload"]
+
+    def test_webauthn_register_begin_generates_eppn(self) -> None:
+        """Verify that session.signup.eppn is set after begin."""
+        self._prepare_for_webauthn()
+        self._begin_register_webauthn()
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                assert sess.signup.eppn is not None
+
+    def test_webauthn_register_begin_requires_captcha(self) -> None:
+        """Unset captcha, expect failure."""
+        self._prepare_for_webauthn()
+        # Unset captcha completed
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                sess.signup.captcha.completed = False
+        response = self._begin_register_webauthn()
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_WEBAUTHN_REGISTER_BEGIN_FAIL"
+        assert data["payload"]["message"] == SignupMsg.captcha_not_completed.value
+
+    def test_webauthn_register_begin_requires_email_verified(self) -> None:
+        """Unset email, expect failure."""
+        self._prepare_for_webauthn()
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                sess.signup.email.completed = False
+        response = self._begin_register_webauthn()
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_WEBAUTHN_REGISTER_BEGIN_FAIL"
+        assert data["payload"]["message"] == SignupMsg.email_verification_not_complete.value
+
+    def test_webauthn_register_begin_requires_tou(self) -> None:
+        """Unset tou, expect failure."""
+        self._prepare_for_webauthn()
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                sess.signup.tou.completed = False
+        response = self._begin_register_webauthn()
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_WEBAUTHN_REGISTER_BEGIN_FAIL"
+        assert data["payload"]["message"] == SignupMsg.tou_not_completed.value
+
+    def test_webauthn_register_complete(self) -> None:
+        """Happy path with mocked state, verify credentials.completed and webauthn_registered."""
+        self._prepare_for_webauthn()
+        response = self._complete_register_webauthn()
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_WEBAUTHN_REGISTER_COMPLETE_SUCCESS"
+        assert data["payload"]["state"]["credentials"]["completed"] is True
+        assert data["payload"]["state"]["credentials"]["webauthn_registered"] is True
+
+    def test_webauthn_register_complete_no_state(self) -> None:
+        """No registration in session, expect failure."""
+        self._prepare_for_webauthn()
+        # Do NOT set webauthn_registration in session; just call complete directly
+        self.app.conf.magic_cookie = "magic-cookie"
+        self.app.conf.magic_cookie_name = "magic"
+        self.app.conf.environment = EduidEnvironment("dev")
+
+        with self.session_cookie(self.browser, eppn=None) as client:
+            client.set_cookie(domain=self.test_domain, key="magic", value="magic-cookie")
+            with client.session_transaction() as sess:
+                csrf_token = sess.get_csrf_token()
+                data = {
+                    "csrf_token": csrf_token,
+                    "response": {
+                        "credentialId": CREDENTIAL_ID,
+                        "rawId": CREDENTIAL_ID,
+                        "response": {
+                            "attestationObject": ATTESTATION_OBJECT.decode(),
+                            "clientDataJSON": CLIENT_DATA_JSON.decode(),
+                            "credentialId": CREDENTIAL_ID,
+                        },
+                    },
+                    "description": "test security key",
+                }
+            response = client.post(
+                "/webauthn/register/complete", data=json.dumps(data), content_type=self.content_type_json
+            )
+        resp_data = response.json
+        assert resp_data is not None
+        assert resp_data["type"] == "POST_SIGNUP_WEBAUTHN_REGISTER_COMPLETE_FAIL"
+        assert resp_data["payload"]["message"] == SignupMsg.webauthn_not_registered.value
+
+    def test_create_user_with_webauthn_only(self) -> None:
+        """Full flow with webauthn, no password."""
+        self._prepare_for_webauthn()
+        self._set_webauthn_credential_in_session()
+        response = self._create_user_with_webauthn(use_suggested_password=False, use_webauthn=True)
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_CREATE_USER_SUCCESS"
+        assert data["payload"]["state"]["user_created"] is True
+        assert data["payload"]["state"]["credentials"]["completed"] is True
+        assert data["payload"]["state"]["credentials"]["webauthn_registered"] is True
+
+        # Verify the user was created with a webauthn credential
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                eppn = sess.common.eppn
+                assert eppn is not None
+        user = self.app.central_userdb.get_user_by_eppn(eppn)
+        assert user is not None
+        webauthn_creds = user.credentials.filter(Webauthn)
+        assert len(webauthn_creds) == 1
+        passwords = user.credentials.filter(Password)
+        assert len(passwords) == 0
+
+    def test_create_user_with_password_and_webauthn(self) -> None:
+        """Full flow with both password and webauthn."""
+        self._prepare_for_webauthn()
+        self._set_webauthn_credential_in_session()
+        # Also set a generated password
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                sess.signup.credentials.generated_password = "test_password"
+
+        response = self._create_user_with_webauthn(use_suggested_password=True, use_webauthn=True)
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_CREATE_USER_SUCCESS"
+        assert data["payload"]["state"]["user_created"] is True
+        assert data["payload"]["state"]["credentials"]["completed"] is True
+        assert data["payload"]["state"]["credentials"]["webauthn_registered"] is True
+
+        # Verify the user was created with both credentials
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                eppn = sess.common.eppn
+                assert eppn is not None
+        user = self.app.central_userdb.get_user_by_eppn(eppn)
+        assert user is not None
+        webauthn_creds = user.credentials.filter(Webauthn)
+        assert len(webauthn_creds) == 1
+        passwords = user.credentials.filter(Password)
+        assert len(passwords) == 1
+        assert passwords[0].is_generated is True
+
+    def test_create_user_no_credential(self) -> None:
+        """Neither password nor webauthn, expect failure."""
+        self._prepare_for_webauthn()
+        response = self._create_user_with_webauthn(use_suggested_password=False, use_webauthn=False)
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_CREATE_USER_FAIL"
+        assert data["payload"]["message"] == SignupMsg.credential_not_added.value

--- a/src/eduid/webapp/signup/tests/test_webauthn.py
+++ b/src/eduid/webapp/signup/tests/test_webauthn.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 from fido2.webauthn import AuthenticatorAttachment, RegistrationResponse
+from fido_mds.models.webauthn import AttestationFormat
 from jwcrypto.jwk import JWK
 from pytest_mock import MockerFixture
 from werkzeug.test import TestResponse
@@ -203,6 +204,9 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
                 ).decode("ascii")
                 sess.signup.credentials.webauthn_keyhandle = auth_data.credential_data.credential_id.hex()
                 sess.signup.credentials.webauthn_authenticator = AuthenticatorAttachment.CROSS_PLATFORM
+                sess.signup.credentials.webauthn_authenticator_id = "test-authenticator-id"
+                sess.signup.credentials.webauthn_mfa_approved = False
+                sess.signup.credentials.webauthn_attestation_format = AttestationFormat.FIDO_U2F
                 sess.signup.credentials.webauthn_description = "test security key"
                 sess.signup.credentials.completed = True
 

--- a/src/eduid/webapp/signup/tests/test_webauthn.py
+++ b/src/eduid/webapp/signup/tests/test_webauthn.py
@@ -117,7 +117,9 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
             with client.session_transaction() as sess:
                 csrf_token = sess.get_csrf_token()
                 data = {"csrf_token": csrf_token, "authenticator": authenticator}
-            response = client.post("/webauthn/register/begin", data=json.dumps(data), content_type=self.content_type_json)
+            response = client.post(
+                "/webauthn/register/begin", data=json.dumps(data), content_type=self.content_type_json
+            )
             return response
 
     def _complete_register_webauthn(self) -> TestResponse:

--- a/src/eduid/webapp/signup/tests/test_webauthn.py
+++ b/src/eduid/webapp/signup/tests/test_webauthn.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pytest
 from fido2.webauthn import AuthenticatorAttachment, RegistrationResponse
-from fido_mds.models.webauthn import AttestationFormat
 from jwcrypto.jwk import JWK
 from pytest_mock import MockerFixture
 from werkzeug.test import TestResponse
@@ -16,7 +15,7 @@ from eduid.userdb.credentials import Password, Webauthn
 from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.common.authn.webauthn import get_webauthn_server
 from eduid.webapp.common.session import EduidSession
-from eduid.webapp.common.session.namespaces import WebauthnRegistration, WebauthnState
+from eduid.webapp.common.session.namespaces import WebauthnCredential, WebauthnRegistration, WebauthnState
 from eduid.webapp.signup.app import SignupApp, signup_init_app
 from eduid.webapp.signup.helpers import SignupMsg
 
@@ -199,15 +198,13 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
 
         with self.session_cookie(self.browser, eppn=None) as client:
             with client.session_transaction() as sess:
-                sess.signup.credentials.webauthn_credential_data = base64.urlsafe_b64encode(
-                    auth_data.credential_data
-                ).decode("ascii")
-                sess.signup.credentials.webauthn_keyhandle = auth_data.credential_data.credential_id.hex()
-                sess.signup.credentials.webauthn_authenticator = AuthenticatorAttachment.CROSS_PLATFORM
-                sess.signup.credentials.webauthn_authenticator_id = "test-authenticator-id"
-                sess.signup.credentials.webauthn_mfa_approved = False
-                sess.signup.credentials.webauthn_attestation_format = AttestationFormat.FIDO_U2F
-                sess.signup.credentials.webauthn_description = "test security key"
+                sess.signup.credentials.webauthn = WebauthnCredential(
+                    credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
+                    keyhandle=auth_data.credential_data.credential_id.hex(),
+                    authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
+                    authenticator_id="test-authenticator-id",
+                    description="test security key",
+                )
                 sess.signup.credentials.completed = True
 
     # --- Tests ---
@@ -308,7 +305,7 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
         resp_data = response.json
         assert resp_data is not None
         assert resp_data["type"] == "POST_SIGNUP_WEBAUTHN_REGISTER_COMPLETE_FAIL"
-        assert resp_data["payload"]["message"] == SignupMsg.webauthn_not_registered.value
+        assert resp_data["payload"]["message"] == SignupMsg.webauthn_registration_failed.value
 
     def test_create_user_with_webauthn_only(self) -> None:
         """Full flow with webauthn, no password."""
@@ -372,3 +369,50 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
         assert data is not None
         assert data["type"] == "POST_SIGNUP_CREATE_USER_FAIL"
         assert data["payload"]["message"] == SignupMsg.credential_not_added.value
+
+    def test_create_user_with_mfa_approved_webauthn(self) -> None:
+        """Verify proofing log is written when webauthn credential is MFA-approved."""
+        self._prepare_for_webauthn()
+
+        # Set up credential with mfa_approved=True and user_verified=True
+        server = get_webauthn_server(rp_id=self.app.conf.fido2_rp_id, rp_name=self.app.conf.fido2_rp_name)
+        reg_response = {
+            "credentialId": CREDENTIAL_ID,
+            "rawId": CREDENTIAL_ID,
+            "response": {
+                "attestationObject": ATTESTATION_OBJECT.decode("ascii").strip("="),
+                "clientDataJSON": CLIENT_DATA_JSON.decode("ascii").strip("="),
+            },
+        }
+        registration = RegistrationResponse.from_dict(reg_response)
+        auth_data = server.register_complete(state=STATE, response=registration)
+        assert auth_data.credential_data is not None
+
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                sess.signup.credentials.webauthn = WebauthnCredential(
+                    credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
+                    keyhandle=auth_data.credential_data.credential_id.hex(),
+                    authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
+                    authenticator_id="test-authenticator-id",
+                    mfa_approved=True,
+                    user_verified=True,
+                    description="mfa security key",
+                )
+                sess.signup.credentials.completed = True
+
+        response = self._create_user_with_webauthn(use_suggested_password=False, use_webauthn=True)
+        data = response.json
+        assert data is not None
+        assert data["type"] == "POST_SIGNUP_CREATE_USER_SUCCESS"
+
+        # Verify proofing log was written
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with client.session_transaction() as sess:
+                eppn = sess.common.eppn
+                assert eppn is not None
+        proofing_logs = self.app.proofing_log._coll.find({"eduPersonPrincipalName": eppn})
+        # Should have mail address proofing + webauthn mfa capability proofing
+        log_entries = list(proofing_logs)
+        proofing_types = [entry.get("proofing_method") for entry in log_entries]
+        assert "webauthn metadata" in proofing_types

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -1,14 +1,7 @@
-import base64
 from typing import Any
 from uuid import uuid4
 
-from fido2.webauthn import (
-    AuthenticatorAttachment,
-    AuthenticatorData,
-    PublicKeyCredentialUserEntity,
-    RegistrationResponse,
-)
-from fido_mds.exceptions import AttestationVerificationError
+from fido2.webauthn import AuthenticatorAttachment, PublicKeyCredentialUserEntity
 from fido_mds.models.webauthn import AttestationFormat
 from flask import Blueprint, abort, request
 
@@ -27,9 +20,9 @@ from eduid.webapp.common.api.schemas.csrf import EmptyRequest
 from eduid.webapp.common.api.utils import make_short_code
 from eduid.webapp.common.authn.webauthn import (
     AuthenticatorInformation,
-    get_authenticator_information,
+    RegistrationError,
     get_webauthn_server,
-    is_authenticator_mfa_approved,
+    verify_webauthn_registration,
 )
 from eduid.webapp.common.session import session
 from eduid.webapp.common.session.namespaces import WebauthnCredential, WebauthnRegistration
@@ -342,66 +335,49 @@ def webauthn_register_complete(
 ) -> FluxData:
     current_app.logger.info("WebAuthn registration complete")
 
-    if client_extension_results:
-        response["client_extension_results"] = client_extension_results
-    registration = RegistrationResponse.from_dict(response)
-
     if not session.signup.credentials.webauthn_registration:
         current_app.logger.info("Found no webauthn registration state in the session")
-        return error_response(message=SignupMsg.webauthn_registration_failed)
-
-    # verify attestation and gather authenticator information
-    try:
-        authenticator_info = get_authenticator_information(
-            attestation=registration.response.attestation_object,
-            client_data=registration.response.client_data,
-            fido_mds=current_app.fido_mds,
-            fido_metadata_log=current_app.fido_metadata_log,
-            app_name=current_app.conf.app_name,
-            is_backdoor=check_magic_cookie(current_app.conf),
-        )
-    except (AttestationVerificationError, NotImplementedError, ValueError):
-        current_app.logger.exception("attestation verification failed")
         return error_response(message=SignupMsg.webauthn_registration_failed)
 
     reg_state = session.signup.credentials.webauthn_registration
     session.signup.credentials.webauthn_registration = None
 
-    server = get_webauthn_server(rp_id=current_app.conf.fido2_rp_id, rp_name=current_app.conf.fido2_rp_name)
     try:
-        auth_data: AuthenticatorData = server.register_complete(state=reg_state.webauthn_state, response=registration)
-    except ValueError:
-        current_app.logger.exception("Webauthn registration failed")
+        result = verify_webauthn_registration(
+            response=response,
+            webauthn_state=reg_state.webauthn_state,
+            authenticator=reg_state.authenticator,
+            rp_id=current_app.conf.fido2_rp_id,
+            rp_name=current_app.conf.fido2_rp_name,
+            fido_mds=current_app.fido_mds,
+            fido_metadata_log=current_app.fido_metadata_log,
+            app_name=current_app.conf.app_name,
+            is_backdoor=check_magic_cookie(current_app.conf),
+            disallowed_status=current_app.conf.webauthn_disallowed_status,
+            client_extension_results=client_extension_results,
+        )
+    except RegistrationError:
         return error_response(message=SignupMsg.webauthn_registration_failed)
-
-    if auth_data.credential_data is None:
-        current_app.logger.error("Webauthn credential data is missing")
-        return error_response(message=SignupMsg.webauthn_registration_failed)
-
-    mfa_approved = is_authenticator_mfa_approved(
-        authenticator_info=authenticator_info,
-        disallowed_status=current_app.conf.webauthn_disallowed_status,
-    )
 
     # Store completed credential in session for user creation
     session.signup.credentials.webauthn = WebauthnCredential(
-        credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
-        keyhandle=auth_data.credential_data.credential_id.hex(),
-        authenticator=reg_state.authenticator,
-        authenticator_id=str(authenticator_info.authenticator_id),
-        mfa_approved=mfa_approved,
-        attestation_format=authenticator_info.attestation_format,
+        credential_data=result.credential_data,
+        keyhandle=result.keyhandle,
+        authenticator=result.authenticator,
+        authenticator_id=str(result.authenticator_info.authenticator_id),
+        mfa_approved=result.mfa_approved,
+        attestation_format=result.authenticator_info.attestation_format,
         description=description,
-        user_present=authenticator_info.user_present,
-        user_verified=authenticator_info.user_verified,
-        user_verification_methods=authenticator_info.user_verification_methods,
-        key_protection=authenticator_info.key_protection,
+        user_present=result.authenticator_info.user_present,
+        user_verified=result.authenticator_info.user_verified,
+        user_verification_methods=result.authenticator_info.user_verification_methods,
+        key_protection=result.authenticator_info.key_protection,
     )
     session.signup.credentials.completed = True
 
     current_app.logger.info("WebAuthn registration completed")
     current_app.stats.count(name="webauthn_register_complete")
-    if mfa_approved:
+    if result.mfa_approved:
         current_app.stats.count(name="webauthn_mfa_approved")
 
     return success_response(payload={"state": session.signup.to_dict()})

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -35,7 +35,7 @@ from eduid.webapp.signup.helpers import (
     check_email_status,
     complete_and_update_invite,
     create_and_sync_user,
-    ensure_eppn,
+    get_eppn,
     is_email_verification_expired,
     is_valid_custom_password,
     send_signup_mail,
@@ -291,7 +291,7 @@ def webauthn_register_begin(authenticator: str) -> FluxData:
     except ValueError:
         return error_response(message=SignupMsg.webauthn_registration_failed)
 
-    eppn = ensure_eppn()
+    eppn = get_eppn()
 
     server = get_webauthn_server(
         rp_id=current_app.conf.fido2_rp_id,
@@ -464,7 +464,6 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
             tou_version=session.signup.tou.version,
             webauthn=webauthn_credential,
             webauthn_authenticator_info=webauthn_authenticator_info,
-            eppn=session.signup.eppn,
         )
     except EmailAlreadyVerifiedException:
         return error_response(message=SignupMsg.email_used)

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -25,6 +25,7 @@ from eduid.webapp.common.api.schemas.base import FluxStandardAction
 from eduid.webapp.common.api.schemas.csrf import EmptyRequest
 from eduid.webapp.common.api.utils import make_short_code
 from eduid.webapp.common.authn.webauthn import (
+    AuthenticatorInformation,
     get_authenticator_information,
     get_webauthn_server,
     is_authenticator_mfa_approved,
@@ -390,6 +391,8 @@ def webauthn_register_complete(
     session.signup.credentials.webauthn_mfa_approved = mfa_approved
     session.signup.credentials.webauthn_attestation_format = authenticator_info.attestation_format
     session.signup.credentials.webauthn_description = description
+    session.signup.credentials.webauthn_user_verification_methods = authenticator_info.user_verification_methods
+    session.signup.credentials.webauthn_key_protection = authenticator_info.key_protection
     session.signup.credentials.completed = True
 
     current_app.logger.info("WebAuthn registration completed")
@@ -447,10 +450,12 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
     assert session.signup.tou.version is not None  # please mypy
 
     webauthn_credential = None
+    webauthn_authenticator_info = None
     if use_webauthn:
         assert session.signup.credentials.webauthn_keyhandle is not None
         assert session.signup.credentials.webauthn_credential_data is not None
         assert session.signup.credentials.webauthn_authenticator is not None
+        assert session.signup.credentials.webauthn_attestation_format is not None
         webauthn_credential = Webauthn(
             keyhandle=session.signup.credentials.webauthn_keyhandle,
             credential_data=session.signup.credentials.webauthn_credential_data,
@@ -463,6 +468,14 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
             webauthn_proofing_version=current_app.conf.webauthn_proofing_version,
             attestation_format=session.signup.credentials.webauthn_attestation_format,
         )
+        webauthn_authenticator_info = AuthenticatorInformation(
+            authenticator_id=session.signup.credentials.webauthn_authenticator_id or "",
+            attestation_format=session.signup.credentials.webauthn_attestation_format,
+            user_present=True,
+            user_verified=session.signup.credentials.webauthn_mfa_approved,
+            user_verification_methods=session.signup.credentials.webauthn_user_verification_methods,
+            key_protection=session.signup.credentials.webauthn_key_protection,
+        )
 
     try:
         signup_user = create_and_sync_user(
@@ -473,6 +486,7 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
             custom_password=custom_password,
             tou_version=session.signup.tou.version,
             webauthn=webauthn_credential,
+            webauthn_authenticator_info=webauthn_authenticator_info,
             eppn=session.signup.eppn,
         )
     except EmailAlreadyVerifiedException:

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -266,7 +266,6 @@ def captcha_response(internal_response: str | None = None) -> FluxData:
 @require_not_logged_in
 def get_password() -> FluxData:
     current_app.logger.info("Password requested")
-    ensure_eppn()
     if session.signup.credentials.generated_password is None:
         session.signup.credentials.generated_password = generate_password(length=current_app.conf.password_length)
         session.signup.credentials.completed = True

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -356,7 +356,7 @@ def webauthn_register_complete(
             client_data=registration.response.client_data,
             fido_mds=current_app.fido_mds,
             fido_metadata_log=current_app.fido_metadata_log,
-            config=current_app.conf,
+            is_backdoor=check_magic_cookie(current_app.conf),
         )
     except (AttestationVerificationError, NotImplementedError, ValueError):
         current_app.logger.exception("attestation verification failed")

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -366,9 +366,7 @@ def webauthn_register_complete(
 
     server = get_webauthn_server(rp_id=current_app.conf.fido2_rp_id, rp_name=current_app.conf.fido2_rp_name)
     try:
-        auth_data: AuthenticatorData = server.register_complete(
-            state=reg_state.webauthn_state, response=registration
-        )
+        auth_data: AuthenticatorData = server.register_complete(state=reg_state.webauthn_state, response=registration)
     except ValueError:
         current_app.logger.exception("Webauthn registration failed")
         return error_response(message=SignupMsg.webauthn_not_registered)
@@ -383,9 +381,9 @@ def webauthn_register_complete(
     )
 
     # Store credential fields in session for user creation
-    session.signup.credentials.webauthn_credential_data = base64.urlsafe_b64encode(
-        auth_data.credential_data
-    ).decode("ascii")
+    session.signup.credentials.webauthn_credential_data = base64.urlsafe_b64encode(auth_data.credential_data).decode(
+        "ascii"
+    )
     session.signup.credentials.webauthn_keyhandle = auth_data.credential_data.credential_id.hex()
     session.signup.credentials.webauthn_authenticator = reg_state.authenticator
     session.signup.credentials.webauthn_authenticator_id = str(authenticator_info.authenticator_id)

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -1,20 +1,36 @@
+import base64
 from typing import Any
 from uuid import uuid4
 
+from fido2.webauthn import (
+    AuthenticatorAttachment,
+    AuthenticatorData,
+    PublicKeyCredentialUserEntity,
+    RegistrationResponse,
+)
+from fido_mds.exceptions import AttestationVerificationError
 from flask import Blueprint, abort, request
 
 from eduid.common.misc.timeutil import utc_now
 from eduid.common.utils import generate_password
 from eduid.userdb import User
+from eduid.userdb.credentials import Webauthn
 from eduid.userdb.exceptions import UserOutOfSync
 from eduid.webapp.common.api.captcha import CaptchaCompleteRequest, CaptchaResponse
 from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith, require_not_logged_in, require_user
 from eduid.webapp.common.api.exceptions import ProofingLogFailure
 from eduid.webapp.common.api.helpers import check_magic_cookie
 from eduid.webapp.common.api.messages import CommonMsg, FluxData, error_response, success_response
+from eduid.webapp.common.api.schemas.base import FluxStandardAction
 from eduid.webapp.common.api.schemas.csrf import EmptyRequest
 from eduid.webapp.common.api.utils import make_short_code
+from eduid.webapp.common.authn.webauthn import (
+    get_authenticator_information,
+    get_webauthn_server,
+    is_authenticator_mfa_approved,
+)
 from eduid.webapp.common.session import session
+from eduid.webapp.common.session.namespaces import WebauthnRegistration
 from eduid.webapp.signup.app import current_signup_app as current_app
 from eduid.webapp.signup.helpers import (
     EmailAlreadyVerifiedException,
@@ -24,6 +40,7 @@ from eduid.webapp.signup.helpers import (
     check_email_status,
     complete_and_update_invite,
     create_and_sync_user,
+    ensure_eppn,
     is_email_verification_expired,
     is_valid_custom_password,
     send_signup_mail,
@@ -36,6 +53,8 @@ from eduid.webapp.signup.schemas import (
     NameAndEmailSchema,
     SignupStatusResponse,
     VerifyEmailRequest,
+    WebauthnRegisterBeginRequest,
+    WebauthnRegisterCompleteRequest,
 )
 
 signup_views = Blueprint("signup", __name__, url_prefix="", template_folder="templates")
@@ -252,9 +271,134 @@ def captcha_response(internal_response: str | None = None) -> FluxData:
 @require_not_logged_in
 def get_password() -> FluxData:
     current_app.logger.info("Password requested")
+    ensure_eppn()
     if session.signup.credentials.generated_password is None:
         session.signup.credentials.generated_password = generate_password(length=current_app.conf.password_length)
         session.signup.credentials.completed = True
+    return success_response(payload={"state": session.signup.to_dict()})
+
+
+@signup_views.route("/webauthn/register/begin", methods=["POST"])
+@UnmarshalWith(WebauthnRegisterBeginRequest)
+@MarshalWith(FluxStandardAction)
+@require_not_logged_in
+def webauthn_register_begin(authenticator: str) -> FluxData:
+    current_app.logger.info("WebAuthn registration begin")
+
+    if not session.signup.captcha.completed:
+        return error_response(message=SignupMsg.captcha_not_completed)
+    if not session.signup.email.completed:
+        return error_response(message=SignupMsg.email_verification_not_complete)
+    if not session.signup.tou.completed:
+        return error_response(message=SignupMsg.tou_not_completed)
+
+    try:
+        _auth_enum = AuthenticatorAttachment(authenticator)
+    except ValueError:
+        return error_response(message=SignupMsg.webauthn_not_registered)
+
+    eppn = ensure_eppn()
+
+    server = get_webauthn_server(
+        rp_id=current_app.conf.fido2_rp_id,
+        rp_name=current_app.conf.fido2_rp_name,
+        attestation=current_app.conf.webauthn_attestation,
+    )
+
+    assert session.signup.name.given_name is not None
+    assert session.signup.name.surname is not None
+    user_entity = PublicKeyCredentialUserEntity(
+        id=bytes(eppn, "utf-8"),
+        name=eppn,
+        display_name=f"{session.signup.name.given_name} {session.signup.name.surname}",
+    )
+    registration_data, state = server.register_begin(
+        user=user_entity,
+        credentials=[],
+        user_verification=current_app.conf.webauthn_user_verification,
+        resident_key_requirement=current_app.conf.webauthn_resident_key_requirement,
+        authenticator_attachment=_auth_enum,
+    )
+    session.signup.credentials.webauthn_registration = WebauthnRegistration(
+        webauthn_state=state, authenticator=_auth_enum
+    )
+
+    current_app.logger.info("WebAuthn registration begun")
+    current_app.stats.count(name="webauthn_register_begin")
+
+    return success_response(
+        payload={"csrf_token": session.new_csrf_token(), "registration_data": dict(registration_data)}
+    )
+
+
+@signup_views.route("/webauthn/register/complete", methods=["POST"])
+@UnmarshalWith(WebauthnRegisterCompleteRequest)
+@MarshalWith(SignupStatusResponse)
+@require_not_logged_in
+def webauthn_register_complete(
+    response: dict[str, Any], description: str, client_extension_results: dict[str, Any] | None = None
+) -> FluxData:
+    current_app.logger.info("WebAuthn registration complete")
+
+    if client_extension_results:
+        response["client_extension_results"] = client_extension_results
+    registration = RegistrationResponse.from_dict(response)
+
+    if not session.signup.credentials.webauthn_registration:
+        current_app.logger.info("Found no webauthn registration state in the session")
+        return error_response(message=SignupMsg.webauthn_not_registered)
+
+    # verify attestation and gather authenticator information
+    try:
+        authenticator_info = get_authenticator_information(
+            attestation=registration.response.attestation_object,
+            client_data=registration.response.client_data,
+            fido_mds=current_app.fido_mds,
+            fido_metadata_log=current_app.fido_metadata_log,
+            config=current_app.conf,
+        )
+    except (AttestationVerificationError, NotImplementedError, ValueError):
+        current_app.logger.exception("attestation verification failed")
+        return error_response(message=SignupMsg.webauthn_not_registered)
+
+    reg_state = session.signup.credentials.webauthn_registration
+    session.signup.credentials.webauthn_registration = None
+
+    server = get_webauthn_server(rp_id=current_app.conf.fido2_rp_id, rp_name=current_app.conf.fido2_rp_name)
+    try:
+        auth_data: AuthenticatorData = server.register_complete(
+            state=reg_state.webauthn_state, response=registration
+        )
+    except ValueError:
+        current_app.logger.exception("Webauthn registration failed")
+        return error_response(message=SignupMsg.webauthn_not_registered)
+
+    if auth_data.credential_data is None:
+        current_app.logger.error("Webauthn credential data is missing")
+        return error_response(message=SignupMsg.webauthn_not_registered)
+
+    mfa_approved = is_authenticator_mfa_approved(
+        authenticator_info=authenticator_info,
+        disallowed_status=current_app.conf.webauthn_disallowed_status,
+    )
+
+    # Store credential fields in session for user creation
+    session.signup.credentials.webauthn_credential_data = base64.urlsafe_b64encode(
+        auth_data.credential_data
+    ).decode("ascii")
+    session.signup.credentials.webauthn_keyhandle = auth_data.credential_data.credential_id.hex()
+    session.signup.credentials.webauthn_authenticator = reg_state.authenticator
+    session.signup.credentials.webauthn_authenticator_id = str(authenticator_info.authenticator_id)
+    session.signup.credentials.webauthn_mfa_approved = mfa_approved
+    session.signup.credentials.webauthn_attestation_format = authenticator_info.attestation_format
+    session.signup.credentials.webauthn_description = description
+    session.signup.credentials.completed = True
+
+    current_app.logger.info("WebAuthn registration completed")
+    current_app.stats.count(name="webauthn_register_complete")
+    if mfa_approved:
+        current_app.stats.count(name="webauthn_mfa_approved")
+
     return success_response(payload={"state": session.signup.to_dict()})
 
 
@@ -292,7 +436,7 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
         if not is_valid_custom_password(custom_password):
             current_app.logger.error("Weak custom password")
             return error_response(message=SignupMsg.weak_custom_password)
-    if use_webauthn and not session.signup.credentials.webauthn:
+    if use_webauthn and not session.signup.credentials.webauthn_credential_data:
         current_app.logger.error("No webauthn registered")
         return error_response(message=SignupMsg.webauthn_not_registered)
     if not use_password and not use_webauthn:
@@ -303,6 +447,25 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
     assert session.signup.name.surname is not None  # please mypy
     assert session.signup.email.address is not None  # please mypy
     assert session.signup.tou.version is not None  # please mypy
+
+    webauthn_credential = None
+    if use_webauthn:
+        assert session.signup.credentials.webauthn_keyhandle is not None
+        assert session.signup.credentials.webauthn_credential_data is not None
+        assert session.signup.credentials.webauthn_authenticator is not None
+        webauthn_credential = Webauthn(
+            keyhandle=session.signup.credentials.webauthn_keyhandle,
+            credential_data=session.signup.credentials.webauthn_credential_data,
+            authenticator_id=session.signup.credentials.webauthn_authenticator_id,
+            authenticator=session.signup.credentials.webauthn_authenticator,
+            app_id=current_app.conf.fido2_rp_id,
+            description=session.signup.credentials.webauthn_description or "",
+            created_by=current_app.conf.app_name,
+            mfa_approved=session.signup.credentials.webauthn_mfa_approved,
+            webauthn_proofing_version=current_app.conf.webauthn_proofing_version,
+            attestation_format=session.signup.credentials.webauthn_attestation_format,
+        )
+
     try:
         signup_user = create_and_sync_user(
             given_name=session.signup.name.given_name,
@@ -311,6 +474,8 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
             generated_password=session.signup.credentials.generated_password,
             custom_password=custom_password,
             tou_version=session.signup.tou.version,
+            webauthn=webauthn_credential,
+            eppn=session.signup.eppn,
         )
     except EmailAlreadyVerifiedException:
         return error_response(message=SignupMsg.email_used)

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -9,6 +9,7 @@ from fido2.webauthn import (
     RegistrationResponse,
 )
 from fido_mds.exceptions import AttestationVerificationError
+from fido_mds.models.webauthn import AttestationFormat
 from flask import Blueprint, abort, request
 
 from eduid.common.misc.timeutil import utc_now
@@ -31,7 +32,7 @@ from eduid.webapp.common.authn.webauthn import (
     is_authenticator_mfa_approved,
 )
 from eduid.webapp.common.session import session
-from eduid.webapp.common.session.namespaces import WebauthnRegistration
+from eduid.webapp.common.session.namespaces import WebauthnCredential, WebauthnRegistration
 from eduid.webapp.signup.app import current_signup_app as current_app
 from eduid.webapp.signup.helpers import (
     EmailAlreadyVerifiedException,
@@ -296,7 +297,7 @@ def webauthn_register_begin(authenticator: str) -> FluxData:
     try:
         _auth_enum = AuthenticatorAttachment(authenticator)
     except ValueError:
-        return error_response(message=SignupMsg.webauthn_not_registered)
+        return error_response(message=SignupMsg.webauthn_registration_failed)
 
     eppn = ensure_eppn()
 
@@ -306,8 +307,8 @@ def webauthn_register_begin(authenticator: str) -> FluxData:
         attestation=current_app.conf.webauthn_attestation,
     )
 
-    assert session.signup.name.given_name is not None
-    assert session.signup.name.surname is not None
+    if not session.signup.name.given_name or not session.signup.name.surname:
+        return error_response(message=SignupMsg.name_not_set)
     user_entity = PublicKeyCredentialUserEntity(
         id=bytes(eppn, "utf-8"),
         name=eppn,
@@ -347,7 +348,7 @@ def webauthn_register_complete(
 
     if not session.signup.credentials.webauthn_registration:
         current_app.logger.info("Found no webauthn registration state in the session")
-        return error_response(message=SignupMsg.webauthn_not_registered)
+        return error_response(message=SignupMsg.webauthn_registration_failed)
 
     # verify attestation and gather authenticator information
     try:
@@ -356,11 +357,12 @@ def webauthn_register_complete(
             client_data=registration.response.client_data,
             fido_mds=current_app.fido_mds,
             fido_metadata_log=current_app.fido_metadata_log,
+            app_name=current_app.conf.app_name,
             is_backdoor=check_magic_cookie(current_app.conf),
         )
     except (AttestationVerificationError, NotImplementedError, ValueError):
         current_app.logger.exception("attestation verification failed")
-        return error_response(message=SignupMsg.webauthn_not_registered)
+        return error_response(message=SignupMsg.webauthn_registration_failed)
 
     reg_state = session.signup.credentials.webauthn_registration
     session.signup.credentials.webauthn_registration = None
@@ -370,29 +372,31 @@ def webauthn_register_complete(
         auth_data: AuthenticatorData = server.register_complete(state=reg_state.webauthn_state, response=registration)
     except ValueError:
         current_app.logger.exception("Webauthn registration failed")
-        return error_response(message=SignupMsg.webauthn_not_registered)
+        return error_response(message=SignupMsg.webauthn_registration_failed)
 
     if auth_data.credential_data is None:
         current_app.logger.error("Webauthn credential data is missing")
-        return error_response(message=SignupMsg.webauthn_not_registered)
+        return error_response(message=SignupMsg.webauthn_registration_failed)
 
     mfa_approved = is_authenticator_mfa_approved(
         authenticator_info=authenticator_info,
         disallowed_status=current_app.conf.webauthn_disallowed_status,
     )
 
-    # Store credential fields in session for user creation
-    session.signup.credentials.webauthn_credential_data = base64.urlsafe_b64encode(auth_data.credential_data).decode(
-        "ascii"
+    # Store completed credential in session for user creation
+    session.signup.credentials.webauthn = WebauthnCredential(
+        credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
+        keyhandle=auth_data.credential_data.credential_id.hex(),
+        authenticator=reg_state.authenticator,
+        authenticator_id=str(authenticator_info.authenticator_id),
+        mfa_approved=mfa_approved,
+        attestation_format=authenticator_info.attestation_format,
+        description=description,
+        user_present=authenticator_info.user_present,
+        user_verified=authenticator_info.user_verified,
+        user_verification_methods=authenticator_info.user_verification_methods,
+        key_protection=authenticator_info.key_protection,
     )
-    session.signup.credentials.webauthn_keyhandle = auth_data.credential_data.credential_id.hex()
-    session.signup.credentials.webauthn_authenticator = reg_state.authenticator
-    session.signup.credentials.webauthn_authenticator_id = str(authenticator_info.authenticator_id)
-    session.signup.credentials.webauthn_mfa_approved = mfa_approved
-    session.signup.credentials.webauthn_attestation_format = authenticator_info.attestation_format
-    session.signup.credentials.webauthn_description = description
-    session.signup.credentials.webauthn_user_verification_methods = authenticator_info.user_verification_methods
-    session.signup.credentials.webauthn_key_protection = authenticator_info.key_protection
     session.signup.credentials.completed = True
 
     current_app.logger.info("WebAuthn registration completed")
@@ -437,9 +441,9 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
         if not is_valid_custom_password(custom_password):
             current_app.logger.error("Weak custom password")
             return error_response(message=SignupMsg.weak_custom_password)
-    if use_webauthn and not session.signup.credentials.webauthn_credential_data:
+    if use_webauthn and not session.signup.credentials.webauthn:
         current_app.logger.error("No webauthn registered")
-        return error_response(message=SignupMsg.webauthn_not_registered)
+        return error_response(message=SignupMsg.webauthn_registration_failed)
     if not use_password and not use_webauthn:
         current_app.logger.error("Neither generated_password nor webauthn selected")
         return error_response(message=SignupMsg.credential_not_added)
@@ -452,29 +456,27 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
     webauthn_credential = None
     webauthn_authenticator_info = None
     if use_webauthn:
-        assert session.signup.credentials.webauthn_keyhandle is not None
-        assert session.signup.credentials.webauthn_credential_data is not None
-        assert session.signup.credentials.webauthn_authenticator is not None
-        assert session.signup.credentials.webauthn_attestation_format is not None
+        wn = session.signup.credentials.webauthn
+        assert wn is not None  # checked above
         webauthn_credential = Webauthn(
-            keyhandle=session.signup.credentials.webauthn_keyhandle,
-            credential_data=session.signup.credentials.webauthn_credential_data,
-            authenticator_id=session.signup.credentials.webauthn_authenticator_id,
-            authenticator=session.signup.credentials.webauthn_authenticator,
+            keyhandle=wn.keyhandle,
+            credential_data=wn.credential_data,
+            authenticator_id=wn.authenticator_id,
+            authenticator=wn.authenticator,
             app_id=current_app.conf.fido2_rp_id,
-            description=session.signup.credentials.webauthn_description or "",
+            description=wn.description,
             created_by=current_app.conf.app_name,
-            mfa_approved=session.signup.credentials.webauthn_mfa_approved,
+            mfa_approved=wn.mfa_approved,
             webauthn_proofing_version=current_app.conf.webauthn_proofing_version,
-            attestation_format=session.signup.credentials.webauthn_attestation_format,
+            attestation_format=wn.attestation_format,
         )
         webauthn_authenticator_info = AuthenticatorInformation(
-            authenticator_id=session.signup.credentials.webauthn_authenticator_id or "",
-            attestation_format=session.signup.credentials.webauthn_attestation_format,
-            user_present=True,
-            user_verified=session.signup.credentials.webauthn_mfa_approved,
-            user_verification_methods=session.signup.credentials.webauthn_user_verification_methods,
-            key_protection=session.signup.credentials.webauthn_key_protection,
+            authenticator_id=wn.authenticator_id or "",
+            attestation_format=wn.attestation_format or AttestationFormat.NONE,
+            user_present=wn.user_present,
+            user_verified=wn.user_verified,
+            user_verification_methods=wn.user_verification_methods,
+            key_protection=wn.key_protection,
         )
 
     try:


### PR DESCRIPTION
The signup app now supports registering a WebAuthn security key as a credential, either instead of or alongside a password.                 
                                                                                                                                              
  ### New Endpoints                                                                                                                           
           
  #### `POST /webauthn/register/begin`                                                                                                        
   
  | Field | Type | Required |                                                                                                                 
  |-------|------|----------|
  | `authenticator` | `"cross-platform"` \| `"platform"` | yes |
  | `csrf_token` | `string` | yes |                                                                                                           
   
  **Preconditions:** captcha, email verification, and ToU must be completed.                                                                  
           
  Returns `registration_data` (PublicKeyCredentialCreationOptions) to pass to `navigator.credentials.create()`.                               
           
  **Response type:** `POST_SIGNUP_WEBAUTHN_REGISTER_BEGIN_SUCCESS`                                                                            
   
  #### `POST /webauthn/register/complete`                                                                                                     
           
  | Field | Type | Required |
  |-------|------|----------|
  | `response` | object from `navigator.credentials.create()` | yes |
  | `description` | `string` | yes |                                                                                                          
  | `clientExtensionResults` | `object` | no |
  | `csrf_token` | `string` | yes |                                                                                                           
                                                                                                                                              
  Returns the full signup state with `credentials.webauthn_registered: true`.
                                                                                                                                              
  **Response type:** `POST_SIGNUP_WEBAUTHN_REGISTER_COMPLETE_SUCCESS`
         
  ### Changed Endpoints

  #### `POST /create-user`                                                                                                                    
   
  `use_webauthn: bool` is now functional. Valid credential combinations:                                                                      
           
  - Password only (`use_suggested_password: true` or `custom_password` set)                                                                   
  - WebAuthn only (`use_webauthn: true`)
  - Both password and WebAuthn                                                                                                                
           
  ### State Changes                                                                                                                           
           
  `state.credentials` now includes:

  - `webauthn_registered` (`bool`) — `true` after successful `/webauthn/register/complete`                                                    
   
  ### Error Messages                                                                                                                          
           
  | Message | When |
  |---------|------|
  | `signup.webauthn-registration-failed` | Any failure during WebAuthn registration |
  | `signup.name-not-set` | `/webauthn/register/begin` called before name provided |                                                          
  | `signup.credential-not-added` | `/create-user` called with no credential selected |