### PR TITLE
Remove redundant self.conf assignments; tighten InputsTests typing

### DIFF
--- a/src/eduid/webapp/authn/app.py
+++ b/src/eduid/webapp/authn/app.py
@@ -13,7 +13,6 @@ class AuthnApp(EduIDBaseApp[AuthnConfig]):
     def __init__(self, config: AuthnConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 
 

--- a/src/eduid/webapp/authn/tests/test_authn.py
+++ b/src/eduid/webapp/authn/tests/test_authn.py
@@ -306,7 +306,6 @@ class AuthnAPITestCase(AuthnAPITestBase):
 class AuthnTestApp(AuthnBaseApp[AuthnConfig]):
     def __init__(self, config: AuthnConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
-        self.conf = config
 
 
 class UnAuthnAPITestCase(EduidAPITestCase[AuthnTestApp]):

--- a/src/eduid/webapp/bankid/app.py
+++ b/src/eduid/webapp/bankid/app.py
@@ -19,7 +19,6 @@ class BankIDApp(AuthnBaseApp[BankIDConfig]):
     def __init__(self, config: BankIDConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 
         # Init dbs

--- a/src/eduid/webapp/common/api/tests/test_backdoor.py
+++ b/src/eduid/webapp/common/api/tests/test_backdoor.py
@@ -39,8 +39,6 @@ class BackdoorTestApp(EduIDBaseApp[BackdoorTestConfig]):
     def __init__(self, config: BackdoorTestConfig) -> None:
         super().__init__(config)
 
-        self.conf = config
-
 
 class BackdoorTests(EduidAPITestCase[BackdoorTestApp]):
     @pytest.fixture(autouse=True)

--- a/src/eduid/webapp/common/api/tests/test_decorators.py
+++ b/src/eduid/webapp/common/api/tests/test_decorators.py
@@ -23,8 +23,6 @@ class DecoratorTestApp(EduIDBaseApp[DecoratorTestConfig]):
     def __init__(self, config: DecoratorTestConfig) -> None:
         super().__init__(config)
 
-        self.conf = config
-
 
 test_views = flask.Blueprint("test", __name__, url_prefix="/test")
 

--- a/src/eduid/webapp/common/api/tests/test_inputs.py
+++ b/src/eduid/webapp/common/api/tests/test_inputs.py
@@ -108,9 +108,6 @@ def values_view() -> Response:
 class InputsTestApp(EduIDBaseApp[EduIDBaseAppConfig]):
     def __init__(self, config: EduIDBaseAppConfig) -> None:
         super().__init__(config)
-
-        self.conf = config
-
         self.session_interface = SessionFactory(config)
 
 

--- a/src/eduid/webapp/common/api/tests/test_inputs.py
+++ b/src/eduid/webapp/common/api/tests/test_inputs.py
@@ -111,7 +111,7 @@ class InputsTestApp(EduIDBaseApp[EduIDBaseAppConfig]):
         self.session_interface = SessionFactory(config)
 
 
-class InputsTests(EduidAPITestCase[Any]):
+class InputsTests(EduidAPITestCase[InputsTestApp]):
     def load_app(self, config: Mapping[str, Any]) -> InputsTestApp:
         """
         Called from the parent class, so we can provide the appropriate flask
@@ -126,24 +126,28 @@ class InputsTests(EduidAPITestCase[Any]):
         url = "/test-get-param?test-param=test-param"
         with self.app.test_request_context(url, method="GET"):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"test-param" in response.data
 
     def test_get_param_script(self) -> None:
         url = '/test-get-param?test-param=<script>alert("ho")</script>'
         with self.app.test_request_context(url, method="GET"):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_get_param_script_percent_encoded(self) -> None:
         url = "/test-get-param?test-param=%3Cscript%3Ealert%28%22ho%22%29%3C%2Fscript%3E"
         with self.app.test_request_context(url, method="GET"):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_get_param_script_percent_encoded_twice(self) -> None:
         url = "/test-get-param?test-param=%253Cscript%253Ealert%2528%2522ho%2522%2529%253C%252Fscript%253E"
         with self.app.test_request_context(url, method="GET"):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             unquoted_response = unquote(response.data.decode("utf8"))
             assert b"<script>" not in response.data
             assert "<script>" not in unquoted_response
@@ -152,6 +156,7 @@ class InputsTests(EduidAPITestCase[Any]):
         url = "/test-get-param?test-param=åäöхэжこんにちわ"
         with self.app.test_request_context(url, method="GET"):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert "åäöхэжこんにちわ" in response.data.decode("utf8")
 
     def test_get_param_unicode_percent_encoded(self) -> None:
@@ -161,12 +166,14 @@ class InputsTests(EduidAPITestCase[Any]):
         )
         with self.app.test_request_context(url, method="GET"):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert "åäöхэжこんにちわ" in response.data.decode("utf8")
 
     def test_post_param_script(self) -> None:
         url = "/test-post-param"
         with self.app.test_request_context(url, method="POST", data={"test-param": '<script>alert("ho")</script>'}):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_post_param_script_percent_encoded(self) -> None:
@@ -175,6 +182,7 @@ class InputsTests(EduidAPITestCase[Any]):
             url, method="POST", data={"test-param": "%3Cscript%3Ealert%28%22ho%22%29%3C%2Fscript%3E"}
         ):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_post_param_script_percent_encoded_twice(self) -> None:
@@ -183,6 +191,7 @@ class InputsTests(EduidAPITestCase[Any]):
             url, method="POST", data={"test-param": b"%253Cscript%253Ealert%2528%2522ho%2522%2529%253C%252Fscript%253E"}
         ):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             unquoted_response = unquote(response.data.decode("ascii"))
             assert b"<script>" not in response.data
             assert "<script>" not in unquoted_response
@@ -213,6 +222,7 @@ class InputsTests(EduidAPITestCase[Any]):
         cookie = dump_cookie("test-cookie", '<script>alert("ho")</script>')
         with self.app.test_request_context(url, method="GET", headers={"Cookie": cookie}):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_header_script(self) -> None:
@@ -220,18 +230,21 @@ class InputsTests(EduidAPITestCase[Any]):
         script = '<script>alert("ho")</script>'
         with self.app.test_request_context(url, method="GET", headers={"X-TEST": script}):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_get_values_script(self) -> None:
         url = "/test-values?test-param=test-param"
         with self.app.test_request_context(url, method="GET"):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_post_values_script(self) -> None:
         url = "/test-values"
         with self.app.test_request_context(url, method="POST", data={"test-param": '<script>alert("ho")</script>'}):
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert b"<script>" not in response.data
 
     def test_get_using_empty_session(self) -> None:
@@ -244,6 +257,7 @@ class InputsTests(EduidAPITestCase[Any]):
             # This state should be treated in the same way as no session
             # instead of crashing.
             response = self.app.dispatch_request()
+            assert isinstance(response, Response)
             assert response.data == b"<html><body></body></html>"
 
     @staticmethod

--- a/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
+++ b/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
@@ -54,8 +54,6 @@ class MockFidoApp(EduIDBaseApp[MockFidoConfig]):
     def __init__(self, config: MockFidoConfig) -> None:
         super().__init__(config)
 
-        self.conf = config
-
 
 # These values were extracted from a working webauthn login in our development environment.
 #

--- a/src/eduid/webapp/common/session/tests/test_eduid_session.py
+++ b/src/eduid/webapp/common/session/tests/test_eduid_session.py
@@ -23,8 +23,6 @@ class SessionTestApp(AuthnBaseApp[SessionTestConfig]):
     def __init__(self, config: SessionTestConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-        self.conf = config
-
 
 def session_init_app(name: str, test_config: Mapping[str, Any]) -> SessionTestApp:
     config = load_config(typ=SessionTestConfig, app_name=name, ns="webapp", test_config=test_config)

--- a/src/eduid/webapp/eidas/app.py
+++ b/src/eduid/webapp/eidas/app.py
@@ -19,7 +19,6 @@ class EidasApp(AuthnBaseApp[EidasConfig]):
     def __init__(self, config: EidasConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 
         # Init dbs

--- a/src/eduid/webapp/email/app.py
+++ b/src/eduid/webapp/email/app.py
@@ -16,7 +16,6 @@ class EmailApp(AuthnBaseApp[EmailConfig]):
     def __init__(self, config: EmailConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init celery
         self.am_relay = AmRelay(config)
 

--- a/src/eduid/webapp/group_management/app.py
+++ b/src/eduid/webapp/group_management/app.py
@@ -19,7 +19,6 @@ class GroupManagementApp(AuthnBaseApp[GroupManagementConfig]):
     def __init__(self, config: GroupManagementConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init dbs
         self.invite_state_db = GroupManagementInviteStateDB(config.mongo_uri)
         _owner = config.scim_data_owner.replace(

--- a/src/eduid/webapp/idp/app.py
+++ b/src/eduid/webapp/idp/app.py
@@ -25,7 +25,6 @@ class IdPApp(EduIDBaseApp[IdPConfig]):
     def __init__(self, config: IdPConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Initiate external modules
         self.babel = translation.init_babel(self)
 

--- a/src/eduid/webapp/jsconfig/app.py
+++ b/src/eduid/webapp/jsconfig/app.py
@@ -16,7 +16,6 @@ class JSConfigApp(EduIDBaseApp[JSConfigConfig]):
         super().__init__(config, **kwargs)
 
 
-
 current_jsconfig_app: JSConfigApp = cast(JSConfigApp, current_app)
 
 

--- a/src/eduid/webapp/ladok/app.py
+++ b/src/eduid/webapp/ladok/app.py
@@ -18,7 +18,6 @@ class LadokApp(AuthnBaseApp[LadokConfig]):
     def __init__(self, config: LadokConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init dbs
         self.private_userdb = LadokProofingUserDB(config.mongo_uri, auto_expire=config.private_userdb_auto_expire)
         self.proofing_log = ProofingLog(config.mongo_uri)

--- a/src/eduid/webapp/letter_proofing/app.py
+++ b/src/eduid/webapp/letter_proofing/app.py
@@ -20,7 +20,6 @@ class LetterProofingApp(AuthnBaseApp[LetterProofingConfig]):
     def __init__(self, config: LetterProofingConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init dbs
         self.private_userdb = LetterProofingUserDB(config.mongo_uri, auto_expire=config.private_userdb_auto_expire)
         self.proofing_statedb = LetterProofingStateDB(config.mongo_uri, auto_expire=config.state_db_auto_expire)

--- a/src/eduid/webapp/lookup_mobile_proofing/app.py
+++ b/src/eduid/webapp/lookup_mobile_proofing/app.py
@@ -19,7 +19,6 @@ class MobileProofingApp(AuthnBaseApp[MobileProofingConfig]):
     def __init__(self, config: MobileProofingConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init dbs
         self.private_userdb = LookupMobileProofingUserDB(
             config.mongo_uri, auto_expire=config.private_userdb_auto_expire

--- a/src/eduid/webapp/orcid/app.py
+++ b/src/eduid/webapp/orcid/app.py
@@ -18,7 +18,6 @@ class OrcidApp(AuthnBaseApp[OrcidConfig]):
     def __init__(self, config: OrcidConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init dbs
         self.private_userdb = OrcidProofingUserDB(config.mongo_uri, auto_expire=config.private_userdb_auto_expire)
         self.proofing_statedb = OrcidProofingStateDB(config.mongo_uri, auto_expire=config.state_db_auto_expire)

--- a/src/eduid/webapp/personal_data/app.py
+++ b/src/eduid/webapp/personal_data/app.py
@@ -14,7 +14,6 @@ class PersonalDataApp(AuthnBaseApp[PersonalDataConfig]):
     def __init__(self, config: PersonalDataConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init celery
         self.am_relay = AmRelay(config)
 

--- a/src/eduid/webapp/phone/app.py
+++ b/src/eduid/webapp/phone/app.py
@@ -18,7 +18,6 @@ class PhoneApp(AuthnBaseApp[PhoneConfig]):
     def __init__(self, config: PhoneConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init celery
         self.am_relay = AmRelay(config)
         self.msg_relay = MsgRelay(config)

--- a/src/eduid/webapp/reset_password/app.py
+++ b/src/eduid/webapp/reset_password/app.py
@@ -21,7 +21,6 @@ class ResetPasswordApp(EduIDBaseApp[ResetPasswordConfig]):
     def __init__(self, config: ResetPasswordConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         # Init celery
         self.msg_relay = MsgRelay(config)
         self.am_relay = AmRelay(config)

--- a/src/eduid/webapp/samleid/app.py
+++ b/src/eduid/webapp/samleid/app.py
@@ -19,7 +19,6 @@ class SamlEidApp(AuthnBaseApp[SamlEidConfig]):
     def __init__(self, config: SamlEidConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         self.saml2_config = get_saml2_config(config.saml2_settings_module)
 
         # Init dbs

--- a/src/eduid/webapp/security/app.py
+++ b/src/eduid/webapp/security/app.py
@@ -20,7 +20,6 @@ class SecurityApp(AuthnBaseApp[SecurityConfig]):
     def __init__(self, config: SecurityConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         self.am_relay = AmRelay(config)
         self.msg_relay = MsgRelay(config)
 

--- a/src/eduid/webapp/signup/app.py
+++ b/src/eduid/webapp/signup/app.py
@@ -21,7 +21,6 @@ class SignupApp(EduIDBaseApp[SignupConfig]):
     def __init__(self, config: SignupConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         self.am_relay = AmRelay(config)
 
         self.captcha = init_captcha(config)

--- a/src/eduid/webapp/support/app.py
+++ b/src/eduid/webapp/support/app.py
@@ -19,7 +19,6 @@ class SupportApp(EduIDBaseApp[SupportConfig]):
     def __init__(self, config: SupportConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 
-
         self.support_user_db = db.SupportUserDB(config.mongo_uri)
         self.support_authn_db = db.SupportAuthnInfoDB(config.mongo_uri)
         self.support_proofing_log_db = db.SupportProofingLogDB(config.mongo_uri)


### PR DESCRIPTION
# Remove redundant self.conf assignments; tighten InputsTests typing

## Summary

- Remove redundant `self.conf = config` from all app subclasses — now owned by `EduIDBaseApp.__init__`
- Fix `InputsTests` to use concrete `EduidAPITestCase[InputsTestApp]` instead of `[Any]`

## Why

### `self.conf` redundancy

A previous PR added `self.conf = config` to `EduIDBaseApp.__init__`. All concrete app
subclasses had been doing this themselves — now that the base class owns it, the
subclass assignments are pure repetition.

### `InputsTests` typing

`EduidAPITestCase[Any]` was a workaround: using `EduidAPITestCase[InputsTestApp]`
tightened `self.app` to `InputsTestApp`, which exposed `dispatch_request()` returning
the broad `ResponseReturnValue` union while tests accessed `.data` directly. Fixed by
adding `assert isinstance(response, Response)` after each call — accurate since all
routes in the file return `Response`, and adds runtime validation.

## Changes

| File | Change |
|---|---|
| `webapp/*/app.py` (18 files) | Remove redundant `self.conf = config` |
| `webapp/common/api/tests/test_backdoor.py` | Same |
| `webapp/common/api/tests/test_decorators.py` | Same |
| `webapp/authn/tests/test_authn.py` | Same |
| `webapp/common/authn/tests/test_fido_tokens.py` | Same |
| `webapp/common/session/tests/test_eduid_session.py` | Same |
| `webapp/common/api/tests/test_inputs.py` | `EduidAPITestCase[InputsTestApp]`; `assert isinstance(response, Response)` at 14 `dispatch_request()` call sites; remove redundant `self.conf` |
