### PR TITLE
Cast Any returns to eliminate no-any-return errors in strict mypy

### DIFF
--- a/src/eduid/common/clients/gnap_client/base.py
+++ b/src/eduid/common/clients/gnap_client/base.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC
 from collections.abc import Coroutine
 from datetime import datetime, timedelta
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from httpx import Request
 from jwcrypto.jwk import JWK
@@ -72,7 +72,7 @@ class GNAPBearerTokenMixin(ABC):
             key=self._auth_data.client_jwk,
             protected=jws_header.model_dump_json(exclude_none=True),
         )
-        return _jws.serialize(compact=True)
+        return cast(str, _jws.serialize(compact=True))
 
     def _set_bearer_token(self, grant_response: GrantResponse) -> None:
         logger.debug(f"gnap response: {grant_response}")

--- a/src/eduid/common/fastapi/context_request.py
+++ b/src/eduid/common/fastapi/context_request.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, cast
 
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
@@ -20,7 +20,7 @@ class ContextRequest(Request):
     @property
     def context(self) -> Context:
         try:
-            return self.state.context
+            return cast(Context, self.state.context)
         except AttributeError:
             # Lazy init of self.state.context
             self.state.context = self.contextClass()

--- a/src/eduid/common/models/generic.py
+++ b/src/eduid/common/models/generic.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from bson import ObjectId
 from jwcrypto.common import JWException
@@ -76,7 +76,7 @@ class JWKPydanticAnnotation:
 
         def serialize_to_dict(instance: JWK) -> dict[str, str]:
             # JWK inherits from dict, so we can just return it
