### PR TITLE
Enable follow_untyped_imports for ndnkdf and fido_mds

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,5 @@
 [mypy]
 plugins = pydantic.mypy, marshmallow_dataclass.mypy
+
+[mypy-ndnkdf.*]
+follow_untyped_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,6 @@ plugins = pydantic.mypy, marshmallow_dataclass.mypy
 
 [mypy-ndnkdf.*]
 follow_untyped_imports = True
+
+[mypy-fido_mds.*]
+follow_untyped_imports = True

--- a/src/eduid/vccs/server/password.py
+++ b/src/eduid/vccs/server/password.py
@@ -1,5 +1,4 @@
 from binascii import unhexlify
-from typing import cast
 
 from ndnkdf import NDNKDF
 
@@ -106,4 +105,4 @@ async def calculate_cred_hash(
 
     # PBKDF2 again with iter=1 to mix in the local_salt into the final H2.
     H2 = kdf.pbkdf2_hmac_sha512(T2, 1, local_salt)
-    return cast(str, H2.hex())
+    return H2.hex()

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -96,6 +96,8 @@ def get_authenticator_information(
     user_present = att.auth_data.flags.user_present
     user_verified = att.auth_data.flags.user_verified
     authenticator_id = att.aaguid or att.certificate_key_identifier
+    if authenticator_id is None:
+        raise AttestationVerificationError("attestation contains no authenticator id (aaguid or certificate key identifier)")
 
     # allow automatic tests to use any webauthn device
     if is_backdoor:
@@ -159,6 +161,8 @@ def get_authenticator_information(
 
     # create authenticator information from attestation and metadata
     metadata_entry = fido_mds.get_entry(authenticator_id=authenticator_id)
+    if metadata_entry is None:
+        raise AttestationVerificationError(f"no metadata entry found for authenticator {authenticator_id}")
     # mongodb does not support date
     last_status_change = metadata_entry.time_of_last_status_change
     user_verification_methods = [
@@ -178,7 +182,7 @@ def get_authenticator_information(
 
     return AuthenticatorInformation(
         attestation_format=att.fmt,
-        authenticator_id=att.aaguid or att.certificate_key_identifier,
+        authenticator_id=authenticator_id,
         status=max(
             metadata_entry.status_reports, key=lambda sr: sr.effective_date
         ).status,  # latest status reports status

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -387,17 +387,17 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
         self: FidoMetadataStore, attestation: Attestation, client_data: bytes
     ) -> bool:
         if attestation.fmt is AttestationFormat.PACKED:
-            return cast(bool, self.verify_packed_attestation(attestation=attestation, client_data=client_data))
+            return self.verify_packed_attestation(attestation=attestation, client_data=client_data)
         if attestation.fmt is AttestationFormat.APPLE:
             # apple attestation cert in fido_mds test data is only valid for three days
             return True
         if attestation.fmt is AttestationFormat.TPM:
-            return cast(bool, self.verify_tpm_attestation(attestation=attestation, client_data=client_data))
+            return self.verify_tpm_attestation(attestation=attestation, client_data=client_data)
         if attestation.fmt is AttestationFormat.ANDROID_SAFETYNET:
             # android attestation cert in fido_mds test data is only valid for three months
             return True
         if attestation.fmt is AttestationFormat.FIDO_U2F:
-            return cast(bool, self.verify_fido_u2f_attestation(attestation=attestation, client_data=client_data))
+            return self.verify_fido_u2f_attestation(attestation=attestation, client_data=client_data)
         raise NotImplementedError(f"verification of {attestation.fmt.value} not implemented")
 
     # actual tests

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -10,7 +10,9 @@ from fido2.webauthn import (
     RegistrationResponse,
     UserVerificationRequirement,
 )
-from fido_mds import FidoMetadataStore
+from fido_mds import Attestation, FidoMetadataStore
+from fido_mds.models.webauthn import AttestationFormat
+from fido_mds.tests.data import IPHONE_12, MICROSOFT_SURFACE_1796, NEXUS_5, NONE_ATTESTATION, YUBIKEY_4, YUBIKEY_5_NFC
 from future.backports.datetime import timedelta
 from pytest_mock import MockerFixture
 from werkzeug.test import TestResponse
@@ -34,10 +36,22 @@ __author__ = "eperez"
 
 # CTAP1 test data
 
-# result of calling Fido2Server.register_begin
-from fido_mds import Attestation
-from fido_mds.models.webauthn import AttestationFormat
-from fido_mds.tests.data import IPHONE_12, MICROSOFT_SURFACE_1796, NEXUS_5, NONE_ATTESTATION, YUBIKEY_4, YUBIKEY_5_NFC
+
+def _apple_special_verify_attestation(self: FidoMetadataStore, attestation: Attestation, client_data: bytes) -> bool:
+    if attestation.fmt is AttestationFormat.PACKED:
+        return self.verify_packed_attestation(attestation=attestation, client_data=client_data)
+    if attestation.fmt is AttestationFormat.APPLE:
+        # apple attestation cert in fido_mds test data is only valid for three days
+        return True
+    if attestation.fmt is AttestationFormat.TPM:
+        return self.verify_tpm_attestation(attestation=attestation, client_data=client_data)
+    if attestation.fmt is AttestationFormat.ANDROID_SAFETYNET:
+        # android attestation cert in fido_mds test data is only valid for three months
+        return True
+    if attestation.fmt is AttestationFormat.FIDO_U2F:
+        return self.verify_fido_u2f_attestation(attestation=attestation, client_data=client_data)
+    raise NotImplementedError(f"verification of {attestation.fmt.value} not implemented")
+
 
 # CTAP1 security key
 STATE = {"challenge": "u3zHzb7krB4c4wj0Uxuhsz2lCXqLnwV9ZxMhvL2lcfo", "user_verification": "discouraged"}
@@ -383,23 +397,6 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
             response2 = client.post("/webauthn/remove", json=data)
             return user_token, response2
 
-    def _apple_special_verify_attestation(
-        self: FidoMetadataStore, attestation: Attestation, client_data: bytes
-    ) -> bool:
-        if attestation.fmt is AttestationFormat.PACKED:
-            return self.verify_packed_attestation(attestation=attestation, client_data=client_data)
-        if attestation.fmt is AttestationFormat.APPLE:
-            # apple attestation cert in fido_mds test data is only valid for three days
-            return True
-        if attestation.fmt is AttestationFormat.TPM:
-            return self.verify_tpm_attestation(attestation=attestation, client_data=client_data)
-        if attestation.fmt is AttestationFormat.ANDROID_SAFETYNET:
-            # android attestation cert in fido_mds test data is only valid for three months
-            return True
-        if attestation.fmt is AttestationFormat.FIDO_U2F:
-            return self.verify_fido_u2f_attestation(attestation=attestation, client_data=client_data)
-        raise NotImplementedError(f"verification of {attestation.fmt.value} not implemented")
-
     # actual tests
 
     def test_begin_no_login(self) -> None:
@@ -636,7 +633,7 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
 
     def test_authenticator_information(self, mocker: MockerFixture) -> None:
         mocker.patch(
-            "fido_mds.FidoMetadataStore.verify_attestation", SecurityWebauthnTests._apple_special_verify_attestation
+            "fido_mds.FidoMetadataStore.verify_attestation", _apple_special_verify_attestation
         )
         authenticators = [YUBIKEY_4, YUBIKEY_5_NFC, MICROSOFT_SURFACE_1796, NEXUS_5, IPHONE_12, NONE_ATTESTATION]
         for authenticator in authenticators:


### PR DESCRIPTION
# Enable follow_untyped_imports for ndnkdf and fido_mds

## Summary

- Enable `follow_untyped_imports = True` in `mypy.ini` for `ndnkdf` and `fido_mds`,
  letting mypy check call sites against inferred types from both libraries
- Fix real bugs exposed by fido_mds typing in `webauthn.py`
- Move test monkey-patch helper to module level to eliminate the typing workaround
- Remove now-unnecessary `cast()` in `vccs/server/password.py` (ndnkdf typing resolved the return type)

## Changes

### `mypy.ini`

Added `follow_untyped_imports = True` for `ndnkdf` and `fido_mds`. This makes mypy
follow the libraries' unannotated source and check call sites against inferred types,
surfacing real type mismatches instead of silently accepting `Any`.

Both entries will be removed once the upstream libraries ship their own type annotations
(python-fido-mds upstream PR pending).

### `webauthn.py` — real bugs fixed

`follow_untyped_imports` revealed two latent crash paths in `get_authenticator_information`:

**`authenticator_id` could be `None`** — `att.aaguid or att.certificate_key_identifier`
produces `UUID | str | None` if both are `None`. fido_mds APIs (`get_entry`, `exists`,
`AuthenticatorInformation`) all require `UUID | str`. Added an early guard:

```python
if authenticator_id is None:
    raise AttestationVerificationError("attestation contains no authenticator id ...")
```

**`metadata_entry` could be `None`** — `fido_mds.get_entry()` returns
`MetadataEntry | None`. Code accessed attributes directly without checking. Added a
guard after the call. Also removed a duplicate `att.aaguid or att.certificate_key_identifier`
expression in the final return, replacing it with the already-guarded `authenticator_id`.

### `test_webauthn.py` — monkey-patch to module level

`_apple_special_verify_attestation` was defined as a method on `SecurityWebauthnTests`
with `self: FidoMetadataStore` explicitly typed for monkey-patching. With fido_mds now
typed, mypy flagged the erased-type mismatch (`[misc]`). Moved to module level — at
module scope `self` is a plain parameter with no class hierarchy check — and updated
the `mocker.patch` call site. Also consolidated the mid-file fido_mds imports to the
top of the file.

### `vccs/server/password.py`

Removed `cast(str, H2.hex())` — with `follow_untyped_imports` for ndnkdf, mypy now
correctly infers that `H2.hex()` returns `str`.
