### PR TITLE
Fix bare generic type-arg errors, enable ruff B009, promote typecheck to strict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,9 @@ lint:
 	ruff check
 
 typecheck:
-	MYPYPATH=$(SRCDIR) mypy $(MYPY_ARGS) --namespace-packages -p eduid --check-untyped-defs
-
-typecheck_strict:
-	$(info Running mypy in semi-strict mode (not enforced in the build pipeline yet))
 	MYPYPATH=$(SRCDIR) mypy $(MYPY_ARGS) $(MYPY_STRICT) --namespace-packages -p eduid --check-untyped-defs
+
+typecheck_strict: typecheck
 
 update_webapp_translations:
 	pybabel extract -k _ -k gettext -k ngettext --mapping=babel.cfg --width=120 --output=$(SOURCE)/webapp/translations/messages.pot $(SOURCE)/webapp/

--- a/ruff.toml
+++ b/ruff.toml
@@ -30,7 +30,6 @@ select = [
 ]
 
 ignore = [
-  "B009",     # will require type generics for conf in EduIDBaseApp (refactor)
   "PLR09",    # rule set for complexity checks
   "PLC0415",  # non top level imports
   "SIM102",   # collapsible-if

--- a/src/eduid/common/rpc/lookup_mobile_relay.py
+++ b/src/eduid/common/rpc/lookup_mobile_relay.py
@@ -22,9 +22,7 @@ class LookupMobileRelay:
     def find_nin_by_mobile(self, mobile_number: str) -> str | None:
         try:
             rtask = self._find_nin_by_mobile.delay(mobile_number)
-            result = cast(
-                str | None, rtask.get(timeout=10)
-            )  # Lower timeout than standard gunicorn worker timeout (25)
+            result = cast(str | None, rtask.get(timeout=10))  # Lower timeout than standard gunicorn worker timeout (25)
             return result
         except Exception as e:
             raise LookupMobileTaskFailed(f"find_nin_by_mobile task failed: {e}") from e

--- a/src/eduid/webapp/authn/app.py
+++ b/src/eduid/webapp/authn/app.py
@@ -13,7 +13,6 @@ class AuthnApp(EduIDBaseApp[AuthnConfig]):
     def __init__(self, config: AuthnConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 

--- a/src/eduid/webapp/bankid/app.py
+++ b/src/eduid/webapp/bankid/app.py
@@ -19,7 +19,6 @@ class BankIDApp(AuthnBaseApp[BankIDConfig]):
     def __init__(self, config: BankIDConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 

--- a/src/eduid/webapp/common/api/app.py
+++ b/src/eduid/webapp/common/api/app.py
@@ -65,6 +65,7 @@ class EduIDBaseApp[C: EduIDBaseAppConfig](Flask, metaclass=ABCMeta):
         :param handle_exceptions: Whether to install exception handler or not.
         """
         super().__init__(config.app_name, **kwargs)
+        self.conf = config
         _flask_config = {x.upper(): v for x, v in config.flask.to_mapping().items()}
         self.config.from_mapping(_flask_config)
 

--- a/src/eduid/webapp/common/api/app.py
+++ b/src/eduid/webapp/common/api/app.py
@@ -169,7 +169,7 @@ class EduIDBaseApp[C: EduIDBaseAppConfig](Flask, metaclass=ABCMeta):
         return res
 
 
-def init_status_views(app: EduIDBaseApp, config: EduIDBaseAppConfig) -> None:
+def init_status_views(app: EduIDBaseApp[Any], config: EduIDBaseAppConfig) -> None:
     """
     Register status views for any app, and configure them as public.
     """

--- a/src/eduid/webapp/common/api/checks.py
+++ b/src/eduid/webapp/common/api/checks.py
@@ -26,9 +26,9 @@ __author__ = "lundberg"
 def get_current_app() -> EduIDBaseApp[EduIDBaseAppConfig]:
     from eduid.webapp.common.api.app import EduIDBaseApp
 
-    _conf = getattr(flask_current_app, "conf")
-    assert isinstance(_conf, EduIDBaseAppConfig)
-    return cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
+    _app = cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
+    assert isinstance(_app.conf, EduIDBaseAppConfig)
+    return _app
 
 
 @dataclass
@@ -113,7 +113,7 @@ def check_mongo() -> bool:
 
 def check_redis() -> bool:
     current_app = get_current_app()
-    _conf = getattr(current_app, "conf")
+    _conf = current_app.conf
     assert isinstance(_conf, RedisConfigMixin)
     pool = get_redis_pool(_conf.redis_config)
     client = redis.StrictRedis(connection_pool=pool)
@@ -184,7 +184,7 @@ def check_lookup_mobile() -> bool:
 def check_vccs() -> bool:
     current_app = get_current_app()
 
-    _conf = getattr(current_app, "conf")
+    _conf = current_app.conf
     if not isinstance(_conf, VCCSConfigMixin):
         return True
     # Do not force this check if not configured

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -134,8 +134,7 @@ class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
         self.test_domain = "test.localhost"
 
         # Save app conf so mutations by individual tests don't leak to subsequent tests.
-        # Use getattr so mypy doesn't complain about T not having "conf".
-        _saved_conf = deepcopy(getattr(self.app, "conf", None))
+        _saved_conf = deepcopy(self.app.conf)
 
         _users = UserFixtures()
         _standard_test_users = {
@@ -222,7 +221,7 @@ class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
                 sess.common.eppn = eppn
                 sess.common.is_logged_in = logged_in
             assert isinstance(self.app, EduIDBaseApp)
-            _conf = getattr(self.app, "conf")
+            _conf = self.app.conf
             assert isinstance(_conf, EduIDBaseAppConfig)
             client.set_cookie(domain=domain, key=_conf.flask.session_cookie_name, value=sess.meta.cookie_val)
         yield client
@@ -246,7 +245,7 @@ class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
         if domain is None:
             domain = self.test_domain
         assert isinstance(self.app, EduIDBaseApp)
-        _conf = getattr(self.app, "conf")
+        _conf = self.app.conf
         assert isinstance(_conf, MagicCookieMixin)
         if magic_cookie_name is None:
             assert _conf.magic_cookie_name is not None
@@ -615,7 +614,7 @@ class CSRFTestClient(FlaskClient):
         that makes it harder to override per call to post.
         """
         assert isinstance(self.application, EduIDBaseApp)
-        _conf = getattr(self.application, "conf")
+        _conf = self.application.conf
         assert isinstance(_conf, EduIDBaseAppConfig)
 
         test_host = f"{_conf.flask.preferred_url_scheme}://{_conf.flask.server_name}"

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -155,7 +155,7 @@ class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
 
         if self.copy_user_to_private:
             data = self.test_user.to_dict()
-            _private_userdb = getattr(self.app, "private_userdb")
+            _private_userdb = getattr(self.app, "private_userdb")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
             assert isinstance(_private_userdb, UserDB)
             logging.info(f"Copying test-user {self.test_user} to private_userdb {_private_userdb}")
             _private_userdb.save(_private_userdb.user_from_dict(data=data))
@@ -585,7 +585,7 @@ class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
         assert user.identities.nin.proofing_method is not None
         assert user.identities.nin.proofing_version is not None
 
-        _log = getattr(self.app, "proofing_log")
+        _log = getattr(self.app, "proofing_log")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
         assert isinstance(_log, ProofingLog)
         assert _log.db_count() == 1
 
@@ -599,7 +599,7 @@ class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
             assert user.identities.nin.created_by == created_by
         assert user.identities.nin.is_verified is False
 
-        _log = getattr(self.app, "proofing_log")
+        _log = getattr(self.app, "proofing_log")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
         assert isinstance(_log, ProofingLog)
         assert _log.db_count() == 0
 

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -89,7 +89,7 @@ TEST_CONFIG = {
 }
 
 
-class EduidAPITestCase[T: EduIDBaseApp](CommonTestCase):
+class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
     """
     Base Test case for eduID APIs.
 

--- a/src/eduid/webapp/common/api/tests/test_inputs.py
+++ b/src/eduid/webapp/common/api/tests/test_inputs.py
@@ -114,7 +114,7 @@ class InputsTestApp(EduIDBaseApp[EduIDBaseAppConfig]):
         self.session_interface = SessionFactory(config)
 
 
-class InputsTests(EduidAPITestCase[InputsTestApp]):
+class InputsTests(EduidAPITestCase[Any]):
     def load_app(self, config: Mapping[str, Any]) -> InputsTestApp:
         """
         Called from the parent class, so we can provide the appropriate flask

--- a/src/eduid/webapp/common/api/tests/test_inputs.py
+++ b/src/eduid/webapp/common/api/tests/test_inputs.py
@@ -114,7 +114,7 @@ class InputsTestApp(EduIDBaseApp[EduIDBaseAppConfig]):
         self.session_interface = SessionFactory(config)
 
 
-class InputsTests(EduidAPITestCase):
+class InputsTests(EduidAPITestCase[InputsTestApp]):
     def load_app(self, config: Mapping[str, Any]) -> InputsTestApp:
         """
         Called from the parent class, so we can provide the appropriate flask

--- a/src/eduid/webapp/common/api/translation.py
+++ b/src/eduid/webapp/common/api/translation.py
@@ -1,4 +1,5 @@
 from importlib.resources import files
+from typing import Any
 
 from flask import current_app, request
 from flask_babel import Babel
@@ -27,7 +28,7 @@ def get_user_locale() -> str | None:
     return lang
 
 
-def init_babel(app: EduIDBaseApp) -> Babel:
+def init_babel(app: EduIDBaseApp[Any]) -> Babel:
     """
     :param app: Flask app
     """

--- a/src/eduid/webapp/common/api/translation.py
+++ b/src/eduid/webapp/common/api/translation.py
@@ -22,7 +22,7 @@ def get_user_locale() -> str | None:
         return lang
     # otherwise try to guess the language from the user accept
     # header the browser transmits. The best match wins.
-    _conf = getattr(app, "conf")
+    _conf = app.conf
     lang = request.accept_languages.best_match(_conf.available_languages)
     app.logger.debug(f"Language (best match) for request: {lang}")
     return lang
@@ -33,7 +33,7 @@ def init_babel(app: EduIDBaseApp[Any]) -> Babel:
     :param app: Flask app
     """
 
-    _conf = getattr(app, "conf")
+    _conf = app.conf
     assert isinstance(_conf, EduIDBaseAppConfig)
     conf_translations_dirs = ";".join(_conf.flask.babel_translation_directories)
     # Add pkg_resource path to translation directory as the default location does not work

--- a/src/eduid/webapp/common/authn/utils.py
+++ b/src/eduid/webapp/common/authn/utils.py
@@ -236,8 +236,7 @@ def check_reauthn(
 ) -> FluxData | None:
     """Check if a re-authentication has been performed recently enough for this action"""
 
-    # please mypy
-    conf = getattr(current_app, "conf", None)
+    conf = current_app.conf
     if not isinstance(conf, FrontendActionMixin):
         raise RuntimeError(f"Could not find conf in {current_app}")
 

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -97,7 +97,9 @@ def get_authenticator_information(
     user_verified = att.auth_data.flags.user_verified
     authenticator_id = att.aaguid or att.certificate_key_identifier
     if authenticator_id is None:
-        raise AttestationVerificationError("attestation contains no authenticator id (aaguid or certificate key identifier)")
+        raise AttestationVerificationError(
+            "attestation contains no authenticator id (aaguid or certificate key identifier)"
+        )
 
     # allow automatic tests to use any webauthn device
     if is_backdoor:

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -83,7 +83,7 @@ class ProofingTests[T: EduIDBaseApp[Any]](EduidAPITestCase[T]):
                 f"User token was expected to be verified={token_verified}"
             )
 
-        _log = getattr(self.app, "proofing_log")
+        _log = getattr(self.app, "proofing_log")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
         assert isinstance(_log, ProofingLog)
         assert _log.db_count() == num_proofings, (
             f"Unexpected number of proofings in db. {_log.db_count()}, expected {num_proofings}"

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -5,7 +5,6 @@ from eduid.userdb.credentials import FidoCredential
 from eduid.userdb.identity import IdentityElement, IdentityProofingMethod
 from eduid.userdb.logs.db import ProofingLog
 from eduid.userdb.user import User
-from eduid.userdb.userdb import AmDB
 from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.api.messages import TranslatableMsg
 from eduid.webapp.common.api.testing import CSRFTestClient, EduidAPITestCase, logger
@@ -70,8 +69,7 @@ class ProofingTests[T: EduIDBaseApp[Any]](EduidAPITestCase[T]):
         """This function is used to verify a user's parameters at the start of a test case,
         and then again at the end to ensure the right set of changes occurred to the user in the database.
         """
-        _am_db = getattr(self.app, "central_userdb")
-        assert isinstance(_am_db, AmDB)
+        _am_db = self.app.central_userdb
         user = _am_db.get_user_by_eppn(eppn)
         assert isinstance(user, User)
         user_mfa_tokens = user.credentials.filter(FidoCredential)

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from eduid.common.config.base import EduIDBaseAppConfig, FrontendAction
 from eduid.userdb.credentials import FidoCredential
 from eduid.userdb.identity import IdentityElement, IdentityProofingMethod
@@ -11,7 +13,7 @@ from eduid.webapp.common.api.testing import CSRFTestClient, EduidAPITestCase, lo
 __author__ = "lundberg"
 
 
-class ProofingTests[T: EduIDBaseApp](EduidAPITestCase[T]):
+class ProofingTests[T: EduIDBaseApp[Any]](EduidAPITestCase[T]):
     def _verify_status(
         self,
         finish_url: str,

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -36,7 +36,7 @@ class ProofingTests[T: EduIDBaseApp[Any]](EduidAPITestCase[T]):
         app_name, authn_id = finish_url.split("/")[-2:]
 
         assert isinstance(self.app, EduIDBaseApp)
-        _conf = getattr(self.app, "conf")
+        _conf = self.app.conf
         assert isinstance(_conf, EduIDBaseAppConfig)
         assert app_name == _conf.app_name, f"expected app_name {_conf.app_name} but got {app_name}"
 

--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -376,7 +376,7 @@ class EduidSession(SessionMixin):
             self._session.commit()
             self.new = False
             self.modified = False
-            _conf = getattr(self.app, "conf", None)
+            _conf = self.app.conf
             if self.app.debug or (isinstance(_conf, EduIDBaseAppConfig) and _conf.testing):
                 _saved_data = json.dumps(self._session.to_dict(), indent=4, sort_keys=True, cls=EduidJSONEncoder)
                 logger.debug(f"Saved session {self}:\n{_saved_data}")

--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -6,7 +6,7 @@ import os
 import pprint
 from collections.abc import Iterator
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from flask import Flask, Request, Response
 from flask.sessions import SessionInterface, SessionMixin
@@ -99,7 +99,7 @@ class EduidSession(SessionMixin):
     """
 
     def __init__(
-        self, app: EduIDBaseApp, meta: SessionMeta, base_session: RedisEncryptedSession, new: bool = False
+        self, app: EduIDBaseApp[Any], meta: SessionMeta, base_session: RedisEncryptedSession, new: bool = False
     ) -> None:
         """
         :param app: the flask app

--- a/src/eduid/webapp/eidas/app.py
+++ b/src/eduid/webapp/eidas/app.py
@@ -19,7 +19,6 @@ class EidasApp(AuthnBaseApp[EidasConfig]):
     def __init__(self, config: EidasConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 

--- a/src/eduid/webapp/email/app.py
+++ b/src/eduid/webapp/email/app.py
@@ -16,7 +16,6 @@ class EmailApp(AuthnBaseApp[EmailConfig]):
     def __init__(self, config: EmailConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init celery
         self.am_relay = AmRelay(config)

--- a/src/eduid/webapp/freja_eid/app.py
+++ b/src/eduid/webapp/freja_eid/app.py
@@ -21,7 +21,6 @@ class FrejaEIDApp(AuthnBaseApp[FrejaEIDConfig]):
     def __init__(self, config: FrejaEIDConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
         # Init dbs
         self.private_userdb = FrejaEIDProofingUserDB(self.conf.mongo_uri, auto_expire=config.private_userdb_auto_expire)
         self.proofing_log = ProofingLog(config.mongo_uri)

--- a/src/eduid/webapp/group_management/app.py
+++ b/src/eduid/webapp/group_management/app.py
@@ -19,7 +19,6 @@ class GroupManagementApp(AuthnBaseApp[GroupManagementConfig]):
     def __init__(self, config: GroupManagementConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init dbs
         self.invite_state_db = GroupManagementInviteStateDB(config.mongo_uri)

--- a/src/eduid/webapp/idp/app.py
+++ b/src/eduid/webapp/idp/app.py
@@ -25,7 +25,6 @@ class IdPApp(EduIDBaseApp[IdPConfig]):
     def __init__(self, config: IdPConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Initiate external modules
         self.babel = translation.init_babel(self)

--- a/src/eduid/webapp/jsconfig/app.py
+++ b/src/eduid/webapp/jsconfig/app.py
@@ -15,7 +15,6 @@ class JSConfigApp(EduIDBaseApp[JSConfigConfig]):
 
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
 
 current_jsconfig_app: JSConfigApp = cast(JSConfigApp, current_app)

--- a/src/eduid/webapp/ladok/app.py
+++ b/src/eduid/webapp/ladok/app.py
@@ -18,7 +18,6 @@ class LadokApp(AuthnBaseApp[LadokConfig]):
     def __init__(self, config: LadokConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init dbs
         self.private_userdb = LadokProofingUserDB(config.mongo_uri, auto_expire=config.private_userdb_auto_expire)

--- a/src/eduid/webapp/letter_proofing/app.py
+++ b/src/eduid/webapp/letter_proofing/app.py
@@ -20,7 +20,6 @@ class LetterProofingApp(AuthnBaseApp[LetterProofingConfig]):
     def __init__(self, config: LetterProofingConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init dbs
         self.private_userdb = LetterProofingUserDB(config.mongo_uri, auto_expire=config.private_userdb_auto_expire)

--- a/src/eduid/webapp/lookup_mobile_proofing/app.py
+++ b/src/eduid/webapp/lookup_mobile_proofing/app.py
@@ -19,7 +19,6 @@ class MobileProofingApp(AuthnBaseApp[MobileProofingConfig]):
     def __init__(self, config: MobileProofingConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init dbs
         self.private_userdb = LookupMobileProofingUserDB(

--- a/src/eduid/webapp/orcid/app.py
+++ b/src/eduid/webapp/orcid/app.py
@@ -18,7 +18,6 @@ class OrcidApp(AuthnBaseApp[OrcidConfig]):
     def __init__(self, config: OrcidConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init dbs
         self.private_userdb = OrcidProofingUserDB(config.mongo_uri, auto_expire=config.private_userdb_auto_expire)

--- a/src/eduid/webapp/personal_data/app.py
+++ b/src/eduid/webapp/personal_data/app.py
@@ -14,7 +14,6 @@ class PersonalDataApp(AuthnBaseApp[PersonalDataConfig]):
     def __init__(self, config: PersonalDataConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init celery
         self.am_relay = AmRelay(config)

--- a/src/eduid/webapp/phone/app.py
+++ b/src/eduid/webapp/phone/app.py
@@ -18,7 +18,6 @@ class PhoneApp(AuthnBaseApp[PhoneConfig]):
     def __init__(self, config: PhoneConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init celery
         self.am_relay = AmRelay(config)

--- a/src/eduid/webapp/reset_password/app.py
+++ b/src/eduid/webapp/reset_password/app.py
@@ -21,7 +21,6 @@ class ResetPasswordApp(EduIDBaseApp[ResetPasswordConfig]):
     def __init__(self, config: ResetPasswordConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         # Init celery
         self.msg_relay = MsgRelay(config)

--- a/src/eduid/webapp/samleid/app.py
+++ b/src/eduid/webapp/samleid/app.py
@@ -19,7 +19,6 @@ class SamlEidApp(AuthnBaseApp[SamlEidConfig]):
     def __init__(self, config: SamlEidConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 

--- a/src/eduid/webapp/security/app.py
+++ b/src/eduid/webapp/security/app.py
@@ -20,7 +20,6 @@ class SecurityApp(AuthnBaseApp[SecurityConfig]):
     def __init__(self, config: SecurityConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         self.am_relay = AmRelay(config)
         self.msg_relay = MsgRelay(config)

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -632,9 +632,7 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
         assert data["payload"]["error"]["csrf_token"] == ["CSRF failed to validate"]
 
     def test_authenticator_information(self, mocker: MockerFixture) -> None:
-        mocker.patch(
-            "fido_mds.FidoMetadataStore.verify_attestation", _apple_special_verify_attestation
-        )
+        mocker.patch("fido_mds.FidoMetadataStore.verify_attestation", _apple_special_verify_attestation)
         authenticators = [YUBIKEY_4, YUBIKEY_5_NFC, MICROSOFT_SURFACE_1796, NEXUS_5, IPHONE_12, NONE_ATTESTATION]
         for authenticator in authenticators:
             self.app.logger.debug(f"Testing authenticator: {authenticator}")

--- a/src/eduid/webapp/signup/app.py
+++ b/src/eduid/webapp/signup/app.py
@@ -21,7 +21,6 @@ class SignupApp(EduIDBaseApp[SignupConfig]):
     def __init__(self, config: SignupConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         self.am_relay = AmRelay(config)
 

--- a/src/eduid/webapp/support/app.py
+++ b/src/eduid/webapp/support/app.py
@@ -19,7 +19,6 @@ class SupportApp(EduIDBaseApp[SupportConfig]):
     def __init__(self, config: SupportConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
 
         self.support_user_db = db.SupportUserDB(config.mongo_uri)
         self.support_authn_db = db.SupportAuthnInfoDB(config.mongo_uri)

--- a/src/eduid/webapp/svipe_id/app.py
+++ b/src/eduid/webapp/svipe_id/app.py
@@ -19,7 +19,6 @@ class SvipeIdApp(AuthnBaseApp[SvipeIdConfig]):
     def __init__(self, config: SvipeIdConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
         # Init dbs
         self.private_userdb = SvideIDProofingUserDB(self.conf.mongo_uri, auto_expire=config.private_userdb_auto_expire)
         self.proofing_log = ProofingLog(config.mongo_uri)

--- a/src/eduid/workers/am/ams/common.py
+++ b/src/eduid/workers/am/ams/common.py
@@ -31,7 +31,7 @@ class AttributeFetcher(ABC):
 
     @classmethod
     @abstractmethod
-    def get_user_db(cls, uri: str) -> UserDB:
+    def get_user_db(cls, uri: str) -> UserDB[Any]:
         """
         return an instance of the subclass of eduid.userdb.userdb.UserDB
         corresponding to the database holding the data to be fetched.


### PR DESCRIPTION
# Fix bare generic type-arg errors, enable ruff B009, promote typecheck to strict

## Summary

- Fix all 7 remaining `[type-arg]` mypy strict errors (bare generic type parameters)
- Assign `self.conf = config` in `EduIDBaseApp.__init__`; remove redundant assignment from 20 subclasses
- Replace `getattr(app, "conf")` and `getattr(app, "central_userdb")` with direct attribute access
- Enable ruff rule B009 (do not use `getattr` with constant string attribute)
- Promote `make typecheck` to run in strict mode — strict is now the enforced baseline

## Why

### `[type-arg]`

`EduIDBaseApp` is already generic (`EduIDBaseApp[C: EduIDBaseAppConfig]`), but shared
functions and test base classes declared bare `EduIDBaseApp` as a type annotation, which
mypy strict flags as `[type-arg]`. The invariance problem prevents using
`EduIDBaseApp[EduIDBaseAppConfig]` as a bound (subclasses with more specific configs would
be rejected), so `EduIDBaseApp[Any]` is the correct pragmatic fix. Same pattern applied
to `UserDB[Any]` on the abstract `AttributeFetcher.get_user_db` return type.

### B009

With `EduIDBaseApp[Any]` properly typed, `app.conf` is now a valid direct access and
`getattr(app, "conf")` is needlessly indirect. 11 `conf` call sites replaced, plus
`central_userdb` (a base class property). Four `getattr` calls on `proofing_log` and
`private_userdb` remain — these attributes are not on `EduIDBaseApp` and vary by app
subclass; they carry `# noqa: B009` with an explanatory comment pending a Protocol-based
fix.

### Strict baseline

Both `typecheck` and `typecheck_strict` were clean before this PR. `make typecheck` now
runs with `--strict` flags directly; `typecheck_strict` becomes an alias for backwards
compatibility. The `$(info ...)` banner noting strict was "not enforced" is removed.

## Changes

| File | Change |
|---|---|
| `webapp/common/api/app.py` | `init_status_views` arg: bare `EduIDBaseApp` → `EduIDBaseApp[Any]`; assign `self.conf = config` in `__init__` |
| `webapp/*/app.py` (20 files) | Remove redundant `self.conf = config` now owned by base class |
| `webapp/common/api/translation.py` | `init_babel` arg: same; `getattr conf` → `app.conf` (×2) |
| `webapp/common/session/eduid_session.py` | `EduidSession.__init__` arg: same; `getattr conf` → `app.conf` |
| `webapp/common/api/checks.py` | `get_current_app`: cast before `.conf`; `check_redis`/`check_vccs`: `getattr conf` → `.conf` |
| `webapp/common/authn/utils.py` | `getattr conf` → `current_app.conf` |
| `webapp/common/api/testing.py` | `EduidAPITestCase[T: EduIDBaseApp[Any]]`; `getattr conf` → `.conf` (×3); `noqa: B009` on `proofing_log`/`private_userdb` (×3) |
| `webapp/common/proofing/testing.py` | `ProofingTests[T: EduIDBaseApp[Any]]`; `getattr conf` → `.conf`; `getattr central_userdb` → `.central_userdb`; `noqa: B009` on `proofing_log`; drop unused `AmDB` import |
| `workers/am/ams/common.py` | `get_user_db` return: bare `UserDB` → `UserDB[Any]` |
| `webapp/common/api/tests/test_inputs.py` | `InputsTests(EduidAPITestCase[Any])` — concrete type deferred, pre-existing `dispatch_request()` return union issues |
| `ruff.toml` | Remove `B009` from `ignore` |
| `Makefile` | `typecheck` runs strict flags; `typecheck_strict` is now an alias |

## Strict mypy result

`Success: no issues found in 811 source files`

## Deferred

- Protocol fix for `proofing_log`/`private_userdb` (`# noqa: B009` for now)
- `InputsTests` with concrete `EduidAPITestCase[InputsTestApp]` (blocked on `dispatch_request()` return type narrowing)
- `save_and_sync_user` bounded TypeVar to remove 3 × `type: ignore[arg-type]`
- `make typecheck` flag audit (`--allow-untyped-calls`, `--implicit-reexport`, `--check-untyped-defs`)