-            return instance
+            return cast(dict[str, str], instance)
 
         from_dict_schema = core_schema.chain_schema(
             [

--- a/src/eduid/common/rpc/am_relay.py
+++ b/src/eduid/common/rpc/am_relay.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 import eduid.workers.am
 from eduid.common.config.base import AmConfigMixin
@@ -56,7 +57,7 @@ class AmRelay:
         logger.debug(f"Asking Attribute Manager to sync user {user} from {_app_name}")
         rtask = self._update_attrs.delay(_app_name, user_id)
         try:
-            result = rtask.get(timeout=timeout)
+            result = cast(bool, rtask.get(timeout=timeout))
             logger.debug(f"Attribute Manager sync result: {result} for user {user}")
             return result
         except LockedIdentityViolation as e:
@@ -74,7 +75,7 @@ class AmRelay:
         """
         rtask = self._pong.apply_async(kwargs={"app_name": self.app_name})
         try:
-            return rtask.get(timeout=timeout)
+            return cast(str, rtask.get(timeout=timeout))
         except Exception as e:
             rtask.forget()
             raise AmTaskFailed(f"ping task failed: {e!r}") from e

--- a/src/eduid/common/rpc/lookup_mobile_relay.py
+++ b/src/eduid/common/rpc/lookup_mobile_relay.py
@@ -21,9 +21,9 @@ class LookupMobileRelay:
 
     def find_nin_by_mobile(self, mobile_number: str) -> str | None:
         try:
-            result = self._find_nin_by_mobile.delay(mobile_number)
+            rtask = self._find_nin_by_mobile.delay(mobile_number)
             result = cast(
-                str | None, result.get(timeout=10)
+                str | None, rtask.get(timeout=10)
             )  # Lower timeout than standard gunicorn worker timeout (25)
             return result
         except Exception as e:

--- a/src/eduid/common/rpc/lookup_mobile_relay.py
+++ b/src/eduid/common/rpc/lookup_mobile_relay.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import eduid.workers.lookup_mobile
 
@@ -22,7 +22,9 @@ class LookupMobileRelay:
     def find_nin_by_mobile(self, mobile_number: str) -> str | None:
         try:
             result = self._find_nin_by_mobile.delay(mobile_number)
-            result = result.get(timeout=10)  # Lower timeout than standard gunicorn worker timeout (25)
+            result = cast(
+                str | None, result.get(timeout=10)
+            )  # Lower timeout than standard gunicorn worker timeout (25)
             return result
         except Exception as e:
             raise LookupMobileTaskFailed(f"find_nin_by_mobile task failed: {e}") from e
@@ -43,7 +45,7 @@ class LookupMobileRelay:
         """
         rtask = self._pong.apply_async(kwargs={"app_name": self.app_name})
         try:
-            return rtask.get(timeout=timeout)
+            return cast(str, rtask.get(timeout=timeout))
         except Exception as e:
             rtask.forget()
             raise LookupMobileTaskFailed(f"ping task failed: {e!r}") from e

--- a/src/eduid/common/rpc/msg_relay.py
+++ b/src/eduid/common/rpc/msg_relay.py
@@ -1,5 +1,6 @@
 import logging
 from enum import StrEnum
+from typing import cast
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -276,7 +277,7 @@ class MsgRelay:
         """
         rtask = self._pong.apply_async(kwargs={"app_name": self.app_name})
         try:
-            return rtask.get(timeout=timeout)
+            return cast(str, rtask.get(timeout=timeout))
         except Exception as e:
             rtask.forget()
             raise MsgTaskFailed(f"ping task failed: {e!r}") from e

--- a/src/eduid/common/testing_base.py
+++ b/src/eduid/common/testing_base.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from bson import ObjectId
@@ -70,7 +70,7 @@ def normalised_data[SomeData: dict[str, Any] | list[Any]](
 
             # catch all for wierd stuff in pydantic 2 errors
             try:
-                return super().default(o)
+                return cast(Iterable[Any], super().default(o))
             except TypeError:
                 return repr(o)
 
@@ -128,4 +128,4 @@ def normalised_data[SomeData: dict[str, Any] | list[Any]](
             _exclude_keys(exclude_key=_key, obj=_data)
     _dumped = json.dumps(_data, sort_keys=True, cls=NormaliseEncoder)
     _loaded = json.loads(_dumped, cls=NormaliseDecoder)
-    return _loaded
+    return cast(SomeData, _loaded)

--- a/src/eduid/common/utils.py
+++ b/src/eduid/common/utils.py
@@ -1,6 +1,7 @@
 __author__ = "lundberg"
 
 from datetime import datetime
+from typing import cast
 from uuid import uuid4
 
 from bson import ObjectId
@@ -41,7 +42,7 @@ def get_short_hash(entropy: int = 10) -> str:
 
 
 def generate_password(length: int = 12) -> str:
-    return pwgen(int(length), no_capitalize=True, no_symbols=True)
+    return cast(str, pwgen(int(length), no_capitalize=True, no_symbols=True))
 
 
 def serialize_xml_datetime(value: datetime) -> str:

--- a/src/eduid/graphdb/db.py
+++ b/src/eduid/graphdb/db.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from neo4j import Driver, GraphDatabase, basic_auth
@@ -54,7 +54,7 @@ class Neo4jDB:
         with self.driver.session() as session:
             record = session.run(q).single()
             if record:
-                return record["count"]
+                return cast(int | None, record["count"])
         return None
 
     @property

--- a/src/eduid/graphdb/testing.py
+++ b/src/eduid/graphdb/testing.py
@@ -4,6 +4,7 @@ import logging
 import random
 from collections.abc import Sequence
 from os import environ
+from typing import cast
 
 import pytest
 from neo4j.exceptions import ServiceUnavailable
@@ -91,7 +92,7 @@ class Neo4jTemporaryInstance(EduidTemporaryInstance):
     def conn(self) -> Neo4jDB:
         if self._conn is None:
             raise RuntimeError("Missing temporary Neo4jDB instance")
-        return self._conn
+        return cast(Neo4jDB, self._conn)
 
     @property
     def host(self) -> str:

--- a/src/eduid/maccapi/tests/test_maccapi.py
+++ b/src/eduid/maccapi/tests/test_maccapi.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Mapping
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from jwcrypto import jwt
@@ -28,7 +28,7 @@ class TestMAccApi(MAccApiTestCase):
         token = jwt.JWT(header={"alg": "ES256"}, claims=claims)
         jwk = next(iter(self.context.jwks))
         token.make_signed_token(jwk)
-        return token.serialize()
+        return cast(str, token.serialize())
 
     def _is_presentable_format(self, password: str) -> bool:
         return len(password) == 14 and password[4] == " " and password[9] == " "

--- a/src/eduid/satosa/scimapi/common.py
+++ b/src/eduid/satosa/scimapi/common.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Generator
+from typing import cast
 
 import satosa.context
 import satosa.internal
@@ -40,4 +41,4 @@ def get_metadata(context: satosa.context.Context) -> Generator[MetaData]:
 
 def get_internal_attribute_name(converter: AttributeMapper, attr_name: str) -> str:
     _int = converter.to_internal("saml", {attr_name: ["something"]})
-    return next(iter(_int.keys()))
+    return cast(str, next(iter(_int.keys())))

--- a/src/eduid/satosa/scimapi/stepup.py
+++ b/src/eduid/satosa/scimapi/stepup.py
@@ -4,7 +4,7 @@ import functools
 import json
 import logging
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, NewType
+from typing import Any, NewType, cast
 from urllib.parse import urlparse
 
 import satosa.context
@@ -564,7 +564,7 @@ class AuthnContext(RequestMicroService):
     def get_from_state(context: Context, state_key: str) -> list[str]:
         _res = context.state.get(CONTEXT_NAME, {}).get(state_key, [])
         logger.debug(f"Retrieved state from context {CONTEXT_NAME}: {_res} (state_key: {state_key})")
-        return _res
+        return cast(list[str], _res)
 
     @staticmethod
     def sp_wants_mfa(context: Context, state_key: str = STATE_KEY_MFA) -> bool:

--- a/src/eduid/scimapi/test-scripts/scim-util.py
+++ b/src/eduid/scimapi/test-scripts/scim-util.py
@@ -58,7 +58,7 @@ def scim_request(
     if not r:
         return None
 
-    response = r.json()
+    response = cast(dict[str, Any], r.json())
     logger.debug(f"Response:\n{pformat(response, width=120)}")
     return response
 
@@ -82,7 +82,7 @@ def _make_request(
         except Exception:
             logger.error(f"Error {r} received from server: {r.text}")
         return None
-    return r
+    return cast(requests.Response, r)
 
 
 def search_user(api: Api, search_filter: str) -> dict[str, Any] | None:

--- a/src/eduid/scimapi/tests/test_authn.py
+++ b/src/eduid/scimapi/tests/test_authn.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import PurePath
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -421,7 +421,7 @@ class TestAuthnUserResource(ScimApiTestUserResourceBase):
         token = jwt.JWT(header={"alg": "ES256"}, claims=claims)
         jwk = next(iter(self.context.jwks))
         token.make_signed_token(jwk)
-        return token.serialize()
+        return cast(str, token.serialize())
 
     def test_get_user_no_authn(self) -> None:
         db_user = self.add_user(identifier=str(uuid4()), external_id="test-id-1", profiles={"test": self.test_profile})

--- a/src/eduid/scimapi/tests/test_scimgroup.py
+++ b/src/eduid/scimapi/tests/test_scimgroup.py
@@ -2,7 +2,7 @@ __author__ = "lundberg"
 
 import logging
 from collections.abc import Iterator, Mapping
-from typing import Any
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 import pytest
@@ -102,7 +102,7 @@ class TestGroupResource(ScimApiTestCase):
         response = self.client.post(url="/Groups/.search", json=req, headers=self.headers)
         logger.info(f"Search parsed_response:\n{response.json}")
         if return_json:
-            return response.json()
+            return cast(dict[str, Any], response.json())
 
         expected_schemas = [SCIMSchema.API_MESSAGES_20_LIST_RESPONSE.value]
         response_schemas = response.json().get("schemas")
@@ -135,7 +135,7 @@ class TestGroupResource(ScimApiTestCase):
                 f"Search parsed_response group does not have the expected displayName: {expected_group.display_name!s}"
             )
 
-        return resources
+        return cast(dict[str, Any], resources)
 
     def _assertGroupUpdateSuccess(self, req: Mapping[str, Any], response: Response, group: ScimApiGroup) -> None:
         """Function to validate successful responses to SCIM calls that update a group according to a request."""

--- a/src/eduid/scimapi/tests/test_sciminvite.py
+++ b/src/eduid/scimapi/tests/test_sciminvite.py
@@ -5,7 +5,7 @@ from copy import copy
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from bson import ObjectId
@@ -304,7 +304,7 @@ class TestInviteResource(ScimApiTestCase):
         response = self.client.post(url="/Invites/.search", json=req, headers=self.headers)
         logger.info(f"Search parsed_response:\n{response.json()}")
         if return_json:
-            return response.json()
+            return cast(dict[str, Any], response.json())
         expected_schemas = [SCIMSchema.API_MESSAGES_20_LIST_RESPONSE.value]
         response_schemas = response.json().get("schemas")
         assert isinstance(response_schemas, list), "Response schemas not present, or not a list"
@@ -336,7 +336,7 @@ class TestInviteResource(ScimApiTestCase):
 
         assert [SCIMSchema.API_MESSAGES_20_LIST_RESPONSE.value] == response.json().get("schemas")
         resources = response.json().get("Resources")
-        return resources
+        return cast(dict[str, Any], resources)
 
     def test_create_invite(self) -> None:
         req = {

--- a/src/eduid/scimapi/tests/test_scimuser.py
+++ b/src/eduid/scimapi/tests/test_scimuser.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 import bson
@@ -827,7 +827,7 @@ class TestUserResource(ScimApiTestUserResourceBase):
         response = self.client.post(url="/Users/.search", json=req, headers=self.headers)
         logger.info(f"Search parsed_response:\n{response.json()}")
         if return_json:
-            return response.json()
+            return cast(list[dict[str, Any]], response.json())
         self._assertResponse(response)
         expected_schemas = [SCIMSchema.API_MESSAGES_20_LIST_RESPONSE.value]
         response_schemas = response.json().get("schemas")
@@ -860,7 +860,7 @@ class TestUserResource(ScimApiTestUserResourceBase):
 
         assert [SCIMSchema.API_MESSAGES_20_LIST_RESPONSE.value] == response.json().get("schemas")
         resources = response.json().get("Resources")
-        return resources
+        return cast(list[dict[str, Any]], resources)
 
 
 class TestAsyncUserResource(ScimApiTestCase):

--- a/src/eduid/userdb/testing/__init__.py
+++ b/src/eduid/userdb/testing/__init__.py
@@ -8,7 +8,7 @@ import logging
 import logging.config
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import pymongo
 import pymongo.errors
@@ -55,7 +55,7 @@ class MongoTemporaryInstance(EduidTemporaryInstance):
     def conn(self) -> pymongo.MongoClient[TUserDbDocument]:
         if self._conn is None:
             raise RuntimeError("Missing temporary MongoDB instance")
-        return self._conn
+        return cast(pymongo.MongoClient[TUserDbDocument], self._conn)
 
     @property
     def uri(self) -> str:

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -398,6 +398,4 @@ class User(BaseModel):
         Parse the Profile elements.
         """
         profiles = data.pop("profiles", [])
-        if isinstance(profiles, list):
-            return ProfileList.from_list_of_dicts(profiles)
-        return cast(ProfileList, profiles)
+        return ProfileList.from_list_of_dicts(profiles)

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -400,4 +400,4 @@ class User(BaseModel):
         profiles = data.pop("profiles", [])
         if isinstance(profiles, list):
             return ProfileList.from_list_of_dicts(profiles)
-        return profiles
+        return cast(ProfileList, profiles)

--- a/src/eduid/vccs/client/__init__.py
+++ b/src/eduid/vccs/client/__init__.py
@@ -411,7 +411,7 @@ class VCCSClient:
             raise AssertionError(f"Received response of unknown version {resp_ver!r}")
         return cast(dict[str, Any], resp[response_label])
 
-    def _execute_request_response(self, service: str, values: dict[str, Any]) -> str:
+    def _execute_request_response(self, service: str, values: dict[str, Any]) -> bytes:
         """
         The part of _execute that has actual side effects. In a separate function
         to make everything else easily testable.
@@ -427,7 +427,7 @@ class VCCSClient:
         except URLError as exc:
             raise VCCSClientHTTPError(reason="Authentication backend unavailable", http_code=503) from exc
 
-        return cast(str, response.read())
+        return cast(bytes, response.read())
 
     def _make_request(self, action: str, user_id: str, factors: Sequence[VCCSFactor]) -> str:
         """

--- a/src/eduid/vccs/client/__init__.py
+++ b/src/eduid/vccs/client/__init__.py
@@ -43,7 +43,7 @@ Revoke a credential (irreversible!) :
 
 import os
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -409,7 +409,7 @@ class VCCSClient:
         resp_ver = resp[response_label]["version"]
         if resp_ver != 1:
             raise AssertionError(f"Received response of unknown version {resp_ver!r}")
-        return resp[response_label]
+        return cast(dict[str, Any], resp[response_label])
 
     def _execute_request_response(self, service: str, values: dict[str, Any]) -> str:
         """
@@ -427,7 +427,7 @@ class VCCSClient:
         except URLError as exc:
             raise VCCSClientHTTPError(reason="Authentication backend unavailable", http_code=503) from exc
 
-        return response.read()
+        return cast(str, response.read())
 
     def _make_request(self, action: str, user_id: str, factors: Sequence[VCCSFactor]) -> str:
         """

--- a/src/eduid/vccs/client/tests/test_client.py
+++ b/src/eduid/vccs/client/tests/test_client.py
@@ -20,10 +20,10 @@ class FakeVCCSClient(VCCSClient):
         self.fake_response = fake_response
         VCCSClient.__init__(self)
 
-    def _execute_request_response(self, service: str, values: dict[str, Any]) -> str:
+    def _execute_request_response(self, service: str, values: dict[str, Any]) -> bytes:
         self.last_service = service
         self.last_values = values
-        return self.fake_response
+        return self.fake_response.encode()
 
 
 class FakeVCCSPasswordFactor(VCCSPasswordFactor):

--- a/src/eduid/vccs/server/db.py
+++ b/src/eduid/vccs/server/db.py
@@ -195,7 +195,7 @@ class CredentialDB(BaseDB):
         except DuplicateKeyError:
             logger.warning(f"A credential with credential_id {credential.credential_id} already exists in the db")
             return False
-        _success = result.inserted_id == credential.obj_id
+        _success: bool = result.inserted_id == credential.obj_id
         logger.debug(f"Added credential {credential} to the db: {_success}")
         return _success
 

--- a/src/eduid/vccs/server/endpoints/add_creds.py
+++ b/src/eduid/vccs/server/endpoints/add_creds.py
@@ -1,5 +1,5 @@
 import json
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Form, Request
 from pydantic.main import BaseModel
@@ -115,4 +115,4 @@ async def _add_password_credential(
     req.app.logger.info(
         f"AUDIT: Add credential credential_id={cred.credential_id}, version={version.value}, H2[16]={H2[:8]}, res={_res!r}"
     )
-    return _res
+    return cast(bool, _res)

--- a/src/eduid/vccs/server/hasher.py
+++ b/src/eduid/vccs/server/hasher.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from asyncio.locks import Lock
 from binascii import unhexlify
 from hashlib import sha1, sha256
-from typing import Literal
+from typing import Literal, cast
 
 import pkcs11
 import pyhsm
@@ -108,7 +108,7 @@ class VCCSYHSMHasher(VCCSHasher):
             self.lock_release()
 
     def unsafe_hmac_sha1(self, key_handle: int, data: bytes) -> bytes:
-        return self._yhsm.hmac_sha1(key_handle, data).get_hash()
+        return cast(bytes, self._yhsm.hmac_sha1(key_handle, data).get_hash())
 
     async def hmac_sha256(self, key_label: str, data: bytes) -> bytes:
         raise NotImplementedError("hmac sha256 not supported by YubiHSM")
@@ -311,7 +311,7 @@ class VCCSHSMKeyHasher(VCCSHasher):
         with self._pool.session() as session:
             key = self._get_hmac_key(session, key_handle)
             # Use the key's sign method with SHA_1_HMAC mechanism
-            return key.sign(data, mechanism=Mechanism.SHA_1_HMAC)
+            return cast(bytes, key.sign(data, mechanism=Mechanism.SHA_1_HMAC))
 
     async def hmac_sha256(self, key_label: str, data: bytes) -> bytes:
         """
@@ -340,7 +340,7 @@ class VCCSHSMKeyHasher(VCCSHasher):
         with self._pool.session() as session:
             key = self._get_hmac_key(session, key_label=key_label)
             # Use the key's sign method with SHA256_HMAC mechanism
-            return key.sign(data, mechanism=Mechanism.SHA256_HMAC)
+            return cast(bytes, key.sign(data, mechanism=Mechanism.SHA256_HMAC))
 
     async def safe_random(self, byte_count: int) -> bytes:
         """

--- a/src/eduid/vccs/server/password.py
+++ b/src/eduid/vccs/server/password.py
@@ -1,4 +1,5 @@
 from binascii import unhexlify
+from typing import cast
 
 from ndnkdf import NDNKDF
 
@@ -105,4 +106,4 @@ async def calculate_cred_hash(
 
     # PBKDF2 again with iter=1 to mix in the local_salt into the final H2.
     H2 = kdf.pbkdf2_hmac_sha512(T2, 1, local_salt)
-    return H2.hex()
+    return cast(str, H2.hex())

--- a/src/eduid/webapp/common/api/debug.py
+++ b/src/eduid/webapp/common/api/debug.py
@@ -3,7 +3,7 @@ import sys
 import warnings
 from collections.abc import Callable, Iterable
 from dataclasses import asdict
-from typing import Any
+from typing import Any, cast
 from urllib import parse
 from wsgiref.types import StartResponse, WSGIEnvironment
 
@@ -24,7 +24,7 @@ class LoggingMiddleware:
             pprint.pprint(("RESPONSE", status, headers), stream=errorlog)
             return start_response(status, headers, *args)
 
-        return self._app(environ, log_response)
+        return cast(Iterable[bytes], self._app(environ, log_response))
 
 
 def log_endpoints(app: Flask) -> None:

--- a/src/eduid/webapp/common/api/middleware.py
+++ b/src/eduid/webapp/common/api/middleware.py
@@ -1,7 +1,7 @@
 __author__ = "lundberg"
 
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import Any, cast
 from wsgiref.types import StartResponse, WSGIEnvironment
 
 
@@ -21,11 +21,11 @@ class PrefixMiddleware:
         if environ.get("REMOTE_ADDR") == "127.0.0.1":
             environ["HTTP_HOST"] = self.server_name or "localhost"
             environ["SCRIPT_NAME"] = self.prefix
-            return self.app(environ, start_response)
+            return cast(Iterable[bytes], self.app(environ, start_response))
         elif environ.get("PATH_INFO", "").startswith(self.prefix):
             environ["PATH_INFO"] = environ["PATH_INFO"][len(self.prefix) :]
             environ["SCRIPT_NAME"] = self.prefix
-            return self.app(environ, start_response)
+            return cast(Iterable[bytes], self.app(environ, start_response))
         else:
             start_response("404", [("Content-Type", "text/plain")])
             return [b"Not found."]

--- a/src/eduid/webapp/common/authn/utils.py
+++ b/src/eduid/webapp/common/authn/utils.py
@@ -54,7 +54,7 @@ def get_location(http_info: SAMLHttpArgs) -> str:
     assert len(headers) == 1
     header_name, header_value = headers[0]
     assert header_name == "Location"
-    return header_value
+    return cast(str, header_value)
 
 
 def get_saml_attribute(session_info: SessionInfo, attr_name: str) -> list[str] | None:
@@ -84,7 +84,7 @@ def get_saml_attribute(session_info: SessionInfo, attr_name: str) -> list[str] |
     # Look for the canonicalized attribute in the SAML assertion attributes
     for saml_attr in attributes:
         if saml_attr.lower() == attr_name.lower():
-            return attributes[saml_attr]
+            return cast(list[str], attributes[saml_attr])
     return None
 
 

--- a/src/eduid/webapp/common/session/redis_session.py
+++ b/src/eduid/webapp/common/session/redis_session.py
@@ -49,7 +49,7 @@ import json
 import logging
 import typing
 from collections.abc import Iterator, Mapping
-from typing import Any
+from typing import Any, cast
 
 import nacl.encoding
 import nacl.secret
@@ -305,7 +305,7 @@ class RedisEncryptedSession(typing.MutableMapping[str, Any]):
         if "v2" in versioned:
             _data = self.secret_box.decrypt(versioned["v2"], encoder=nacl.encoding.Base64Encoder)
             decrypted = json.loads(_data)
-            return decrypted
+            return cast(dict[str, Any], decrypted)
 
         logger.error(f"Unknown data retrieved from Redis[{self.short_id}]: {data_str!r}")
         raise ValueError("Unknown data retrieved from Redis")

--- a/src/eduid/webapp/common/session/testing.py
+++ b/src/eduid/webapp/common/session/testing.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Sequence
+from typing import cast
 
 import redis
 
@@ -47,7 +48,7 @@ class RedisTemporaryInstance(EduidTemporaryInstance):
     def conn(self) -> redis.Redis:
         if self._conn is None:
             raise RuntimeError("Missing temporary Redis instance")
-        return self._conn
+        return cast(redis.Redis, self._conn)
 
     def get_params(self) -> tuple[str, int, int]:
         """

--- a/src/eduid/webapp/email/tests/test_app.py
+++ b/src/eduid/webapp/email/tests/test_app.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pytest_mock import MockerFixture
@@ -77,7 +77,7 @@ class EmailTests(EduidAPITestCase[EmailApp]):
         with self.session_cookie(self.browser, eppn) as client:
             response2 = client.get("/all")
 
-            return json.loads(response2.data)
+            return cast(dict[str, Any], json.loads(response2.data))
 
     def _post_email(
         self,

--- a/src/eduid/webapp/group_management/views/group.py
+++ b/src/eduid/webapp/group_management/views/group.py
@@ -1,3 +1,4 @@
+from typing import cast
 from uuid import UUID
 
 from flask import Blueprint
@@ -77,7 +78,7 @@ def create_group(user: User, display_name: str) -> FluxData:
 
     current_app.logger.info(f"Created ScimApiGroup with scim_id: {group.scim_id}")
     current_app.stats.count(name="group_created")
-    return get_groups()
+    return cast(FluxData, get_groups())
 
 
 @group_management_views.route("/delete", methods=["POST"])
@@ -101,7 +102,7 @@ def delete_group(user: User, group_identifier: UUID) -> FluxData:
             current_app.invite_state_db.remove_state(state)
         current_app.logger.info(f"Deleted ScimApiGroup with scim_id: {group.scim_id}")
         current_app.stats.count(name="group_deleted")
-    return get_groups()
+    return cast(FluxData, get_groups())
 
 
 @group_management_views.route("/remove-user", methods=["POST"])
@@ -146,4 +147,4 @@ def remove_user(user: User, group_identifier: UUID, user_identifier: UUID, role:
         current_app.stats.count(name=f"{role.value}_left_group")
     else:
         current_app.stats.count(name=f"{role.value}_removed_from_group")
-    return get_groups()
+    return cast(FluxData, get_groups())

--- a/src/eduid/webapp/group_management/views/invite.py
+++ b/src/eduid/webapp/group_management/views/invite.py
@@ -1,3 +1,4 @@
+from typing import cast
 from uuid import UUID
 
 from flask import Blueprint
@@ -76,7 +77,7 @@ def create_invite(user: User, group_identifier: UUID, email_address: str, role: 
         current_app.logger.info(f"User is inviting self to group {group_identifier} as {role}")
         if role is GroupRole.OWNER:
             current_app.logger.info(f"User already owner of group {group_identifier}, aborting.")
-            return outgoing_invites()
+            return cast(FluxData, outgoing_invites())
         # Try to add self to group as member
         group = current_app.scimapi_groupdb.get_group_by_scim_id(invite_state.group_scim_id)
         if not group:
@@ -86,7 +87,7 @@ def create_invite(user: User, group_identifier: UUID, email_address: str, role: 
             accept_group_invitation(scim_user, group, invite_state)
         except EduIDDBError:
             return error_response(message=CommonMsg.temp_problem)
-        return outgoing_invites()
+        return cast(FluxData, outgoing_invites())
 
     try:
         current_app.invite_state_db.save(invite_state, is_in_database=False)
@@ -98,7 +99,7 @@ def create_invite(user: User, group_identifier: UUID, email_address: str, role: 
     # Always send an e-mail even it the invite already existed
     send_invite_email(invite_state)
     current_app.stats.count(name="invite_created")
-    return outgoing_invites()
+    return cast(FluxData, outgoing_invites())
 
 
 @group_invite_views.route("/delete", methods=["POST"])
@@ -132,7 +133,7 @@ def delete_invite(user: User, group_identifier: UUID, email_address: str, role: 
 
     send_delete_invite_email(invite_state)
 
-    return outgoing_invites()
+    return cast(FluxData, outgoing_invites())
 
 
 @group_invite_views.route("/accept", methods=["POST"])
@@ -170,7 +171,7 @@ def accept_invite(user: User, group_identifier: UUID, email_address: str, role: 
 
     current_app.invite_state_db.remove_state(invite_state)
     current_app.stats.count(name=f"invite_accepted_{invite_state.role.value}")
-    return incoming_invites()
+    return cast(FluxData, incoming_invites())
 
 
 @group_invite_views.route("/decline", methods=["POST"])
@@ -199,4 +200,4 @@ def decline_invite(user: User, group_identifier: UUID, email_address: str, role:
         return error_response(message=CommonMsg.temp_problem)
 
     current_app.stats.count(name=f"invite_declined_{invite_state.role.value}")
-    return incoming_invites()
+    return cast(FluxData, incoming_invites())

--- a/src/eduid/webapp/idp/decorators.py
+++ b/src/eduid/webapp/idp/decorators.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable
 from functools import wraps
-from typing import Any
+from typing import Any, cast
 
 from flask import Response, jsonify, request
 from werkzeug.wrappers import Response as WerkzeugResponse
@@ -52,7 +52,7 @@ def require_ticket(f: Callable[..., Any]) -> Callable[..., Any]:
                 logger.debug(f"Extra debug: Known device: {this_device}")
 
         kwargs["ticket"] = ticket
-        return f(*args, **kwargs)
+        return cast(Response | WerkzeugResponse, f(*args, **kwargs))
 
     return require_ticket_decorator
 
@@ -63,7 +63,7 @@ def uses_sso_session(f: Callable[..., Any]) -> Callable[..., Any]:
         """Decorator to supply the current SSO session, if one is found and still valid"""
 
         kwargs["sso_session"] = get_sso_session()
-        return f(*args, **kwargs)
+        return cast(FluxData | WerkzeugResponse, f(*args, **kwargs))
 
     return uses_sso_session_decorator
 

--- a/src/eduid/webapp/jsconfig/views.py
+++ b/src/eduid/webapp/jsconfig/views.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from flask import Blueprint, abort
 
 from eduid.webapp.common.api.decorators import MarshalWith
@@ -30,6 +32,6 @@ def get_config_for(frontend_app: str) -> FluxData:
     """
     if frontend_app in ["dashboard", "signup", "login", "errors"]:
         current_app.logger.info(f"requesting config for frontend app {frontend_app}")
-        return get_config()
+        return cast(FluxData, get_config())
     current_app.logger.error(f"{frontend_app} not in the list of supported apps")
     abort(404)

--- a/src/eduid/webapp/letter_proofing/ekopost.py
+++ b/src/eduid/webapp/letter_proofing/ekopost.py
@@ -2,7 +2,7 @@ import base64
 import json
 from http import HTTPStatus
 from io import BytesIO
-from typing import Any
+from typing import Any, cast
 
 from hammock import Hammock
 
@@ -64,7 +64,7 @@ class Ekopost:
         self._close_envelope(campaign["id"], envelope["id"])
         closed_campaign = self._close_campaign(campaign["id"])
 
-        return closed_campaign["id"]
+        return cast(str, closed_campaign["id"])
 
     def _create_campaign(self, name: str, output_date: str, cost_center: str) -> dict[str, Any]:
         """
@@ -80,7 +80,7 @@ class Ekopost:
         response = self.ekopost_api.campaigns.POST(data=campaign_data, headers={"Content-Type": "application/json"})
 
         if response.status_code == HTTPStatus.OK:
-            return response.json()
+            return cast(dict[str, Any], response.json())
 
         raise EkopostException(f"Ekopost exception: {response.status_code!s} {response.text!s}")
 
@@ -106,7 +106,7 @@ class Ekopost:
         )
 
         if response.status_code == HTTPStatus.OK:
-            return response.json()
+            return cast(dict[str, Any], response.json())
 
         raise EkopostException(f"Ekopost exception: {response.status_code!s} {response.text!s}")
 
@@ -145,7 +145,7 @@ class Ekopost:
         )
 
         if response.status_code == HTTPStatus.OK:
-            return response.json()
+            return cast(dict[str, Any], response.json())
 
         raise EkopostException(f"Ekopost exception: {response.status_code!s} {response.text!s}")
 
@@ -162,7 +162,7 @@ class Ekopost:
         )
 
         if response.status_code == HTTPStatus.OK:
-            return response.json()
+            return cast(dict[str, Any], response.json())
 
         raise EkopostException(f"Ekopost exception: {response.status_code!s} {response.text!s}")
 
@@ -176,6 +176,6 @@ class Ekopost:
         response = self.ekopost_api.campaigns(campaign_id).close.POST(headers={"Content-Type": "application/json"})
 
         if response.status_code == HTTPStatus.OK:
-            return response.json()
+            return cast(dict[str, Any], response.json())
 
         raise EkopostException(f"Ekopost exception: {response.status_code!s} {response.text!s}")

--- a/src/eduid/webapp/letter_proofing/tests/test_app.py
+++ b/src/eduid/webapp/letter_proofing/tests/test_app.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Mapping
 from datetime import datetime, timedelta
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 import pytest
 from pytest_mock import MockerFixture
@@ -82,7 +82,7 @@ class LetterProofingTests(EduidAPITestCase[LetterProofingApp]):
         with self.session_cookie(self.browser, self.test_user_eppn) as client:
             response = client.get("/proofing")
         assert response.status_code == 200
-        return json.loads(response.data)
+        return cast(dict[str, Any], json.loads(response.data))
 
     def send_letter(self, nin: str, csrf_token: str | None = None, validate_response: bool = True) -> TestResponse:
         """

--- a/src/eduid/webapp/phone/tests/test_app.py
+++ b/src/eduid/webapp/phone/tests/test_app.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote_plus
 
 import pytest
@@ -57,7 +57,7 @@ class PhoneTests(EduidAPITestCase[PhoneApp]):
         with self.session_cookie(self.browser, eppn) as client:
             response2 = client.get("/all")
 
-            return json.loads(response2.data)
+            return cast(dict[str, Any], json.loads(response2.data))
 
     def _post_phone(
         self,

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from fido2.utils import websafe_decode
@@ -185,7 +185,7 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
         data = response.json
         assert data is not None, "No json data returned"
         assert isinstance(data, dict) is True, "returned json is not a dict"
-        return data
+        return cast(dict[Any, Any], data)
 
     def _check_session_state(self, client: CSRFTestClient) -> None:
         with client.session_transaction() as sess:
@@ -387,17 +387,17 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
         self: FidoMetadataStore, attestation: Attestation, client_data: bytes
     ) -> bool:
         if attestation.fmt is AttestationFormat.PACKED:
-            return self.verify_packed_attestation(attestation=attestation, client_data=client_data)
+            return cast(bool, self.verify_packed_attestation(attestation=attestation, client_data=client_data))
         if attestation.fmt is AttestationFormat.APPLE:
             # apple attestation cert in fido_mds test data is only valid for three days
             return True
         if attestation.fmt is AttestationFormat.TPM:
-            return self.verify_tpm_attestation(attestation=attestation, client_data=client_data)
+            return cast(bool, self.verify_tpm_attestation(attestation=attestation, client_data=client_data))
         if attestation.fmt is AttestationFormat.ANDROID_SAFETYNET:
             # android attestation cert in fido_mds test data is only valid for three months
             return True
         if attestation.fmt is AttestationFormat.FIDO_U2F:
-            return self.verify_fido_u2f_attestation(attestation=attestation, client_data=client_data)
+            return cast(bool, self.verify_fido_u2f_attestation(attestation=attestation, client_data=client_data))
         raise NotImplementedError(f"verification of {attestation.fmt.value} not implemented")
 
     # actual tests

--- a/src/eduid/workers/amapi/context_request.py
+++ b/src/eduid/workers/amapi/context_request.py
@@ -2,7 +2,7 @@ __author__ = "masv"
 
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, cast
 
 from fastapi.routing import APIRoute
 from starlette.requests import Request, empty_receive, empty_send
@@ -23,7 +23,7 @@ class ContextRequest(Request):
     @property
     def context(self) -> Context:
         try:
-            return self.state.context
+            return cast(Context, self.state.context)
         except AttributeError:
             # Lazy init of self.state.context
             self.state.context = Context()

--- a/src/eduid/workers/lookup_mobile/client/mobile_lookup_client.py
+++ b/src/eduid/workers/lookup_mobile/client/mobile_lookup_client.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import Any
+from typing import Any, cast
 
 from suds.client import Client
 from suds.sudsobject import Object
@@ -118,4 +118,4 @@ class MobileLookupClient:
             self.logger.debug(f"Got no search result on mobile number: {mobile_number}")
             return None
 
-        return record[0].SSNo
+        return cast(str, record[0].SSNo)

--- a/src/eduid/workers/lookup_mobile/tasks.py
+++ b/src/eduid/workers/lookup_mobile/tasks.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from celery.utils.log import get_task_logger
 
@@ -35,7 +35,7 @@ def find_mobiles_by_nin(self: MobWorker, national_identity_number: str, number_r
     :param national_identity_number:
     :return: a list of formatted mobile numbers. Empty list if no numbers was registered to the nin
     """
-    return self.lookup_client.find_mobiles_by_nin(national_identity_number, number_region)
+    return cast(list[str], self.lookup_client.find_mobiles_by_nin(national_identity_number, number_region))
 
 
 @app.task(bind=True, base=MobWorker, name="eduid_lookup_mobile.tasks.find_NIN_by_mobile")
@@ -44,7 +44,7 @@ def find_nin_by_mobile(self: MobWorker, mobile_number: str) -> str | None:
     Searches nin with the registered mobile number
     :return: the nin with the registered mobile number
     """
-    return self.lookup_client.find_nin_by_mobile(mobile_number)
+    return cast(str | None, self.lookup_client.find_nin_by_mobile(mobile_number))
 
 
 @app.task(bind=True, base=MobWorker, name="eduid_lookup_mobile.tasks.pong")

--- a/src/eduid/workers/msg/cache.py
+++ b/src/eduid/workers/msg/cache.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 from pymongo.results import DeleteResult
 
@@ -27,8 +27,8 @@ class CacheMDB(BaseDB):
         query = {"identifier": identifier}
         result = self._coll.find_one(query)
         if result is not None:
-            return result["data"]
-        return result
+            return cast(dict[str, Any], result["data"])
+        return None
 
     def get_cached_items_by_query(self, query: dict[str, Any]) -> list[TUserDbDocument]:
         result = self._coll.find(query)

--- a/src/eduid/workers/msg/tasks.py
+++ b/src/eduid/workers/msg/tasks.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import OrderedDict
 from http import HTTPStatus
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from billiard.einfo import ExceptionInfo
 from celery.utils.log import get_task_logger
@@ -133,7 +133,7 @@ class MessageSender(Task[Any, Any]):
             raise NotImplementedError(f"message_type {message_type} is not implemented")
 
         logger.debug(f"send_message result: {status}")
-        return status
+        return cast(str, status)
 
     def get_postal_address(self, identity_number: str) -> OrderedDict[str, Any] | None:
         """
@@ -315,7 +315,7 @@ class MessageSender(Task[Any, Any]):
             logger.debug(f"\nType: sms\nReference: {reference}\nRecipient: {recipient}\nMessage:\n{message}")
             return "no_op_number"
 
-        return self.sms.send(message, MsgCelerySingleton.worker_config.sms_sender, recipient, prio=2)
+        return cast(str, self.sms.send(message, MsgCelerySingleton.worker_config.sms_sender, recipient, prio=2))
 
     def pong(self, app_name: str | None) -> str:
         # Leverage cache to test mongo db health
@@ -336,7 +336,7 @@ def sendsms(self: MessageSender, recipient: str, message: str, reference: str) -
     :param reference: Audit reference to help cross reference audit log and events
     """
     try:
-        return self.sendsms(recipient, message, reference)
+        return cast(str, self.sendsms(recipient, message, reference))
     except Exception as e:
         logger.error(f"sendsms task error: {e}", exc_info=True)
         raise self.retry(countdown=1, max_retries=3, exc=e) from e


### PR DESCRIPTION
# Cast Any returns to eliminate no-any-return errors in strict mypy

## Summary

- Add `cast()` at third-party library boundaries to eliminate all 75 `[no-any-return]` strict mypy errors
- Fix real type bug: `vccs/client` `_execute_request_response` declared `-> str` but `urlopen().read()` returns `bytes`
- Remove dead `isinstance` branch in `userdb/user.py` `_parse_profiles` (unreachable code, now matches sibling parsers)

## Sources of Any

All casts are at boundaries where untyped third-party libraries return `Any`:

| Source | Files | Errors fixed |
|---|---|---|
| Celery `AsyncResult.get()` via `celery-types` stub limitation | relay classes, worker tasks | 13 |
| `@MarshalWith` decorator returning `Callable[..., Any]` (inter-view calls) | group_management, jsconfig | 10 |
| `response.json()` (requests/hammock) | ekopost, scimapi tests | 8 |
| `json.loads()` | test helpers, redis_session | 7 |
| Untyped libs (yubihsm, jwcrypto, pwgen, smscom, ndnkdf, suds) | vccs, common, workers | 10 |
| WSGI `Callable[..., Any]` | middleware, debug | 4 |
| Starlette `state` (Any) | context_request (2 files) | 2 |
| pysaml2 untyped returns | authn/utils, satosa | 3 |
| MongoDB/Neo4j untyped returns | graphdb, testing, vccs/server | 5 |
| Other (decorator wrappers, fido_mds) | idp/decorators, test_webauthn | 5 |

## Strict mypy error reduction

- `[no-any-return]`: 75 → 0
- Total: 98 → 25 (remaining: 16 `[misc]` SATOSA stubs, 7 `[type-arg]` variance, 2 other)
