### PR TITLE
Suppress [misc] for untyped third-party base classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 TOPDIR:=	$(abspath .)
 SRCDIR=		$(TOPDIR)/src
 SOURCE=		$(SRCDIR)/eduid
-MYPY_ARGS=	--install-types --non-interactive --pretty --ignore-missing-imports \
-			--warn-unused-ignores \
+MYPY_ARGS=	--install-types --non-interactive --pretty \
 			# --disallow-untyped-decorators
 MYPY_STRICT= --strict \
 			 --implicit-reexport \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 TOPDIR:=	$(abspath .)
 SRCDIR=		$(TOPDIR)/src
 SOURCE=		$(SRCDIR)/eduid
-MYPY_ARGS=	--install-types --non-interactive --pretty \
-			# --disallow-untyped-decorators
+MYPY_ARGS=	--install-types --non-interactive --pretty
 MYPY_STRICT= --strict \
 			 --implicit-reexport \
 			 --allow-untyped-calls

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,5 @@
 [mypy]
 plugins = pydantic.mypy, marshmallow_dataclass.mypy
 disallow_subclassing_any = True
+ignore_missing_imports = True
+warn_unused_ignores = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 plugins = pydantic.mypy, marshmallow_dataclass.mypy
+disallow_subclassing_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 plugins = pydantic.mypy, marshmallow_dataclass.mypy
 disallow_subclassing_any = True
+disallow_untyped_decorators = True
 ignore_missing_imports = True
 warn_unused_ignores = True

--- a/src/eduid/satosa/scimapi/accr.py
+++ b/src/eduid/satosa/scimapi/accr.py
@@ -18,7 +18,7 @@ InternalACCRRewriteMap = Mapping[str, str]
 type ProcessReturnType = InternalData | Response
 
 
