### PR TITLE
Add type parameters to bare generics across codebase

### DIFF
--- a/src/eduid/common/config/base.py
+++ b/src/eduid/common/config/base.py
@@ -26,15 +26,15 @@ class CeleryConfig(BaseModel):
     accept_content: list[str] = Field(default=["application/json"])
     broker_url: str = ""
     result_backend: str = "cache"
-    result_backend_transport_options: dict = Field(default={})
+    result_backend_transport_options: dict[str, Any] = Field(default={})
     cache_backend: str = "memory"
     task_serializer: str = "json"
     task_eager_propagates: bool = False
     task_always_eager: bool = False
     # backwards incompatible setting that the documentation says will be the default in the future
     broker_transport: str = ""
-    broker_transport_options: dict = Field(default={"fanout_prefix": True})
-    task_routes: dict = Field(
+    broker_transport_options: dict[str, Any] = Field(default={"fanout_prefix": True})
+    task_routes: dict[str, Any] = Field(
         default={
             "eduid.workers.am.*": {"queue": "am"},
             "eduid.workers.msg.*": {"queue": "msg"},
@@ -112,7 +112,7 @@ class CORSMixin(BaseModel):
     cors_methods: str | list[str] = ["GET", "HEAD", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"]
     # The origin(s) to allow requests from. An origin configured here that matches the value of the Origin header in a
     # preflight OPTIONS request is returned as the value of the Access-Control-Allow-Origin response header.
-    cors_origins: str | list[str] | Pattern = [r"^eduid\.se$", r".*\.eduid\.se$"]
+    cors_origins: str | list[str] | Pattern[str] = [r"^eduid\.se$", r".*\.eduid\.se$"]
     # The series of regular expression and (optionally) associated CORS options to be applied to the given resource
     # path.
     # If the value is a dictionary, it’s keys must be regular expressions matching resources, and the values must be
@@ -121,7 +121,7 @@ class CORSMixin(BaseModel):
     # app-wide configured options are applied.
     # If the argument is a string, it is expected to be a regular expression matching resources for which the app-wide
     # configured options are applied.
-    cors_resources: dict[str | Pattern, CORSMixin] | list[str | Pattern] | str | Pattern = r"/*"
+    cors_resources: dict[str | Pattern[str], CORSMixin] | list[str | Pattern[str]] | str | Pattern[str] = r"/*"
     cors_send_wildcard: bool = False
     cors_supports_credentials: bool = True
     cors_vary_header: bool = True
@@ -165,7 +165,7 @@ class FlaskConfig(CORSMixin):
     # the name of the session cookie
     session_cookie_name: str = "sessid"
     # Sets a cookie with legacy SameSite=None, the SameSite key and value is omitted
-    cookies_samesite_compat: list = Field(default=[("sessid", "sessid_samesite_compat")])
+    cookies_samesite_compat: list[tuple[str, str]] = Field(default=[("sessid", "sessid_samesite_compat")])
     # the domain for the session cookie. If this is not set, the cookie will
     # be valid for all subdomains of SERVER_NAME.
     session_cookie_domain: str | None = None
@@ -226,7 +226,7 @@ class ProfilingConfig(BaseModel):
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)  # allow IO type
-    stream: IO | None = None
+    stream: IO[str] | None = None
     sort_by: Iterable[str] = Field(default_factory=lambda: ("time", "calls"))
     restrictions: Iterable[str | int | float] = Field(default_factory=tuple)
     profile_dir: str | None = None
@@ -260,7 +260,7 @@ class LoggingConfigMixin(BaseModel):
     log_format: str = "{asctime} | {levelname:7} | {hostname} | {eppn:11} | {name:35} | {module:10} | {message}"
     log_level: str = "INFO"
     log_filters: Sequence[LoggingFilters] = Field(default=[LoggingFilters.NAMES, LoggingFilters.SESSION_USER])
-    logging_config: dict = Field(default={})
+    logging_config: dict[str, Any] = Field(default={})
 
 
 class StatsConfigMixin(BaseModel):

--- a/src/eduid/common/config/parsers/decorators.py
+++ b/src/eduid/common/config/parsers/decorators.py
@@ -11,7 +11,7 @@ __author__ = "lundberg"
 from eduid.common.config.parsers.exceptions import SecretKeyException
 
 
-def decrypt(f: Callable) -> Callable:
+def decrypt(f: Callable[..., Mapping[str, Any]]) -> Callable[..., Mapping[str, Any]]:
     @wraps(f)
     def decrypt_decorator(*args: Any, **kwargs: Any) -> Mapping[str, Any]:
         config_dict = f(*args, **kwargs)
@@ -50,8 +50,8 @@ def decrypt_config(config_dict: Mapping[str, Any]) -> Mapping[str, Any]:
     :param config_dict: Configuration dictionary
     :return: Configuration dictionary
     """
-    boxes: dict = {}
-    new_config_dict: dict = {}
+    boxes: dict[str, secret.SecretBox] = {}
+    new_config_dict: dict[str, Any] = {}
     for key, value in config_dict.items():
         if key.lower().endswith("_encrypted"):
             decrypted = False
@@ -83,10 +83,10 @@ def decrypt_config(config_dict: Mapping[str, Any]) -> Mapping[str, Any]:
     return new_config_dict
 
 
-def interpolate(f: Callable) -> Callable:
+def interpolate(f: Callable[..., Mapping[str, Any]]) -> Callable[..., dict[str, Any]]:
     @wraps(f)
     def interpolation_decorator(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        config_dict = f(*args, **kwargs)
+        config_dict = dict(f(*args, **kwargs))
         interpolated_config_dict = interpolate_config(config_dict)
         for key in list(interpolated_config_dict.keys()):
             if key.lower().startswith("var_"):
@@ -96,7 +96,7 @@ def interpolate(f: Callable) -> Callable:
     return interpolation_decorator
 
 
-def interpolate_list(config_dict: dict[str, Any], sub_list: list) -> list:
+def interpolate_list(config_dict: dict[str, Any], sub_list: list[Any]) -> list[Any]:
     """
     :param config_dict: Configuration dictionary
     :param sub_list: Sub configuration list

--- a/src/eduid/common/config/workers.py
+++ b/src/eduid/common/config/workers.py
@@ -9,7 +9,7 @@ class AmConfig(WorkerConfig):
     """
 
     new_user_date: str = "2001-01-01"
-    action_plugins: list = Field(default_factory=lambda: ["tou"])
+    action_plugins: list[str] = Field(default_factory=lambda: ["tou"])
 
 
 class MsgConfig(WorkerConfig):

--- a/src/eduid/common/decorators.py
+++ b/src/eduid/common/decorators.py
@@ -6,7 +6,7 @@ from typing import Any
 
 
 # https://stackoverflow.com/questions/2536307/how-do-i-deprecate-python-functions/40301488#40301488
-def deprecated(reason: str | type | Callable) -> Callable:
+def deprecated(reason: str | type | Callable[..., Any]) -> Callable[..., Any]:
     """
     This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emitted
@@ -22,7 +22,7 @@ def deprecated(reason: str | type | Callable) -> Callable:
         #    def old_function(x, y):
         #      pass
 
-        def decorator(func1: Callable) -> Callable:
+        def decorator(func1: Callable[..., Any]) -> Callable[..., Any]:
             if inspect.isclass(func1):
                 fmt1 = "Call to deprecated class {name} ({reason})."
             else:

--- a/src/eduid/common/fastapi/context_request.py
+++ b/src/eduid/common/fastapi/context_request.py
@@ -47,7 +47,7 @@ class ContextRequestRoute(APIRoute, ContextRequestMixin):
     # Override in subclass to change the default context class
     contextClass: type[Context] = Context
 
-    def get_route_handler(self) -> Callable:
+    def get_route_handler(self) -> Callable[..., Any]:
         original_route_handler = super().get_route_handler()
 
         async def context_route_handler(request: Request | ContextRequest) -> Response:

--- a/src/eduid/common/fastapi/exceptions.py
+++ b/src/eduid/common/fastapi/exceptions.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class ErrorDetail(BaseModel):
-    detail: str | dict | list | None = None
+    detail: str | dict[str, Any] | list[Any] | None = None
     status: int | None = None
 
 
@@ -59,18 +59,18 @@ class HTTPErrorDetail(Exception):
         detail: str | None = None,
     ) -> None:
         self._error_detail = ErrorDetail(detail=detail, status=status_code)
-        self._extra_headers: dict | None = None
+        self._extra_headers: dict[str, str] | None = None
 
     @property
     def error_detail(self) -> ErrorDetail:
         return self._error_detail
 
     @property
-    def extra_headers(self) -> dict | None:
+    def extra_headers(self) -> dict[str, str] | None:
         return self._extra_headers
 
     @extra_headers.setter
-    def extra_headers(self, headers: dict) -> None:
+    def extra_headers(self, headers: dict[str, str]) -> None:
         self._extra_headers = headers
 
 

--- a/src/eduid/common/fastapi/utils.py
+++ b/src/eduid/common/fastapi/utils.py
@@ -16,7 +16,7 @@ from eduid.common.misc.timeutil import utc_now
 @dataclass
 class SimpleCacheItem:
     expire_time: datetime
-    data: Mapping
+    data: Mapping[str, Any]
 
 
 @dataclass
@@ -82,7 +82,7 @@ def get_cached_response(req: ContextRequest, resp: Response, key: str) -> Mappin
     return None
 
 
-def set_cached_response(req: ContextRequest, resp: Response, key: str, data: Mapping) -> None:
+def set_cached_response(req: ContextRequest, resp: Response, key: str, data: Mapping[str, Any]) -> None:
     cache_for_seconds = req.app.context.config.status_cache_seconds
     now = utc_now()
     expires = now + timedelta(seconds=cache_for_seconds)

--- a/src/eduid/common/models/jose_models.py
+++ b/src/eduid/common/models/jose_models.py
@@ -100,7 +100,7 @@ class JOSEHeader(BaseModel):
     x5tS256: str | None = Field(default=None, alias="x5t#S256")
     typ: str | None = None
     cty: str | None = None
-    crit: list | None = None
+    crit: list[str] | None = None
 
 
 class RegisteredClaims(BaseModel):

--- a/src/eduid/common/testing_base.py
+++ b/src/eduid/common/testing_base.py
@@ -49,7 +49,7 @@ def normalised_data[SomeData: dict[str, Any] | list[Any]](
     """Utility function for normalising data before comparisons in test cases."""
 
     class NormaliseEncoder(json.JSONEncoder):
-        def default(self, o: object) -> Iterable:
+        def default(self, o: object) -> Iterable[Any]:
             if isinstance(o, datetime):
                 if replace_datetime is not None:
                     return replace_datetime
@@ -78,7 +78,7 @@ def normalised_data[SomeData: dict[str, Any] | list[Any]](
         def __init__(self, **kwargs: Any) -> None:
             super().__init__(object_hook=self.object_hook, **kwargs)
 
-        def object_hook(self, o: dict) -> dict[str, Any]:
+        def object_hook(self, o: dict[str, Any]) -> dict[str, Any]:
             """
             Decode any keys ending in _ts to datetime objects.
 

--- a/src/eduid/graphdb/groupdb/db.py
+++ b/src/eduid/graphdb/groupdb/db.py
@@ -406,17 +406,17 @@ class GroupDB(BaseGraphDB):
         saved_group = replace(saved_group, members=saved_members, owners=saved_owners)
         return saved_group
 
-    def _load_node(self, data: dict | Node) -> User | Group:
+    def _load_node(self, data: dict[str, Any] | Node) -> User | Group:
         if data.get("scope"):
             return self._load_group(data=data)
         return self._load_user(data=data)
 
     @staticmethod
-    def _load_group(data: dict | Node) -> Group:
+    def _load_group(data: dict[str, Any] | Node) -> Group:
         """Method meant to be overridden by subclasses wanting to annotate the group."""
         return Group.from_mapping(data)
 
     @staticmethod
-    def _load_user(data: dict | Node) -> User:
+    def _load_user(data: dict[str, Any] | Node) -> User:
         """Method meant to be overridden by subclasses wanting to annotate the user."""
         return User.from_mapping(data)

--- a/src/eduid/graphdb/groupdb/group.py
+++ b/src/eduid/graphdb/groupdb/group.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 
 from bson import ObjectId
 
@@ -76,7 +77,7 @@ class Group:
         return identifier in [owner.identifier for owner in self.owners]
 
     @classmethod
-    def from_mapping(cls, data: Mapping) -> Group:
+    def from_mapping(cls, data: Mapping[str, Any]) -> Group:
         dt = neo4j_ts_to_dt(data)
         version = data.get("version")
         if version is not None:

--- a/src/eduid/graphdb/groupdb/user.py
+++ b/src/eduid/graphdb/groupdb/user.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from eduid.graphdb.helpers import neo4j_ts_to_dt
 
@@ -17,7 +18,7 @@ class User:
     modified_ts: datetime | None = None
 
     @classmethod
-    def from_mapping(cls, data: Mapping) -> User:
+    def from_mapping(cls, data: Mapping[str, Any]) -> User:
         dt = neo4j_ts_to_dt(data)
         return cls(
             identifier=data["identifier"],

--- a/src/eduid/graphdb/helpers.py
+++ b/src/eduid/graphdb/helpers.py
@@ -1,10 +1,11 @@
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from typing import Any
 
 __author__ = "lundberg"
 
 
-def neo4j_ts_to_dt(data: Mapping) -> Mapping[str, datetime | None]:
+def neo4j_ts_to_dt(data: Mapping[str, Any]) -> Mapping[str, datetime | None]:
     created_ts = data.get("created_ts")
     if isinstance(created_ts, int):
         created_ts = datetime.fromtimestamp(created_ts / 1000, tz=UTC)  # Milliseconds since 1970

--- a/src/eduid/graphdb/tests/test_groupdb.py
+++ b/src/eduid/graphdb/tests/test_groupdb.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from typing import Any
 
 import pytest
 from bson import ObjectId
@@ -17,12 +18,12 @@ class TestGroupDB(Neo4jTestCase):
     def setup(self, setup_neo4j: None) -> None:
         self.db_config = {"encrypted": False, "auth": basic_auth("neo4j", "testingtesting")}
         self.group_db = GroupDB(db_uri=self.neo4jdb.db_uri, scope="__testing__", config=self.db_config)
-        self.group1: dict[str, str | list | None] = {
+        self.group1: dict[str, str | list[Any] | None] = {
             "identifier": "test1",
             "version": None,
             "display_name": "Test Group 1",
         }
-        self.group2: dict[str, str | list | None] = {
+        self.group2: dict[str, str | list[Any] | None] = {
             "identifier": "test2",
             "version": None,
             "display_name": "Test Group 2",

--- a/src/eduid/maccapi/app.py
+++ b/src/eduid/maccapi/app.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
@@ -13,7 +15,7 @@ from eduid.vccs.client import VCCSClient
 
 class MAccAPI(FastAPI):
     def __init__(
-        self, name: str = "maccapi", test_config: dict | None = None, vccs_client: VCCSClient | None = None
+        self, name: str = "maccapi", test_config: dict[str, Any] | None = None, vccs_client: VCCSClient | None = None
     ) -> None:
         self.config = load_config(typ=MAccApiConfig, app_name=name, ns="api", test_config=test_config)
         super().__init__(root_path=self.config.application_root)
@@ -21,7 +23,9 @@ class MAccAPI(FastAPI):
         self.context.logger.info(f"Starting {name} app")
 
 
-def init_api(name: str = "maccapi", test_config: dict | None = None, vccs_client: VCCSClient | None = None) -> MAccAPI:
+def init_api(
+    name: str = "maccapi", test_config: dict[str, Any] | None = None, vccs_client: VCCSClient | None = None
+) -> MAccAPI:
     """
     Initialize the API.
     """

--- a/src/eduid/queue/db/message/payload.py
+++ b/src/eduid/queue/db/message/payload.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from eduid.queue.db import Payload
 
@@ -12,7 +13,7 @@ class EduidTestPayload(Payload):
     counter: int
 
     @classmethod
-    def from_dict(cls, data: Mapping) -> "EduidTestPayload":
+    def from_dict(cls, data: Mapping[str, Any]) -> "EduidTestPayload":
         return cls(**data)
 
 
@@ -27,7 +28,7 @@ class EduidTestResultPayload(Payload):
     per_second: int
 
     @classmethod
-    def from_dict(cls, data: Mapping) -> "EduidTestResultPayload":
+    def from_dict(cls, data: Mapping[str, Any]) -> "EduidTestResultPayload":
         return cls(**data)
 
 
@@ -38,7 +39,7 @@ class EduidSCIMAPINotification(Payload):
     message: str
 
     @classmethod
-    def from_dict(cls, data: Mapping) -> "EduidSCIMAPINotification":
+    def from_dict(cls, data: Mapping[str, Any]) -> "EduidSCIMAPINotification":
         data = dict(data)  # Do not change caller data
         return cls(**data)
 
@@ -50,7 +51,7 @@ class EmailPayload(Payload):
     language: str
 
     @classmethod
-    def from_dict(cls, data: Mapping) -> "EmailPayload":
+    def from_dict(cls, data: Mapping[str, Any]) -> "EmailPayload":
         data = dict(data)  # Do not change caller data
         return cls(**data)
 

--- a/src/eduid/queue/db/worker.py
+++ b/src/eduid/queue/db/worker.py
@@ -34,7 +34,7 @@ class AsyncQueueDB(AsyncBaseDB, QueuePayloadMixin):
         await instance.setup_indexes(indexes)
         return instance
 
-    def parse_queue_item(self, doc: Mapping, parse_payload: bool = True) -> QueueItem:
+    def parse_queue_item(self, doc: Mapping[str, Any], parse_payload: bool = True) -> QueueItem:
         item = QueueItem.from_dict(doc)
         if parse_payload is False:
             # Return the item with the generic RawPayload
@@ -95,7 +95,7 @@ class AsyncQueueDB(AsyncBaseDB, QueuePayloadMixin):
 
     async def find_items(
         self, processed: bool, min_age_in_seconds: int | None = None, expired: bool | None = None
-    ) -> list:
+    ) -> list[Any]:
         # TODO: Add registered payload types to spec
         spec: dict[str, Any] = {}
         if not processed:

--- a/src/eduid/queue/testing.py
+++ b/src/eduid/queue/testing.py
@@ -137,7 +137,7 @@ class QueueAsyncioTest(EduidQueueTestCase):
 
     @pytest_asyncio.fixture(autouse=True)
     async def setup_asyncio_queue(self, setup_queue: None, isolated_async_client_cache: None) -> AsyncIterator[None]:
-        self.tasks: list[Task] = []
+        self.tasks: list[Task[Any]] = []
         await self._init_async_db()
         yield
         for task in self.tasks:

--- a/src/eduid/queue/workers/base.py
+++ b/src/eduid/queue/workers/base.py
@@ -6,6 +6,7 @@ from asyncio import CancelledError, Task
 from collections.abc import Sequence
 from dataclasses import replace
 from os import environ
+from typing import Any
 
 from eduid.common.logging import init_logging
 from eduid.common.misc.timeutil import utc_now
@@ -20,7 +21,7 @@ __author__ = "lundberg"
 logger = logging.getLogger(__name__)
 
 
-def cancel_task(signame: str, task: Task) -> None:
+def cancel_task(signame: str, task: Task[Any]) -> None:
     logger.info(f"got signal {signame}: exit")
     task.cancel()
 
@@ -39,7 +40,7 @@ class QueueWorker:
         logger.info(f"Starting {self.config.app_name}: {self.worker_name}...")
 
     @staticmethod
-    def add_task(tasks: set[Task], task: Task) -> set[Task]:
+    def add_task(tasks: set[Task[None]], task: Task[None]) -> set[Task[None]]:
         # To prevent keeping references to finished tasks forever, make each task remove its own reference
         # from the set after completion.
         task.add_done_callback(tasks.discard)
@@ -127,7 +128,7 @@ class QueueWorker:
 
     async def watch_collection(self) -> None:
         change_stream = None
-        tasks: set[Task] = set()
+        tasks: set[Task[None]] = set()
         try:
             async with self.db.collection.watch() as change_stream:
                 async for change in change_stream:
@@ -151,7 +152,7 @@ class QueueWorker:
                 await asyncio.gather(*tasks)
 
     async def periodic_collection_check(self) -> None:
-        tasks: set[Task] = set()
+        tasks: set[Task[None]] = set()
         try:
             while True:
                 logger.debug("Running periodic collection check")
@@ -170,13 +171,13 @@ class QueueWorker:
             logger.info("Cleaning up periodic_collection_check task...")
             await asyncio.gather(*tasks)
 
-    async def collect_periodic_tasks(self) -> set[Task]:
+    async def collect_periodic_tasks(self) -> set[Task[None]]:
         tasks = await self.collect_forgotten_items()
         tasks.update(await self.collect_expired_items())
         return tasks
 
-    async def collect_forgotten_items(self) -> set[Task]:
-        tasks: set[Task] = set()
+    async def collect_forgotten_items(self) -> set[Task[None]]:
+        tasks: set[Task[None]] = set()
         # Check for forgotten untouched queue items
         items = await self.db.find_items(
             processed=False, min_age_in_seconds=self.config.periodic_min_retry_wait_in_seconds, expired=False
@@ -191,8 +192,8 @@ class QueueWorker:
             )
         return tasks
 
-    async def collect_expired_items(self) -> set[Task]:
-        tasks: set[Task] = set()
+    async def collect_expired_items(self) -> set[Task[None]]:
+        tasks: set[Task[None]] = set()
         # Check for expired untouched queue items
         items = await self.db.find_items(
             processed=False, min_age_in_seconds=self.config.periodic_min_retry_wait_in_seconds, expired=True

--- a/src/eduid/queue/workers/sink.py
+++ b/src/eduid/queue/workers/sink.py
@@ -50,7 +50,7 @@ class SinkQueueWorker(QueueWorker):
     async def handle_expired_item(self, queue_item: QueueItem) -> None:
         logger.warning(f"Found expired item: {queue_item}")
 
-    async def collect_periodic_tasks(self) -> set[Task]:
+    async def collect_periodic_tasks(self) -> set[Task[Any]]:
         tasks = await super().collect_periodic_tasks()
         self.add_task(tasks, asyncio.create_task(self.periodic_stats_publishing(), name="periodic_stats_publishing"))
         return tasks

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class Config:
     mongo_uri: str
     neo4j_uri: str | None = None
-    neo4j_config: dict = field(default_factory=dict)
+    neo4j_config: dict[str, Any] = field(default_factory=dict)
     only_configure_and_expose_scim: bool = False
     allow_users_not_in_database: Mapping[str, bool] = field(default_factory=lambda: {"default": False})
     fallback_data_owner: str | None = None

--- a/src/eduid/satosa/scimapi/serve_static.py
+++ b/src/eduid/satosa/scimapi/serve_static.py
@@ -38,7 +38,7 @@ class ServeStatic(RequestMicroService):
         super().__init__(*args, **kwargs)
         self.locations = config.get("locations", {})
 
-    def register_endpoints(self) -> list:
+    def register_endpoints(self) -> list[Any]:
         url_map = []
         for endpoint_raw, path in self.locations.items():
             endpoint = endpoint_raw.strip("/")

--- a/src/eduid/satosa/scimapi/static_attributes.py
+++ b/src/eduid/satosa/scimapi/static_attributes.py
@@ -56,11 +56,11 @@ class AddStaticAttributesForVirtualIdp(ResponseMicroService):
             "static_appended_attributes_for_virtual_idp"
         )
 
-    def _build_static(self, requester: str, vidp: str, existing_attributes: dict) -> dict[str, list[str]]:
+    def _build_static(self, requester: str, vidp: str, existing_attributes: dict[str, Any]) -> dict[str, list[str]]:
         static_attributes: dict[str, list[str]] = {}
 
         if self.static_attributes:
-            recipes: Mapping[str, list] = get_dict_defaults(self.static_attributes, requester, vidp)
+            recipes: Mapping[str, list[str]] = get_dict_defaults(self.static_attributes, requester, vidp)
             for attr_name, fmt in recipes.items():
                 logger.debug(f"Adding static attribute {attr_name}: {fmt} for requester {requester} or {vidp}")
 

--- a/src/eduid/scimapi/app.py
+++ b/src/eduid/scimapi/app.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from starlette.middleware.cors import CORSMiddleware
@@ -22,14 +24,14 @@ from eduid.scimapi.routers.users import users_router
 
 
 class ScimAPI(FastAPI):
-    def __init__(self, name: str = "scimapi", test_config: dict | None = None) -> None:
+    def __init__(self, name: str = "scimapi", test_config: dict[str, Any] | None = None) -> None:
         self.config = load_config(typ=ScimApiConfig, app_name=name, ns="api", test_config=test_config)
         super().__init__(root_path=self.config.application_root)
         self.context = Context(config=self.config)
         self.context.logger.info(f"Starting {name} app")
 
 
-def init_api(name: str = "scimapi", test_config: dict | None = None) -> ScimAPI:
+def init_api(name: str = "scimapi", test_config: dict[str, Any] | None = None) -> ScimAPI:
     app = ScimAPI(name=name, test_config=test_config)
     app.router.route_class = ScimApiRoute
 

--- a/src/eduid/scimapi/config.py
+++ b/src/eduid/scimapi/config.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -19,7 +20,7 @@ class ScimApiConfig(AuthnBearerTokenConfig, LoggingConfigMixin, AWSMixin):
     """
 
     neo4j_uri: str = ""
-    neo4j_config: dict = Field(default_factory=dict)
+    neo4j_config: dict[str, Any] = Field(default_factory=dict)
     signing_key_id: str
     login_enabled: bool = False
     no_authn_urls: list[str] = Field(

--- a/src/eduid/scimapi/exceptions.py
+++ b/src/eduid/scimapi/exceptions.py
@@ -24,7 +24,7 @@ class MaxRetriesReached(Exception):
 class ErrorDetail(BaseModel):
     scimType: str | None = None
     schemas: list[str] = [SCIMSchema.ERROR.value]
-    detail: str | dict | list | None = None
+    detail: str | dict[str, Any] | list[Any] | None = None
     status: int | None = None
 
 
@@ -75,18 +75,18 @@ class HTTPErrorDetail(Exception):
             schemas = [SCIMSchema.ERROR.value]
 
         self._error_detail = ErrorDetail(scimType=scim_type, schemas=schemas, detail=detail, status=status_code)
-        self._extra_headers: dict | None = None
+        self._extra_headers: dict[str, str] | None = None
 
     @property
     def error_detail(self) -> ErrorDetail:
         return self._error_detail
 
     @property
-    def extra_headers(self) -> dict | None:
+    def extra_headers(self) -> dict[str, str] | None:
         return self._extra_headers
 
     @extra_headers.setter
-    def extra_headers(self, headers: dict) -> None:
+    def extra_headers(self, headers: dict[str, str]) -> None:
         self._extra_headers = headers
 
 

--- a/src/eduid/scimapi/test-scripts/scim-util.py
+++ b/src/eduid/scimapi/test-scripts/scim-util.py
@@ -40,10 +40,10 @@ def parse_args() -> Args:
 
 
 def scim_request(
-    func: Callable,
+    func: Callable[..., Any],
     url: str,
-    data: dict | None = None,
-    headers: dict | None = None,
+    data: dict[str, Any] | None = None,
+    headers: dict[str, Any] | None = None,
     token: str | None = None,
     verify: bool = True,
 ) -> dict[str, Any] | None:
@@ -64,10 +64,10 @@ def scim_request(
 
 
 def _make_request(
-    func: Callable,
+    func: Callable[..., Any],
     url: str,
-    data: dict | None = None,
-    headers: dict | None = None,
+    data: dict[str, Any] | None = None,
+    headers: dict[str, Any] | None = None,
     verify: bool = True,
 ) -> requests.Response | None:
     r = func(url, json=data, headers=headers, verify=verify)

--- a/src/eduid/scimapi/testing.py
+++ b/src/eduid/scimapi/testing.py
@@ -67,7 +67,7 @@ class MongoNeoTestCase(BaseDBTestCase):
     neo4j_instance: Neo4jTemporaryInstance
     neo4j_uri: str
 
-    def _get_config(self) -> dict:
+    def _get_config(self) -> dict[str, Any]:
         config = super()._get_config()
         config.update(
             {
@@ -137,7 +137,7 @@ class ScimApiTestCase(MongoNeoTestCase):
         for dbs in self.context._dbs.values():
             dbs.groupdb.graphdb.db.close()
 
-    def _get_config(self) -> dict:
+    def _get_config(self) -> dict[str, Any]:
         config = super()._get_config()
         config["keystore_path"] = f"{self.datadir}/testing_jwks.json"
         config["signing_key_id"] = "testing-scimapi-2106210000"

--- a/src/eduid/scimapi/tests/test_authn.py
+++ b/src/eduid/scimapi/tests/test_authn.py
@@ -403,7 +403,7 @@ class TestAuthnUserResource(ScimApiTestUserResourceBase):
     def setup(self) -> None:
         self.test_profile = ScimApiProfile(attributes={"displayName": "Test User 1"}, data={"test_key": "test_value"})
 
-    def _get_config(self) -> dict:
+    def _get_config(self) -> dict[str, Any]:
         config = super()._get_config()
         config["keystore_path"] = f"{self.datadir}/testing_jwks.json"
         config["signing_key_id"] = "testing-scimapi-2106210000"

--- a/src/eduid/scimapi/tests/test_login.py
+++ b/src/eduid/scimapi/tests/test_login.py
@@ -2,13 +2,14 @@ __author__ = "lundberg"
 
 import json
 from http import HTTPStatus
+from typing import Any
 from uuid import uuid4
 
 from eduid.scimapi.testing import ScimApiTestCase
 
 
 class TestLoginResource(ScimApiTestCase):
-    def _get_config(self) -> dict:
+    def _get_config(self) -> dict[str, Any]:
         config = super()._get_config()
         config["login_enabled"] = True
         return config

--- a/src/eduid/scimapi/tests/test_scimevent.py
+++ b/src/eduid/scimapi/tests/test_scimevent.py
@@ -20,7 +20,7 @@ class EventApiResult:
     response: Response
     event: NutidEventExtensionV1
     parsed_response: EventResponse
-    request: Mapping | None = None
+    request: Mapping[str, Any] | None = None
 
 
 class TestEventResource(ScimApiTestCase):
@@ -49,7 +49,7 @@ class TestEventResource(ScimApiTestCase):
         parsed_response = EventResponse.model_validate_json(response.text)
         return EventApiResult(event=parsed_response.nutid_event_v1, response=response, parsed_response=parsed_response)
 
-    def _assertEventUpdateSuccess(self, req: Mapping, response: Response, event: ScimApiEvent) -> None:
+    def _assertEventUpdateSuccess(self, req: Mapping[str, Any], response: Response, event: ScimApiEvent) -> None:
         """Function to validate successful responses to SCIM calls that update a event according to a request."""
 
         if response.json().get("schemas") == [SCIMSchema.ERROR.value]:

--- a/src/eduid/scimapi/tests/test_scimgroup.py
+++ b/src/eduid/scimapi/tests/test_scimgroup.py
@@ -91,7 +91,7 @@ class TestGroupResource(ScimApiTestCase):
         expected_group: ScimApiGroup | None = None,
         expected_num_resources: int | None = None,
         expected_total_results: int | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         logger.info(f"Searching for group(s) using filter {search_filter!r}")
         req = {
             "schemas": [SCIMSchema.API_MESSAGES_20_SEARCH_REQUEST.value],
@@ -137,7 +137,7 @@ class TestGroupResource(ScimApiTestCase):
 
         return resources
 
-    def _assertGroupUpdateSuccess(self, req: Mapping, response: Response, group: ScimApiGroup) -> None:
+    def _assertGroupUpdateSuccess(self, req: Mapping[str, Any], response: Response, group: ScimApiGroup) -> None:
         """Function to validate successful responses to SCIM calls that update a group according to a request."""
         if response.json().get("schemas") == [SCIMSchema.ERROR.value]:
             pytest.fail(f"Got SCIM error parsed_response ({response.status_code}):\n{response.json}")

--- a/src/eduid/scimapi/tests/test_sciminvite.py
+++ b/src/eduid/scimapi/tests/test_sciminvite.py
@@ -245,7 +245,7 @@ class TestInviteResource(ScimApiTestCase):
         return db_invite
 
     def _assertUpdateSuccess(
-        self, req: Mapping, response: Response, invite: ScimApiInvite, signup_invite: SignupInvite
+        self, req: Mapping[str, Any], response: Response, invite: ScimApiInvite, signup_invite: SignupInvite
     ) -> None:
         """Function to validate successful responses to SCIM calls that update an invite according to a request."""
         if response.json().get("schemas") == [SCIMSchema.ERROR.value]:
@@ -293,7 +293,7 @@ class TestInviteResource(ScimApiTestCase):
         expected_invite: ScimApiInvite | None = None,
         expected_num_resources: int | None = None,
         expected_total_results: int | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         logger.info(f"Searching for group(s) using filter {search_filter!r}")
         req = {
             "schemas": [SCIMSchema.API_MESSAGES_20_SEARCH_REQUEST.value],

--- a/src/eduid/scimapi/tests/test_scimuser.py
+++ b/src/eduid/scimapi/tests/test_scimuser.py
@@ -189,7 +189,7 @@ class ScimApiTestUserResourceBase(ScimApiTestCase):
             attributes={"displayName": "Test User 2"}, data={"another_test_key": "another_test_value"}
         )
 
-    def _assertUserUpdateSuccess(self, req: Mapping, response: Response, user: ScimApiUser) -> None:
+    def _assertUserUpdateSuccess(self, req: Mapping[str, Any], response: Response, user: ScimApiUser) -> None:
         """Function to validate successful responses to SCIM calls that update a user according to a request."""
 
         if response.json().get("schemas") == [SCIMSchema.ERROR.value]:
@@ -814,7 +814,7 @@ class TestUserResource(ScimApiTestUserResourceBase):
         expected_user: ScimApiUser | None = None,
         expected_num_resources: int | None = None,
         expected_total_results: int | None = None,
-    ) -> dict:
+    ) -> list[dict[str, Any]]:
         logger.info(f"Searching for user(s) using filter {search_filter!r}")
         req = {
             "schemas": [SCIMSchema.API_MESSAGES_20_SEARCH_REQUEST.value],

--- a/src/eduid/scimapi/utils.py
+++ b/src/eduid/scimapi/utils.py
@@ -58,7 +58,7 @@ def load_jwks(config: ScimApiConfig) -> jwk.JWKSet:
     return jwks
 
 
-def retryable_db_write(func: Callable) -> Callable:
+def retryable_db_write(func: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(func)
     def wrapper_run_func(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         max_retries = 10

--- a/src/eduid/userdb/db/sync_db.py
+++ b/src/eduid/userdb/db/sync_db.py
@@ -27,9 +27,9 @@ class MongoClientCache:
     A cache for pymongo.MongoClient instances.
     """
 
-    _clients: ClassVar[dict[str, pymongo.MongoClient]] = {}
+    _clients: ClassVar[dict[str, pymongo.MongoClient[Any]]] = {}
 
-    def get_client(self, db: BaseMongoDB) -> pymongo.MongoClient:
+    def get_client(self, db: BaseMongoDB) -> pymongo.MongoClient[Any]:
         db_args = db.db_args
         connection_uri: str = db_args["host"]
         if connection_uri in self._clients:

--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -294,7 +294,7 @@ class ElementList[ListElement: Element](BaseModel, ABC):
         return values
 
     @classmethod
-    def from_list_of_dicts[T: ElementList](cls: type[T], items: list[dict[str, Any]]) -> T:
+    def from_list_of_dicts[T: ElementList[Any]](cls: type[T], items: list[dict[str, Any]]) -> T:
         # must be implemented by subclass to get correct type information
         raise NotImplementedError()
 

--- a/src/eduid/userdb/reset_password/db.py
+++ b/src/eduid/userdb/reset_password/db.py
@@ -91,7 +91,9 @@ class ResetPasswordStateDB(BaseDB):
         return None
 
     @staticmethod
-    def init_state(state_mapping: Mapping) -> ResetPasswordEmailState | ResetPasswordEmailAndPhoneState | None:
+    def init_state(
+        state_mapping: Mapping[str, Any],
+    ) -> ResetPasswordEmailState | ResetPasswordEmailAndPhoneState | None:
         state = dict(state_mapping)
         if state.get("method") == "email":
             return ResetPasswordEmailState.from_dict(data=state)

--- a/src/eduid/userdb/reset_password/element.py
+++ b/src/eduid/userdb/reset_password/element.py
@@ -53,7 +53,9 @@ class CodeElement(Element):
         return expiry_date < now
 
     @classmethod
-    def parse(cls: type[CodeElement], code_or_element: Mapping | CodeElement | str, application: str) -> CodeElement:
+    def parse(
+        cls: type[CodeElement], code_or_element: Mapping[str, Any] | CodeElement | str, application: str
+    ) -> CodeElement:
         if isinstance(code_or_element, str):
             return cls(created_by=application, code=code_or_element, is_verified=False)
         if isinstance(code_or_element, dict):

--- a/src/eduid/userdb/scimapi/groupdb.py
+++ b/src/eduid/userdb/scimapi/groupdb.py
@@ -35,7 +35,7 @@ class GroupExtensions:
         return asdict(self)
 
     @classmethod
-    def from_mapping(cls: type[Self], data: Mapping) -> Self:
+    def from_mapping(cls: type[Self], data: Mapping[str, Any]) -> Self:
         return cls(
             data=data.get("data", {}),
         )

--- a/src/eduid/userdb/support/models.py
+++ b/src/eduid/userdb/support/models.py
@@ -7,7 +7,7 @@ __author__ = "lundberg"
 
 
 # Models for filtering out unneeded or unwanted data from eduID database objects
-class GenericFilterDict(dict):
+class GenericFilterDict(dict[str, Any]):
     add_keys: ClassVar[list[str] | None] = None
     remove_keys: ClassVar[list[str] | None] = None
 

--- a/src/eduid/userdb/tests/test_tou.py
+++ b/src/eduid/userdb/tests/test_tou.py
@@ -1,5 +1,6 @@
 import copy
 from datetime import datetime, timedelta
+from typing import Any
 from uuid import uuid4
 
 import bson
@@ -49,7 +50,7 @@ _three_dict = {
 class TestToUEvent:
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
-        self.empty: EventList = EventList()
+        self.empty: EventList[Any] = EventList()
         self.one = ToUList.from_list_of_dicts([_one_dict])
         self.two = ToUList.from_list_of_dicts([_one_dict, _two_dict])
         self.three = ToUList.from_list_of_dicts([_one_dict, _two_dict, _three_dict])

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -66,7 +66,7 @@ class User(BaseModel):
     orcid: Orcid | None = None
     ladok: Ladok | None = None
     profiles: ProfileList = Field(default_factory=ProfileList)
-    letter_proofing_data: list | dict | None = None  # remove dict after a full load-save-users
+    letter_proofing_data: list[Any] | dict[str, Any] | None = None  # remove dict after a full load-save-users
     revoked_ts: datetime | None = None
     preferences: UserPreferences = Field(default_factory=UserPreferences)
     model_config = ConfigDict(

--- a/src/eduid/userdb/userdb.py
+++ b/src/eduid/userdb/userdb.py
@@ -464,7 +464,7 @@ class AmDB(UserDB[User]):
         return count
 
 
-class AutoExpiringUserDB[UserVar](UserDB):
+class AutoExpiringUserDB[UserVar](UserDB[UserVar]):
     """
     This should be used for all private userdbs as we only need to keep
     the user around for the sync to am and for any debugging.

--- a/src/eduid/vccs/client/__init__.py
+++ b/src/eduid/vccs/client/__init__.py
@@ -382,7 +382,7 @@ class VCCSClient:
             raise TypeError(f"Operation success value type error : {success!r}")
         return success is True
 
-    def _execute(self, data: str, response_label: str) -> dict:
+    def _execute(self, data: str, response_label: str) -> dict[str, Any]:
         """
         Make a HTTP POST request to the authentication backend, and parse the result.
 

--- a/src/eduid/vccs/server/run.py
+++ b/src/eduid/vccs/server/run.py
@@ -21,7 +21,9 @@ from eduid.vccs.server.log import InterceptHandler, init_logging
 
 
 class VCCS_API(FastAPI):
-    def __init__(self, test_config: Mapping[str, Any] | None = None, lifespan: Callable | None = None) -> None:
+    def __init__(
+        self, test_config: Mapping[str, Any] | None = None, lifespan: Callable[..., Any] | None = None
+    ) -> None:
         print("vccs_api is starting", file=sys.stderr)
         super().__init__(lifespan=lifespan)
 

--- a/src/eduid/webapp/authn/tests/test_authn.py
+++ b/src/eduid/webapp/authn/tests/test_authn.py
@@ -39,7 +39,7 @@ class AcsResult:
     authn_ref: AuthnRequestRef
 
 
-class AuthnAPITestBase(EduidAPITestCase):
+class AuthnAPITestBase(EduidAPITestCase[AuthnApp]):
     """Test cases for the real eduid-authn app"""
 
     app: AuthnApp
@@ -309,7 +309,7 @@ class AuthnTestApp(AuthnBaseApp[AuthnConfig]):
         self.conf = config
 
 
-class UnAuthnAPITestCase(EduidAPITestCase):
+class UnAuthnAPITestCase(EduidAPITestCase[AuthnTestApp]):
     """Tests for a fictitious app based on AuthnBaseApp"""
 
     app: AuthnTestApp
@@ -350,7 +350,7 @@ class UnAuthnAPITestCase(EduidAPITestCase):
                 c.get("/")
 
 
-class NoAuthnAPITestCase(EduidAPITestCase):
+class NoAuthnAPITestCase(EduidAPITestCase[AuthnTestApp]):
     """Tests for a fictitious app based on AuthnBaseApp"""
 
     app: AuthnTestApp

--- a/src/eduid/webapp/bankid/proofing.py
+++ b/src/eduid/webapp/bankid/proofing.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from eduid.common.config.base import ProofingConfigMixin
 from eduid.common.models.saml_models import BaseSessionInfo
@@ -143,7 +144,7 @@ def get_proofing_functions(
     app_name: str,
     config: ProofingConfigMixin,
     backdoor: bool,
-) -> ProofingFunctions:
+) -> ProofingFunctions[Any]:
     if isinstance(session_info, BankIDSessionInfo):
         return BankIDProofingFunctions(session_info=session_info, app_name=app_name, config=config, backdoor=backdoor)
     else:

--- a/src/eduid/webapp/common/api/checks.py
+++ b/src/eduid/webapp/common/api/checks.py
@@ -23,12 +23,12 @@ if TYPE_CHECKING:
 __author__ = "lundberg"
 
 
-def get_current_app() -> EduIDBaseApp:
+def get_current_app() -> EduIDBaseApp[EduIDBaseAppConfig]:
     from eduid.webapp.common.api.app import EduIDBaseApp
 
     _conf = getattr(flask_current_app, "conf")
     assert isinstance(_conf, EduIDBaseAppConfig)
-    return cast(EduIDBaseApp, flask_current_app)
+    return cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
 
 
 @dataclass

--- a/src/eduid/webapp/common/api/decorators.py
+++ b/src/eduid/webapp/common/api/decorators.py
@@ -142,7 +142,7 @@ class MarshalWith:
     def __init__(self, schema: type[Schema]) -> None:
         self.schema = schema
 
-    def __call__(self, f: EduidRouteCallable) -> Callable:
+    def __call__(self, f: EduidRouteCallable) -> Callable[..., Any]:
         @wraps(f)
         def marshal_decorator(*args: Any, **kwargs: Any) -> Response:
             # Call the Flask view, which is expected to return a FluxData instance,
@@ -187,7 +187,7 @@ class UnmarshalWith:
     def __init__(self, schema: type[Schema]) -> None:
         self.schema = schema
 
-    def __call__(self, f: EduidRouteCallable) -> Callable:
+    def __call__(self, f: EduidRouteCallable) -> Callable[..., Any]:
         @wraps(f)
         def unmarshal_decorator(*args: Any, **kwargs: Any) -> ResponseReturnValue:
             flux_logger.debug("")

--- a/src/eduid/webapp/common/api/schemas/base.py
+++ b/src/eduid/webapp/common/api/schemas/base.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from marshmallow import RAISE, Schema, fields
 
 __author__ = "lundberg"
@@ -12,6 +14,6 @@ class EduidSchema(Schema):
 
 class FluxStandardAction(EduidSchema):
     type = fields.String(required=True)
-    payload: fields.Field = fields.Field(required=False)
+    payload: fields.Field[Any] = fields.Field(required=False)
     error = fields.Boolean(required=False)
     meta = fields.Raw(required=False)

--- a/src/eduid/webapp/common/api/tests/test_decorators.py
+++ b/src/eduid/webapp/common/api/tests/test_decorators.py
@@ -36,7 +36,7 @@ def flask_view(ret: FluxData) -> FluxData:
     return ret
 
 
-class MarshalDecoratorTests(EduidAPITestCase):
+class MarshalDecoratorTests(EduidAPITestCase[DecoratorTestApp]):
     app: DecoratorTestApp
 
     def load_app(self, config: Mapping[str, Any]) -> DecoratorTestApp:

--- a/src/eduid/webapp/common/api/tests/test_logging.py
+++ b/src/eduid/webapp/common/api/tests/test_logging.py
@@ -15,7 +15,7 @@ class LoggingTestApp(EduIDBaseApp[EduIDBaseAppConfig]):
     pass
 
 
-class LoggingTest(EduidAPITestCase):
+class LoggingTest(EduidAPITestCase[LoggingTestApp]):
     app: LoggingTestApp
 
     def load_app(self, config: Mapping[str, Any]) -> LoggingTestApp:

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -22,7 +22,7 @@ from eduid.webapp.common.api.exceptions import ApiException
 if TYPE_CHECKING:
     from eduid.webapp.common.api.app import EduIDBaseApp
 
-    current_app = cast(EduIDBaseApp, flask_current_app)
+    current_app = cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
 else:
     current_app = flask_current_app
 

--- a/src/eduid/webapp/common/api/views/status.py
+++ b/src/eduid/webapp/common/api/views/status.py
@@ -16,7 +16,7 @@ from eduid.webapp.common.api.utils import get_from_current_app
 if TYPE_CHECKING:
     from eduid.webapp.common.api.app import EduIDBaseApp
 
-    current_app = cast(EduIDBaseApp, flask_current_app)
+    current_app = cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
 else:
     current_app = flask_current_app
 

--- a/src/eduid/webapp/common/authn/acs_registry.py
+++ b/src/eduid/webapp/common/authn/acs_registry.py
@@ -51,7 +51,7 @@ class UnregisteredAction(Exception):
     pass
 
 
-def acs_action(action: Enum) -> Callable:
+def acs_action(action: Enum) -> Callable[..., Any]:
     """
     Decorator to register a new assertion consumer service action.
 

--- a/src/eduid/webapp/common/authn/eduid_saml2.py
+++ b/src/eduid/webapp/common/authn/eduid_saml2.py
@@ -70,7 +70,7 @@ def get_authn_request(
     authn_id: AuthnRequestRef,
     selected_idp: str | None,
     force_authn: bool = False,
-    req_authn_ctx: list | None = None,
+    req_authn_ctx: list[Any] | None = None,
     sign_alg: str | None = None,
     digest_alg: str | None = None,
     subject: Subject | None = None,
@@ -168,7 +168,7 @@ def get_authn_response(
     return response, authn_reqref
 
 
-def authenticate(session_info: SessionInfo, strip_suffix: str | None, userdb: UserDB) -> User | None:
+def authenticate(session_info: SessionInfo, strip_suffix: str | None, userdb: UserDB[User]) -> User | None:
     """
     Locate a user using the identity found in the SAML assertion.
 

--- a/src/eduid/webapp/common/authn/testing.py
+++ b/src/eduid/webapp/common/authn/testing.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 from eduid.vccs.client import VCCSFactor, VCCSPasswordFactor, VCCSRevokeFactor
 
@@ -51,13 +52,13 @@ class MockVCCSClient:
         return found
 
     def add_credentials(self, user_id: str, factors: Sequence[VCCSFactor]) -> bool:
-        user_factors: list = self.factors.get(str(user_id), [])
+        user_factors: list[Any] = self.factors.get(str(user_id), [])
         user_factors.extend(factors)
         self.factors[str(user_id)] = user_factors
         return True
 
     def revoke_credentials(self, user_id: str, revoked: Sequence[VCCSRevokeFactor]) -> bool:
-        stored: list | None = self.factors.get(user_id, None)
+        stored: list[Any] | None = self.factors.get(user_id, None)
         removed: bool = False
         if stored:  # Nothing stored in test client yet
             for rfactor in revoked:

--- a/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
+++ b/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
@@ -95,7 +95,7 @@ SAMPLE_WEBAUTHN_APP_CONFIG = {
 }
 
 
-class FidoTokensTestCase(EduidAPITestCase):
+class FidoTokensTestCase(EduidAPITestCase[MockFidoApp]):
     app: MockFidoApp
 
     @pytest.fixture(autouse=True)

--- a/src/eduid/webapp/common/authn/tests/test_middleware.py
+++ b/src/eduid/webapp/common/authn/tests/test_middleware.py
@@ -18,7 +18,7 @@ class AuthnTestApp(AuthnBaseApp[EduIDBaseAppConfig]):
         super().__init__(self.conf, **kwargs)
 
 
-class AuthnTests(EduidAPITestCase):
+class AuthnTests(EduidAPITestCase[AuthnTestApp]):
     def load_app(self, config: dict[str, Any]) -> AuthnTestApp:
         """
         Called from the parent class, so we can provide the appropriate flask
@@ -49,7 +49,7 @@ class AuthnTests(EduidAPITestCase):
                 client.get("/some/path")
 
 
-class UnAuthnTests(EduidAPITestCase):
+class UnAuthnTests(EduidAPITestCase[AuthnTestApp]):
     def load_app(self, config: dict[str, Any]) -> AuthnTestApp:
         """
         Called from the parent class, so we can provide the appropriate flask

--- a/src/eduid/webapp/common/authn/utils.py
+++ b/src/eduid/webapp/common/authn/utils.py
@@ -26,7 +26,7 @@ from eduid.webapp.common.session.namespaces import SP_AuthnRequest
 if TYPE_CHECKING:
     from eduid.webapp.common.authn.middleware import AuthnBaseApp
 
-    current_app = cast(AuthnBaseApp, flask_current_app)
+    current_app = cast(AuthnBaseApp[EduIDBaseAppConfig], flask_current_app)
 else:
     current_app = flask_current_app
 

--- a/src/eduid/webapp/common/session/tests/test_eduid_session.py
+++ b/src/eduid/webapp/common/session/tests/test_eduid_session.py
@@ -80,7 +80,7 @@ def session_init_app(name: str, test_config: Mapping[str, Any]) -> SessionTestAp
     return app
 
 
-class EduidSessionTests(EduidAPITestCase):
+class EduidSessionTests(EduidAPITestCase[SessionTestApp]):
     app: SessionTestApp
 
     @pytest.fixture(autouse=True)

--- a/src/eduid/webapp/common/session/tests/test_namespaces.py
+++ b/src/eduid/webapp/common/session/tests/test_namespaces.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-class TestNameSpaceBase(EduidAPITestCase):
+class TestNameSpaceBase(EduidAPITestCase[SessionTestApp]):
     app: SessionTestApp
 
     def load_app(self, config: Mapping[str, Any]) -> SessionTestApp:

--- a/src/eduid/webapp/eidas/proofing.py
+++ b/src/eduid/webapp/eidas/proofing.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
 
 from eduid.common.config.base import ProofingConfigMixin
 from eduid.common.rpc.exceptions import AmTaskFailed
@@ -342,7 +343,7 @@ def get_proofing_functions(
     app_name: str,
     config: ProofingConfigMixin,
     backdoor: bool,
-) -> ProofingFunctions:
+) -> ProofingFunctions[Any]:
     if isinstance(session_info, NinSessionInfo):
         return FrejaProofingFunctions(session_info=session_info, app_name=app_name, config=config, backdoor=backdoor)
     elif isinstance(session_info, ForeignEidSessionInfo):

--- a/src/eduid/webapp/email/tests/test_app.py
+++ b/src/eduid/webapp/email/tests/test_app.py
@@ -66,7 +66,7 @@ class EmailTests(EduidAPITestCase[EmailApp]):
 
     # Parameterized test methods
 
-    def _get_all_emails(self) -> dict:
+    def _get_all_emails(self) -> dict[str, Any]:
         """
         GET a list with all the email addresses of the test user
         """

--- a/src/eduid/webapp/group_management/helpers.py
+++ b/src/eduid/webapp/group_management/helpers.py
@@ -95,7 +95,7 @@ def merge_group_lists(owner_groups: list[ScimApiGroup], member_groups: list[Scim
     return list(combined_groups.values())
 
 
-def list_of_group_data(group_list: list[UserGroup]) -> list[dict]:
+def list_of_group_data(group_list: list[UserGroup]) -> list[dict[str, Any]]:
     ret = []
     for group in group_list:
         members = [{"identifier": member.identifier, "display_name": member.display_name} for member in group.members]

--- a/src/eduid/webapp/idp/decorators.py
+++ b/src/eduid/webapp/idp/decorators.py
@@ -19,7 +19,7 @@ from eduid.webapp.idp.sso_session import get_sso_session
 logger = logging.getLogger(__name__)
 
 
-def require_ticket(f: Callable) -> Callable:
+def require_ticket(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
     def require_ticket_decorator(*args: Any, **kwargs: Any) -> Response | WerkzeugResponse:
         """Decorator to turn the 'ref' parameter sent by the frontend into a ticket (LoginContext)"""
@@ -57,7 +57,7 @@ def require_ticket(f: Callable) -> Callable:
     return require_ticket_decorator
 
 
-def uses_sso_session(f: Callable) -> Callable:
+def uses_sso_session(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
     def uses_sso_session_decorator(*args: Any, **kwargs: Any) -> FluxData | WerkzeugResponse:
         """Decorator to supply the current SSO session, if one is found and still valid"""

--- a/src/eduid/webapp/idp/schemas.py
+++ b/src/eduid/webapp/idp/schemas.py
@@ -76,7 +76,7 @@ class MfaAuthResponseSchema(FluxStandardAction):
     payload = fields.Nested(MfaAuthResponsePayload)
 
 
-class ToUVersions(fields.Field):
+class ToUVersions(fields.Field[Any]):
     """Handle list of ToU versions available in the frontend both as comma-separated string (bug) and as list"""
 
     def _deserialize(self, value: object, attr: str | None, data: object, **kwargs: Any) -> list[str] | None:

--- a/src/eduid/webapp/idp/tests/data/test_SSO_conf.py
+++ b/src/eduid/webapp/idp/tests/data/test_SSO_conf.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT, BINDING_SOAP
 from saml2.saml import NAME_FORMAT_URI, NAMEID_FORMAT_PERSISTENT, NAMEID_FORMAT_TRANSIENT
@@ -100,7 +101,7 @@ CONFIG = {
 
 
 # SP config
-def get_sp_config(sp_base: str) -> dict:
+def get_sp_config(sp_base: str) -> dict[str, Any]:
     """
     Use this to change SP_BASE in config
     """

--- a/src/eduid/webapp/idp/tests/test_SSO.py
+++ b/src/eduid/webapp/idp/tests/test_SSO.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import Mapping
 from datetime import UTC, datetime
+from typing import Any
 from uuid import uuid4
 
 import saml2.server
@@ -122,7 +123,7 @@ class SSOIdPTests(IdPAPITests):
 
     def _parse_SAMLRequest(
         self,
-        info: Mapping,
+        info: Mapping[str, Any],
         binding: str,
         idp: saml2.server.Server,
         debug: bool = False,

--- a/src/eduid/webapp/idp/tests/test_idPUserDb.py
+++ b/src/eduid/webapp/idp/tests/test_idPUserDb.py
@@ -214,7 +214,7 @@ class TestPasswordV2Upgrade(IdPAPITests):
             credential_user = CredentialUser.from_user(pwauth.user, self.app.credential_db)
             save_and_sync_user(
                 credential_user,
-                private_userdb=self.app.credential_db,
+                private_userdb=self.app.credential_db,  # type: ignore[arg-type]
                 app_name_override="eduid_idp",
             )
 

--- a/src/eduid/webapp/idp/views/pw_auth.py
+++ b/src/eduid/webapp/idp/views/pw_auth.py
@@ -70,7 +70,7 @@ def pw_auth(
         try:
             save_and_sync_user(
                 credential_user,
-                private_userdb=current_app.credential_db,
+                private_userdb=current_app.credential_db,  # type: ignore[arg-type]
                 app_name_override="eduid_idp",
             )
             current_app.logger.info(f"Saved credential changes for user {pwauth.user}")

--- a/src/eduid/webapp/letter_proofing/ekopost.py
+++ b/src/eduid/webapp/letter_proofing/ekopost.py
@@ -2,6 +2,7 @@ import base64
 import json
 from http import HTTPStatus
 from io import BytesIO
+from typing import Any
 
 from hammock import Hammock
 
@@ -65,7 +66,7 @@ class Ekopost:
 
         return closed_campaign["id"]
 
-    def _create_campaign(self, name: str, output_date: str, cost_center: str) -> dict:
+    def _create_campaign(self, name: str, output_date: str, cost_center: str) -> dict[str, Any]:
         """
         Create a new campaign
 
@@ -85,7 +86,7 @@ class Ekopost:
 
     def _create_envelope(
         self, campaign_id: str, name: str, postage: str = "priority", plex: str = "simplex", color: str = "false"
-    ) -> dict:
+    ) -> dict[str, Any]:
         """
         Create an envelope for a specified campaign
 
@@ -116,7 +117,7 @@ class Ekopost:
         data: bytes,
         mime: str = "application/pdf",
         content_type: str = "document",
-    ) -> dict:
+    ) -> dict[str, Any]:
         """
         Create the content that should be linked to an envelope
 
@@ -148,7 +149,7 @@ class Ekopost:
 
         raise EkopostException(f"Ekopost exception: {response.status_code!s} {response.text!s}")
 
-    def _close_envelope(self, campaign_id: str, envelope_id: str) -> dict:
+    def _close_envelope(self, campaign_id: str, envelope_id: str) -> dict[str, Any]:
         """
         Change an envelope state to closed and mark it as ready for print & distribution.
         :param campaign_id: Unique id of a campaign within which the envelope exists
@@ -165,7 +166,7 @@ class Ekopost:
 
         raise EkopostException(f"Ekopost exception: {response.status_code!s} {response.text!s}")
 
-    def _close_campaign(self, campaign_id: str) -> dict:
+    def _close_campaign(self, campaign_id: str) -> dict[str, Any]:
         """
         Change a campains state to closed and mark it and all its
         envelopes as ready for print & distribution.

--- a/src/eduid/webapp/letter_proofing/pdf.py
+++ b/src/eduid/webapp/letter_proofing/pdf.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from io import BytesIO, StringIO
 from pathlib import Path
+from typing import Any
 
 from xhtml2pdf import pisa
 
@@ -16,7 +17,7 @@ class AddressFormatException(Exception):
     pass
 
 
-def format_address(recipient: Mapping) -> tuple:
+def format_address(recipient: Mapping[str, Any]) -> tuple[str, ...]:
     """
     :param recipient: official address
     :type recipient: OrderedDict

--- a/src/eduid/webapp/letter_proofing/tests/test_pdf.py
+++ b/src/eduid/webapp/letter_proofing/tests/test_pdf.py
@@ -133,7 +133,7 @@ class FormatAddressTest:
                 pdf.format_address(response)
 
 
-class CreatePDFTest(EduidAPITestCase):
+class CreatePDFTest(EduidAPITestCase[LetterProofingApp]):
     def load_app(self, config: dict[str, Any]) -> LetterProofingApp:
         """
         Called from the parent class, so we can provide the appropriate flask

--- a/src/eduid/webapp/phone/schemas.py
+++ b/src/eduid/webapp/phone/schemas.py
@@ -20,7 +20,7 @@ class PhoneSchema(EduidSchema, CSRFRequestMixin):
     primary = fields.Boolean(attribute="primary")
 
     @pre_load
-    def normalize_phone_number(self, in_data: dict, **kwargs: Any) -> dict:
+    def normalize_phone_number(self, in_data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if in_data.get("number"):
             in_data["number"] = normalize_to_e_164(in_data["number"])
         return in_data

--- a/src/eduid/webapp/phone/tests/test_app.py
+++ b/src/eduid/webapp/phone/tests/test_app.py
@@ -44,7 +44,7 @@ class PhoneTests(EduidAPITestCase[PhoneApp]):
 
     # parameterized test methods
 
-    def _get_all_phone(self, eppn: str | None = None) -> dict:
+    def _get_all_phone(self, eppn: str | None = None) -> dict[str, Any]:
         """
         GET all phone data for some user
 

--- a/src/eduid/webapp/reset_password/helpers.py
+++ b/src/eduid/webapp/reset_password/helpers.py
@@ -352,7 +352,7 @@ def reset_user_password(
     return success_response(message=ResetPwMsg.pw_reset_success)
 
 
-def get_extra_security_alternatives(user: User) -> dict:
+def get_extra_security_alternatives(user: User) -> dict[str, Any]:
     """
     :param user: The user
     :return: Dict of alternatives
@@ -389,7 +389,7 @@ def get_extra_security_alternatives(user: User) -> dict:
     return alternatives
 
 
-def mask_alternatives(alternatives: dict) -> dict:
+def mask_alternatives(alternatives: dict[str, Any]) -> dict[str, Any]:
     """
     :param alternatives: Extra security alternatives collected from user
     :return: Masked extra security alternatives

--- a/src/eduid/webapp/reset_password/schemas.py
+++ b/src/eduid/webapp/reset_password/schemas.py
@@ -32,7 +32,7 @@ class ResetPasswordStatusResponse(FluxStandardAction):
     payload = fields.Nested(StatusSchema)
 
     @pre_dump
-    def throttle_delta_to_seconds(self, out_data: dict, **kwargs: Any) -> dict:
+    def throttle_delta_to_seconds(self, out_data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if out_data["payload"].get("state", {}).get("email", {}).get("sent_at"):
             sent_at = out_data["payload"]["state"]["email"]["sent_at"]
             throttle_time_left = time_left(sent_at, current_app.conf.throttle_resend).total_seconds()
@@ -44,7 +44,7 @@ class ResetPasswordStatusResponse(FluxStandardAction):
         return out_data
 
     @pre_dump
-    def email_verification_timeout_delta_to_seconds(self, out_data: dict, **kwargs: Any) -> dict:
+    def email_verification_timeout_delta_to_seconds(self, out_data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if out_data["payload"].get("state", {}).get("email", {}).get("sent_at"):
             sent_at = out_data["payload"]["state"]["email"]["sent_at"]
             verification_time_left = time_left(sent_at, current_app.conf.email_code_timeout).total_seconds()

--- a/src/eduid/webapp/reset_password/tests/test_app.py
+++ b/src/eduid/webapp/reset_password/tests/test_app.py
@@ -183,7 +183,7 @@ class ResetPasswordTests(EduidAPITestCase[ResetPasswordApp]):
 
     def _post_choose_extra_sec(
         self,
-        sendsms_side_effect: Callable | Exception | Iterable | None = None,
+        sendsms_side_effect: Callable[..., Any] | Exception | Iterable[Any] | None = None,
         data1: dict[str, Any] | None = None,
         data2: dict[str, Any] | None = None,
         data3: dict[str, Any] | None = None,
@@ -438,7 +438,7 @@ class ResetPasswordTests(EduidAPITestCase[ResetPasswordApp]):
 
     def _get_phone_code_backdoor(
         self,
-        sendsms_side_effect: Callable | Exception | Iterable | None = None,
+        sendsms_side_effect: Callable[..., Any] | Exception | Iterable[Any] | None = None,
         magic_cookie_name: str | None = None,
     ) -> TestResponse:
         """

--- a/src/eduid/webapp/samleid/proofing.py
+++ b/src/eduid/webapp/samleid/proofing.py
@@ -5,6 +5,8 @@ This module provides a factory/dispatcher to select the appropriate proofing
 functions based on the authentication method (freja, bankid, or eidas).
 """
 
+from typing import Any
+
 from eduid.common.config.base import ProofingConfigMixin
 from eduid.common.models.saml_models import BaseSessionInfo
 from eduid.webapp.bankid.proofing import BankIDProofingFunctions
@@ -25,7 +27,7 @@ def get_proofing_functions(
     app_name: str,
     config: ProofingConfigMixin,
     backdoor: bool,
-) -> ProofingFunctions:
+) -> ProofingFunctions[Any]:
     """
     Get the appropriate proofing functions based on session info type.
 

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -98,7 +98,7 @@ CREDENTIAL_ID_2 = (
 )
 
 
-class SecurityWebauthnTests(EduidAPITestCase):
+class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
     app: SecurityApp
 
     @pytest.fixture(autouse=True)
@@ -193,17 +193,17 @@ class SecurityWebauthnTests(EduidAPITestCase):
         assert webauthn_state["user_verification"] == UserVerificationRequirement.PREFERRED.value
         assert "challenge" in webauthn_state
 
-    def _check_registration_begun(self, data: dict) -> None:
+    def _check_registration_begun(self, data: dict[str, Any]) -> None:
         assert data["type"] == "POST_WEBAUTHN_WEBAUTHN_REGISTER_BEGIN_SUCCESS"
         assert "registration_data" in data["payload"]
         assert "csrf_token" in data["payload"]
 
-    def _check_registration_complete(self, data: dict) -> None:
+    def _check_registration_complete(self, data: dict[str, Any]) -> None:
         assert data["type"] == "POST_WEBAUTHN_WEBAUTHN_REGISTER_COMPLETE_SUCCESS"
         assert len(data["payload"]["credentials"]) > 0
         assert data["payload"]["message"] == "security.webauthn_register_success"
 
-    def _check_removal(self, data: dict, user_token: Webauthn) -> None:
+    def _check_removal(self, data: dict[str, Any], user_token: Webauthn) -> None:
         assert data["type"] == "POST_WEBAUTHN_WEBAUTHN_REMOVE_SUCCESS"
         assert data["payload"]["credentials"] is not None
         for credential in data["payload"]["credentials"]:
@@ -271,7 +271,7 @@ class SecurityWebauthnTests(EduidAPITestCase):
         self,
         client_data: bytes,
         attestation: bytes,
-        state: dict,
+        state: dict[str, Any],
         cred_id: str,
         existing_legacy_token: bool = False,
         csrf: str | None = None,
@@ -339,10 +339,10 @@ class SecurityWebauthnTests(EduidAPITestCase):
         self,
         client_data: bytes,
         attestation: bytes,
-        state: dict,
+        state: dict[str, Any],
         client_data_2: bytes,
         attestation_2: bytes,
-        state_2: dict,
+        state_2: dict[str, Any],
         existing_legacy_token: bool = False,
         csrf: str | None = None,
     ) -> tuple[Webauthn, TestResponse]:

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -64,19 +64,19 @@ class SignupStatusResponse(FluxStandardAction):
     payload = fields.Nested(StatusSchema)
 
     @pre_dump
-    def set_already_signed_up(self, data: dict, **kwargs: Any) -> dict:
+    def set_already_signed_up(self, data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if data["payload"].get("state"):
             data["payload"]["state"]["already_signed_up"] = bool(session.common.eppn)
         return data
 
     @pre_dump
-    def set_tou_version(self, data: dict, **kwargs: Any) -> dict:
+    def set_tou_version(self, data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if data["payload"].get("state", {}).get("tou") and data["payload"]["state"]["tou"].get("version") is None:
             data["payload"]["state"]["tou"]["version"] = current_app.conf.tou_version
         return data
 
     @pre_dump
-    def throttle_delta_to_seconds(self, out_data: dict, **kwargs: Any) -> dict:
+    def throttle_delta_to_seconds(self, out_data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if out_data["payload"].get("state", {}).get("email", {}).get("sent_at"):
             sent_at = out_data["payload"]["state"]["email"]["sent_at"]
             throttle_time_left = time_left(sent_at, current_app.conf.throttle_resend).total_seconds()
@@ -88,7 +88,7 @@ class SignupStatusResponse(FluxStandardAction):
         return out_data
 
     @pre_dump
-    def email_verification_timeout_delta_to_seconds(self, out_data: dict, **kwargs: Any) -> dict:
+    def email_verification_timeout_delta_to_seconds(self, out_data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if out_data["payload"].get("state", {}).get("email", {}).get("sent_at"):
             sent_at = out_data["payload"]["state"]["email"]["sent_at"]
             verification_time_left = time_left(sent_at, current_app.conf.email_verification_timeout).total_seconds()
@@ -100,7 +100,7 @@ class SignupStatusResponse(FluxStandardAction):
         return out_data
 
     @pre_dump
-    def bad_attempts_max(self, out_data: dict, **kwargs: Any) -> dict:
+    def bad_attempts_max(self, out_data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if out_data["payload"].get("state", {}).get("email"):
             out_data["payload"]["state"]["email"]["bad_attempts_max"] = (
                 current_app.conf.email_verification_max_bad_attempts

--- a/src/eduid/webapp/support/app.py
+++ b/src/eduid/webapp/support/app.py
@@ -46,7 +46,7 @@ def register_template_funcs(app: SupportApp) -> None:
         return value.strftime(fmt)
 
     @app.template_filter("multisort")
-    def sort_multi(items: list, *operators: str, **kwargs: Any) -> list:
+    def sort_multi(items: list[Any], *operators: str, **kwargs: Any) -> list[Any]:
         # Don't try to sort on missing keys
         keys = list(operators)  # operators are immutable
         for key in operators:

--- a/src/eduid/webapp/support/tests/test_app.py
+++ b/src/eduid/webapp/support/tests/test_app.py
@@ -11,7 +11,7 @@ from eduid.webapp.support.app import SupportApp, support_init_app
 __author__ = "lundberg"
 
 
-class SupportAppTests(EduidAPITestCase):
+class SupportAppTests(EduidAPITestCase[SupportApp]):
     """Base TestCase for those tests that need a full environment setup"""
 
     app: SupportApp

--- a/src/eduid/workers/am/consistency_checks.py
+++ b/src/eduid/workers/am/consistency_checks.py
@@ -51,7 +51,7 @@ def _demote_duplicate_phone(userdb: AmDB, user: User, number: str) -> None:
     userdb.save(user)
 
 
-def unverify_duplicates(userdb: AmDB, user_id: ObjectId, attributes: dict) -> dict[str, int]:
+def unverify_duplicates(userdb: AmDB, user_id: ObjectId, attributes: dict[str, Any]) -> dict[str, int]:
     """
     Checks supplied attributes for keys that should have only one user with that
     element verified.
@@ -165,8 +165,12 @@ def unverify_identities(userdb: AmDB, user_id: ObjectId, identities: list[dict[s
 
 
 def check_locked_identity(
-    userdb: AmDB, user_id: ObjectId, attributes: dict, app_name: str, replace_locked: IdentityType | None = None
-) -> dict:
+    userdb: AmDB,
+    user_id: ObjectId,
+    attributes: dict[str, Any],
+    app_name: str,
+    replace_locked: IdentityType | None = None,
+) -> dict[str, Any]:
     """
     :param userdb: Central userdb
     :param user_id: User document _id

--- a/src/eduid/workers/am/tasks.py
+++ b/src/eduid/workers/am/tasks.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import bson
 from billiard.einfo import ExceptionInfo
 from celery import Task
@@ -13,7 +15,7 @@ logger = get_task_logger(__name__)
 app = AmCelerySingleton.celery
 
 
-class AttributeManager(Task):
+class AttributeManager(Task[Any, Any]):
     """Singleton that stores reusable objects like the MongoDB database client"""
 
     abstract = True  # This means Celery won't register this as another task
@@ -31,7 +33,9 @@ class AttributeManager(Task):
             self._userdb = AmDB(AmCelerySingleton.worker_config.mongo_uri, "eduid_am")
         return self._userdb
 
-    def on_failure(self, exc: Exception, task_id: str, args: tuple, kwargs: dict, einfo: ExceptionInfo) -> None:
+    def on_failure(
+        self, exc: Exception, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any], einfo: ExceptionInfo
+    ) -> None:
         # The most common problem when tasks raise exceptions is that mongodb has switched master,
         # but it is hard to accurately trap the right exception without importing pymongo here so
         # let's just reload all databases (self.userdb here and the plugins databases) when we

--- a/src/eduid/workers/am/tasks.py
+++ b/src/eduid/workers/am/tasks.py
@@ -2,13 +2,13 @@ from typing import Any
 
 import bson
 from billiard.einfo import ExceptionInfo
-from celery import Task
 from celery.utils.log import get_task_logger
 
 from eduid.userdb import AmDB
 from eduid.userdb.exceptions import DBConnectionError, LockedIdentityViolation, UserDoesNotExist
 from eduid.workers.am.common import AmCelerySingleton
 from eduid.workers.am.consistency_checks import check_locked_identity, unverify_duplicates
+from eduid.workers.celery_typing import Task
 
 logger = get_task_logger(__name__)
 

--- a/src/eduid/workers/amapi/app.py
+++ b/src/eduid/workers/amapi/app.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import FastAPI
 
 from eduid.common.config.parsers import load_config
@@ -17,14 +19,14 @@ from eduid.workers.amapi.routers.users import users_router
 
 
 class AMAPI(FastAPI):
-    def __init__(self, name: str = "am_api", test_config: dict | None = None) -> None:
+    def __init__(self, name: str = "am_api", test_config: dict[str, Any] | None = None) -> None:
         self.config = load_config(typ=AMApiConfig, app_name=name, ns="api", test_config=test_config)
         super().__init__()
         self.context = Context(config=self.config)
         self.context.logger.info(f"Starting {name} app")
 
 
-def init_api(name: str = "am_api", test_config: dict | None = None) -> AMAPI:
+def init_api(name: str = "am_api", test_config: dict[str, Any] | None = None) -> AMAPI:
     app = AMAPI(name=name, test_config=test_config)
     app.router.route_class = ContextRequestRoute
 

--- a/src/eduid/workers/amapi/context_request.py
+++ b/src/eduid/workers/amapi/context_request.py
@@ -47,7 +47,7 @@ class ContextRequestRoute(APIRoute, ContextRequestMixin):
     Make ContextRequest the default request class
     """
 
-    def get_route_handler(self) -> Callable:
+    def get_route_handler(self) -> Callable[..., Any]:
         original_route_handler = super().get_route_handler()
 
         async def context_route_handler(request: Request | ContextRequest) -> Response:

--- a/src/eduid/workers/amapi/testing.py
+++ b/src/eduid/workers/amapi/testing.py
@@ -43,5 +43,5 @@ class TestAMBase(CommonTestCase):
         return config
 
     @staticmethod
-    def as_json(data: dict) -> str:
+    def as_json(data: dict[str, Any]) -> str:
         return json.dumps(data)

--- a/src/eduid/workers/amapi/tests/test_user.py
+++ b/src/eduid/workers/amapi/tests/test_user.py
@@ -34,7 +34,7 @@ class TestUsers(TestAMBase, GNAPBearerTokenMixin):
         assert audit_logs[0].source == self.source
         assert audit_logs[0].diff == self.as_json(diff)
 
-    def make_put_call(self, json_data: dict, oauth_header: Headers, endpoint: str | None = None) -> Response:
+    def make_put_call(self, json_data: dict[str, Any], oauth_header: Headers, endpoint: str | None = None) -> Response:
         response = self.client.put(
             url=self._make_url(endpoint),
             json=json_data,

--- a/src/eduid/workers/celery_typing.py
+++ b/src/eduid/workers/celery_typing.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from celery import Task
+else:
+    from celery import Task as _CeleryTask
+
+    class Task(_CeleryTask):
+        def __class_getitem__(cls, item: object) -> type["Task"]:
+            return cls

--- a/src/eduid/workers/job_runner/app.py
+++ b/src/eduid/workers/job_runner/app.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi import FastAPI
 
@@ -14,7 +15,10 @@ class JobRunner(FastAPI):
     scheduler: JobScheduler = JobScheduler(timezone="UTC")
 
     def __init__(
-        self, name: str = "job_runner", test_config: dict | None = None, lifespan: Callable | None = None
+        self,
+        name: str = "job_runner",
+        test_config: dict[str, Any] | None = None,
+        lifespan: Callable[..., Any] | None = None,
     ) -> None:
         self.config = load_config(typ=JobRunnerConfig, app_name=name, ns="worker", test_config=test_config)
         super().__init__(root_path=self.config.application_root, lifespan=lifespan)
@@ -32,7 +36,7 @@ async def lifespan(app: JobRunner) -> AsyncIterator[None]:
     app.scheduler.shutdown()
 
 
-def init_app(name: str = "job_runner", test_config: dict | None = None) -> JobRunner:
+def init_app(name: str = "job_runner", test_config: dict[str, Any] | None = None) -> JobRunner:
     app = JobRunner(name, test_config, lifespan=lifespan)
     app.context.logger.info(app.config)
 

--- a/src/eduid/workers/lookup_mobile/client/mobile_lookup_client.py
+++ b/src/eduid/workers/lookup_mobile/client/mobile_lookup_client.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from typing import Any
 
 from suds.client import Client
 from suds.sudsobject import Object
@@ -58,7 +59,7 @@ class MobileLookupClient:
 
         return format_nin(nin)
 
-    def _search(self, param: Object) -> list | None:
+    def _search(self, param: Object) -> list[Any] | None:
         # Start the search
         # TODO: remove self.conf.devel_mode, use environment instead
         if self.conf.testing or self.conf.environment == EduidEnvironment.dev:

--- a/src/eduid/workers/lookup_mobile/tasks.py
+++ b/src/eduid/workers/lookup_mobile/tasks.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from celery import Task
 from celery.utils.log import get_task_logger
 
 from eduid.common.decorators import deprecated
+from eduid.workers.celery_typing import Task
 from eduid.workers.lookup_mobile.client.mobile_lookup_client import MobileLookupClient
 from eduid.workers.lookup_mobile.common import MobCelerySingleton
 

--- a/src/eduid/workers/lookup_mobile/tasks.py
+++ b/src/eduid/workers/lookup_mobile/tasks.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from celery import Task
 from celery.utils.log import get_task_logger
 
@@ -10,7 +12,7 @@ logger = get_task_logger(__name__)
 app = MobCelerySingleton.celery
 
 
-class MobWorker(Task):
+class MobWorker(Task[Any, Any]):
     """Singleton that stores reusable objects like the MobileLookupClient"""
 
     abstract = True  # This means Celery won't register this as another task

--- a/src/eduid/workers/lookup_mobile/test/test_decorators.py
+++ b/src/eduid/workers/lookup_mobile/test/test_decorators.py
@@ -1,5 +1,6 @@
 __author__ = "lundberg"
 
+from typing import Any
 
 import pytest
 
@@ -50,7 +51,7 @@ class TestTransactionAudit(LookupMobileMongoTestCase):
         @TransactionAudit()
         def find_mobiles_by_nin(
             self: TestTransactionAudit, national_identity_number: str, number_region: str | None = None
-        ) -> list:
+        ) -> list[Any]:
             return []
 
         find_mobiles_by_nin(self, "200202025678")

--- a/src/eduid/workers/msg/tasks.py
+++ b/src/eduid/workers/msg/tasks.py
@@ -5,13 +5,13 @@ from http import HTTPStatus
 from typing import Any, ClassVar
 
 from billiard.einfo import ExceptionInfo
-from celery import Task
 from celery.utils.log import get_task_logger
 from hammock import Hammock
 from smscom import SMSClient
 
 from eduid.common.config.base import EduidEnvironment
 from eduid.userdb.exceptions import DBConnectionError
+from eduid.workers.celery_typing import Task
 from eduid.workers.msg.cache import CacheMDB
 from eduid.workers.msg.common import MsgCelerySingleton
 from eduid.workers.msg.decorators import TransactionAudit

--- a/src/eduid/workers/msg/tasks.py
+++ b/src/eduid/workers/msg/tasks.py
@@ -32,7 +32,7 @@ logger: logging.Logger = get_task_logger(__name__)
 app = MsgCelerySingleton.celery
 
 
-class MessageSender(Task):
+class MessageSender(Task[Any, Any]):
     """
     Singleton that stores reusable objects.
     """
@@ -75,7 +75,9 @@ class MessageSender(Task):
         # Remove initiated cache dbs
         cls._cache_store = {}
 
-    def on_failure(self, exc: Exception, task_id: str, args: tuple, kwargs: dict, einfo: ExceptionInfo) -> None:
+    def on_failure(
+        self, exc: Exception, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any], einfo: ExceptionInfo
+    ) -> None:
         # Try to reload the db on connection failures (mongodb has probably switched master)
         if isinstance(exc, DBConnectionError):
             logger.error("Task failed with db exception ConnectionError. Reloading db.")
@@ -86,7 +88,7 @@ class MessageSender(Task):
         self,
         message_type: str,
         reference: str,
-        message_dict: dict,
+        message_dict: dict[str, Any],
         recipient: str,
         template: str,
         language: str,


### PR DESCRIPTION
# Add type parameters to bare generics across the codebase

## Summary

- Add explicit type parameters to ~160 bare generic types (`dict`, `list`, `Mapping`, `Callable`, `tuple`, `MongoClient`, `UserDB`, `EduIDBaseApp`, `EduidAPITestCase`, `Task`, `ProofingFunctions`, `EventList`, `ElementList`, `Field`, etc.) across ~90 files.
- Fix incorrect return type annotation in `_perform_search` (`dict` -> `list[dict]`) in scimapi test.
- Add `from typing import Any` imports where needed (~25 files).
- Add `type: ignore[arg-type]` on 2 new call sites where `CredentialUserDB` (now properly typed as `UserDB[CredentialUser]`) is passed to `save_and_sync_user` expecting `UserDB[User]`.
- Add `eduid.workers.celery_typing` module with a runtime-subscriptable `Task` wrapper. Celery's `Task` class lacks `__class_getitem__`, so `Task[Any, Any]` raises `TypeError` at runtime even though `celery-types` stubs support it for mypy. The wrapper makes `Task[Any, Any]` work at both runtime and type-check time.
- Non-strict mypy: 0 errors (was 0 before, stays 0).
- Strict mypy `[type-arg]` errors: reduced from ~188 to near zero.

## Deferred

Some generic types are left bare where adding type parameters causes variance conflicts (e.g. `EduIDBaseApp` in shared functions, `UserDB` in `AttributeFetcher.get_user_db`).