### PR TITLE
Fix mypy strict type-checking errors

### DIFF
--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -456,7 +456,7 @@ class PrimaryElementList[ListElement: Element](VerifiedElementList[ListElement],
 
         # Go through the whole list. Mark element as primary and all other as *not* primary.
         # Build a new list and re-assign to make sure the validators run.
-        new = []
+        new: list[ListElement] = []
         for this in self.elements:
             if not isinstance(this, PrimaryElement):
                 raise UserDBValueError(f"Element {this!r} is not of type PrimaryElement")

--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -431,7 +431,7 @@ class PrimaryElementList[ListElement: Element](VerifiedElementList[ListElement],
         if not isinstance(match, PrimaryElement):
             raise UserDBValueError(f"Primary element {match!r} is not of type PrimaryElement")
 
-        return cast(ListElement, match)
+        return match
 
     def set_primary(self, key: ElementKey) -> None:
         """
@@ -462,7 +462,7 @@ class PrimaryElementList[ListElement: Element](VerifiedElementList[ListElement],
                 raise UserDBValueError(f"Element {this!r} is not of type PrimaryElement")
             this.is_primary = bool(this.key == key)
             new += [this]
-        self.elements = cast(list[ListElement], new)
+        self.elements = new
 
     @classmethod
     def _get_primary(cls, elements: list[ListElement]) -> ListElement | None:
@@ -488,7 +488,7 @@ class PrimaryElementList[ListElement: Element](VerifiedElementList[ListElement],
         if not primary.is_verified:
             raise PrimaryElementViolation("Primary element is not verified")
 
-        return cast(ListElement, primary)
+        return primary
 
     def remove(self, key: ElementKey) -> None:
         """

--- a/src/eduid/userdb/tests/test_user.py
+++ b/src/eduid/userdb/tests/test_user.py
@@ -659,7 +659,7 @@ class TestNewUser:
         data["locked_identity"] = [locked_identity]
         user = User.from_dict(data)
         assert user.locked_identity.nin is not None
-        assert user.locked_identity.nin.identity_type == IdentityType.NIN.value
+        assert user.locked_identity.nin.identity_type == IdentityType.NIN
         assert user.locked_identity.nin.created_by == "test"
         assert user.locked_identity.nin.created_ts == created_ts
         assert user.locked_identity.nin.number == "197801012345"
@@ -677,7 +677,7 @@ class TestNewUser:
         data["locked_identity"] = [locked_identity]
         user = User.from_dict(data)
         assert user.locked_identity.nin is not None
-        assert user.locked_identity.nin.identity_type == IdentityType.NIN.value
+        assert user.locked_identity.nin.identity_type == IdentityType.NIN
         assert user.locked_identity.nin.created_by == "test"
         assert user.locked_identity.nin.created_ts == created_ts
         assert user.locked_identity.nin.number == "197801012345"
@@ -694,7 +694,7 @@ class TestNewUser:
         assert user.locked_identity.count == 1
 
         assert user.locked_identity.nin is not None
-        assert user.locked_identity.nin.identity_type == IdentityType.NIN.value
+        assert user.locked_identity.nin.identity_type == IdentityType.NIN
         assert user.locked_identity.nin.created_by == "test"
         assert user.locked_identity.nin.number == "197801012345"
         assert user.locked_identity.nin.is_verified is True
@@ -717,14 +717,14 @@ class TestNewUser:
 
         old_user = User.from_dict(user.to_dict())
         assert old_user.locked_identity.nin is not None
-        assert old_user.locked_identity.nin.identity_type == IdentityType.NIN.value
+        assert old_user.locked_identity.nin.identity_type == IdentityType.NIN
         assert old_user.locked_identity.nin.created_by == "test"
         assert old_user.locked_identity.nin.number == "197801012345"
         assert old_user.locked_identity.nin.is_verified is True
 
         new_user = User.from_dict(user.to_dict())
         assert new_user.locked_identity.nin is not None
-        assert new_user.locked_identity.nin.identity_type == IdentityType.NIN.value
+        assert new_user.locked_identity.nin.identity_type == IdentityType.NIN
         assert new_user.locked_identity.nin.created_by == "test"
         assert new_user.locked_identity.nin.number == "197801012345"
         assert new_user.locked_identity.nin.is_verified is True

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass
-from typing import Any, cast, overload
+from typing import cast, overload
 
 from flask import current_app, request
 

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass
-from typing import cast, overload
+from typing import Any, cast, overload
 
 from flask import current_app, request
 
@@ -77,7 +77,7 @@ def add_nin_to_user(user: User, proofing_state: NinProofingState) -> ProofingUse
 def add_nin_to_user[T: User](user: User, proofing_state: NinProofingState, user_type: type[T]) -> T: ...
 
 
-def add_nin_to_user(user, proofing_state, user_type=ProofingUser):
+def add_nin_to_user(user: User, proofing_state: NinProofingState, user_type: type[User] = ProofingUser) -> User:
     private_userdb = cast(UserDB[User], get_from_current_app("private_userdb", UserDB))
     proofing_user = user_type.from_user(user, private_userdb)
     # Add nin to user if not already there

--- a/src/eduid/webapp/common/session/tests/test_eduid_session.py
+++ b/src/eduid/webapp/common/session/tests/test_eduid_session.py
@@ -197,10 +197,10 @@ class EduidSessionTests(EduidAPITestCase[SessionTestApp]):
             keyvalues = cookie[1].split(";")
             for keyvalue in keyvalues:
                 value = keyvalue.split("=")
-                if value == self.app.conf.flask.session_cookie_name:
-                    assert value == ""
-                elif value == "expires":
-                    assert value == "Thu, 01-Jan-1970 00:00:00 GMT"
+                if value[0].strip() == self.app.conf.flask.session_cookie_name:
+                    assert value[1] == ""
+                elif value[0].strip() == "expires":
+                    assert value[1] == "Thu, 01 Jan 1970 00:00:00 GMT"
 
     def _test_bad_session_cookie(self, bad_cookie_value: str) -> None:
         with self.browser as browser:

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -108,7 +108,7 @@ class SignupStatusResponse(FluxStandardAction):
         return out_data
 
     @pre_dump
-    def set_webauthn_registered(self, out_data: dict, **kwargs: Any) -> dict:
+    def set_webauthn_registered(self, out_data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         if out_data["payload"].get("state", {}).get("credentials"):
             out_data["payload"]["state"]["credentials"]["webauthn_registered"] = bool(
                 out_data["payload"]["state"]["credentials"].get("webauthn")


### PR DESCRIPTION
# Fix mypy strict type-checking errors

## Summary

- Fix 9 `[comparison-overlap]` errors in test files
- Remove 3 `[redundant-cast]` in `userdb/element.py`
- Fix bare `dict` → `dict[str, Any]` in `signup/schemas.py` (`[type-arg]`)
- Add missing type annotations to `add_nin_to_user` implementation (`[no-untyped-def]`)

## Details

**comparison-overlap (test_user.py):** Tests compared `identity_type` (enum) to `IdentityType.NIN.value` (string). Changed to compare enum-to-enum.

**comparison-overlap (test_eduid_session.py):** `keyvalue.split("=")` returns `list[str]` but was compared directly to strings — assertions could never trigger. Fixed to index `value[0]`/`value[1]`. Also fixed incorrect date format in expected cookie expiry.

**redundant-cast (element.py):** Removed unnecessary `cast()` wrappers where mypy already knew the type from `isinstance` guards. Added explicit `list[ListElement]` annotation to avoid invariance issue on reassignment.

**no-untyped-def (helpers.py):** Added `User`-bounded annotations to the `add_nin_to_user` overload implementation.

## Strict mypy error reduction

- `[comparison-overlap]`: 9 → 0
- `[redundant-cast]`: 3 → 0
- `[type-arg]`: 8 → 7
- `[no-untyped-def]`: 1 → 0