-class request(RequestMicroService):
+class request(RequestMicroService):  # type: ignore[misc]
     """
     A class to handle and the ACCR request flowing through Satosa.
     ```yaml
@@ -105,7 +105,7 @@ class request(RequestMicroService):
         return super().process(context, data)
 
 
-class response(ResponseMicroService):
+class response(ResponseMicroService):  # type: ignore[misc]
     """
     A class to handle and the ACCR response flowing through Satosa.
     ```yaml

--- a/src/eduid/satosa/scimapi/nameid.py
+++ b/src/eduid/satosa/scimapi/nameid.py
@@ -27,7 +27,7 @@ ALLOWED_NAMEIDS = (
 logger = logging.getLogger(__name__)
 
 
-class request(RequestMicroService):
+class request(RequestMicroService):  # type: ignore[misc]
     def __init__(
         self,
         config: Mapping[str, Any],
@@ -56,7 +56,7 @@ class request(RequestMicroService):
         return super().process(context, data)
 
 
-class response(ResponseMicroService):
+class response(ResponseMicroService):  # type: ignore[misc]
     def __init__(
         self,
         config: Mapping[str, Any],

--- a/src/eduid/satosa/scimapi/pairwiseid.py
+++ b/src/eduid/satosa/scimapi/pairwiseid.py
@@ -18,7 +18,7 @@ class Config:
     pairwise_salt: str
 
 
-class GeneratePairwiseId(ResponseMicroService):
+class GeneratePairwiseId(ResponseMicroService):  # type: ignore[misc]
     """
     MicroService go generate pairwise-id based on subject-id
 

--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -39,7 +39,7 @@ class UserGroups:
     manager: list[ScimApiGroup] = field(default_factory=list)
 
 
-class ScimAttributes(ResponseMicroService):
+class ScimAttributes(ResponseMicroService):  # type: ignore[misc]
     """
     Add attributes from the scim db to the responses.
     """

--- a/src/eduid/satosa/scimapi/serve_static.py
+++ b/src/eduid/satosa/scimapi/serve_static.py
@@ -14,7 +14,7 @@ from satosa.satosa_config import SATOSAConfig
 logger = logging.getLogger("satosa")
 
 
-class ServeStatic(RequestMicroService):
+class ServeStatic(RequestMicroService):  # type: ignore[misc]
     """
     A class to serve static files from a given directory
 

--- a/src/eduid/satosa/scimapi/static_attributes.py
+++ b/src/eduid/satosa/scimapi/static_attributes.py
@@ -15,7 +15,7 @@ StaticAttributesConfig = dict[str, list[dict[str, str]]]
 StaticAppendedAttributesConfig = dict[str, list[dict[str, str]]]
 
 
-class AddStaticAttributesForVirtualIdp(ResponseMicroService):
+class AddStaticAttributesForVirtualIdp(ResponseMicroService):  # type: ignore[misc]
     """
     A class that add static attributes to a response set.
     The following example configuration illustrates most common features:

--- a/src/eduid/satosa/scimapi/statsd.py
+++ b/src/eduid/satosa/scimapi/statsd.py
@@ -13,7 +13,7 @@ from eduid.common.stats import init_app_stats
 logger = logging.getLogger(__name__)
 
 
-class RequesterCounter(ResponseMicroService):
+class RequesterCounter(ResponseMicroService):  # type: ignore[misc]
     """
         A class to count the requesting SP.
 

--- a/src/eduid/satosa/scimapi/stepup.py
+++ b/src/eduid/satosa/scimapi/stepup.py
@@ -58,7 +58,7 @@ STATE_KEY_LOA = "returned-authn-class"
 STATE_KEY_MFA = "requester-authn-class-ref"
 
 
-class StepUpError(SATOSAError):
+class StepUpError(SATOSAError):  # type: ignore[misc]
     """Generic error for this plugin."""
 
 
@@ -104,7 +104,7 @@ class StepupParams(BaseModel):
 
 
 # Applied to response from IDP
-class StepUp(ResponseMicroService):
+class StepUp(ResponseMicroService):  # type: ignore[misc]
     """
     A micro-SP just to handle the communication towards the StepUp Service for SFO.
 
@@ -512,7 +512,7 @@ class StepUp(ResponseMicroService):
 
 
 # applied to incoming request from SP
-class AuthnContext(RequestMicroService):
+class AuthnContext(RequestMicroService):  # type: ignore[misc]
     """
     A micro-service that runs when the authnRequest is first received from the SP.
 
@@ -634,7 +634,7 @@ def get_loa_settings_for_entity_id(
     return None
 
 
-class StepupSAMLBackend(SAMLBackend):
+class StepupSAMLBackend(SAMLBackend):  # type: ignore[misc]
     """
     A SAML backend to request custom authn context class references from IdP:s with certain entity attributes.
     """
@@ -665,7 +665,7 @@ class StepupSAMLBackend(SAMLBackend):
         return super().authn_request(context, entity_id)
 
 
-class RewriteAuthnContextClass(ResponseMicroService):
+class RewriteAuthnContextClass(ResponseMicroService):  # type: ignore[misc]
     """
     When we receive a response from an IdP, we check if we have configuration specifying
     'normalisation' of the authn context class reference in our MFA configuration.

--- a/src/eduid/webapp/common/authn/cache.py
+++ b/src/eduid/webapp/common/authn/cache.py
@@ -64,7 +64,7 @@ class OutstandingQueriesCache:
             del self._db[saml2_session_id]
 
 
-class IdentityCache(Cache):
+class IdentityCache(Cache):  # type: ignore[misc]
     """Handles information about the users that have been successfully logged in.
 
     This information is useful because when the user logs out we must

--- a/src/eduid/workers/job_runner/scheduler.py
+++ b/src/eduid/workers/job_runner/scheduler.py
@@ -6,7 +6,7 @@ from eduid.workers.job_runner.context import Context
 from eduid.workers.job_runner.jobs.skv import check_skv_users, gather_skv_users
 
 
-class JobScheduler(AsyncIOScheduler):
+class JobScheduler(AsyncIOScheduler):  # type: ignore[misc]
     def schedule_jobs(self, context: Context) -> None:
         """
         Schedule all jobs configured for host or environment


### PR DESCRIPTION
# Suppress [misc] for untyped third-party base classes + consolidate mypy config

## Summary

- Add `# type: ignore[misc]` to 16 subclass definitions inheriting from untyped
  third-party base classes
- Move shared mypy flags from `Makefile` into `mypy.ini` so both `typecheck` and
  `typecheck_strict` targets share a single source of truth
- Enable `--disallow-untyped-decorators` (was commented out) and
  `--disallow-subclassing-any` (previously only active under `--strict`) globally

## Why

### `# type: ignore[misc]`

Mypy `--strict` enables `--disallow-subclassing-any`, which flags `class Foo(UntypedBase)`
as `[misc]` when the base class has type `Any`. The subclass bodies are fully typed — the
error is purely about the inheritance declaration. No stub packages exist on PyPI for any
of the affected libraries.

### `mypy.ini` consolidation

`--ignore-missing-imports` and `--warn-unused-ignores` were duplicated in `MYPY_ARGS`
(shared by both targets) but absent from `mypy.ini`. Moving them to `mypy.ini` means
the flags are active whenever mypy runs, not just via `make`. `--disallow-untyped-decorators`
was already correct to enable (no new errors) and follows the same pattern.

`--disallow-subclassing-any` needed to move to `mypy.ini` specifically to keep
`# type: ignore[misc]` valid under plain `typecheck` — without it the ignores are unused
and `--warn-unused-ignores` flags them.

## Affected libraries (`[misc]`)

| Library | Base classes | Files |
|---|---|---|
| SATOSA | `ResponseMicroService`, `RequestMicroService`, `SAMLBackend`, `SATOSAError` | `satosa/scimapi/` (9 files, 14 ignores) |
| pysaml2 | `Cache` | `webapp/common/authn/cache.py` |
| APScheduler | `AsyncIOScheduler` | `workers/job_runner/scheduler.py` |

