### PR TITLE
Use bounded TypeVar for save_and_sync_user, remove arg-type ignores

### DIFF
--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -129,8 +129,8 @@ def has_user_logged_in_with_mfa() -> bool:
     return False
 
 
-def save_and_sync_user(
-    user: User, private_userdb: UserDB[User] | None = None, app_name_override: str | None = None
+def save_and_sync_user[U: User](
+    user: U, private_userdb: UserDB[U] | None = None, app_name_override: str | None = None
 ) -> bool:
     """
     Save (new) user object to the private userdb and propagate the changes to the central user db.

--- a/src/eduid/webapp/idp/tests/test_idPUserDb.py
+++ b/src/eduid/webapp/idp/tests/test_idPUserDb.py
@@ -214,7 +214,7 @@ class TestPasswordV2Upgrade(IdPAPITests):
             credential_user = CredentialUser.from_user(pwauth.user, self.app.credential_db)
             save_and_sync_user(
                 credential_user,
-                private_userdb=self.app.credential_db,  # type: ignore[arg-type]
+                private_userdb=self.app.credential_db,
                 app_name_override="eduid_idp",
             )
 

--- a/src/eduid/webapp/idp/views/pw_auth.py
+++ b/src/eduid/webapp/idp/views/pw_auth.py
@@ -70,7 +70,7 @@ def pw_auth(
         try:
             save_and_sync_user(
                 credential_user,
-                private_userdb=current_app.credential_db,  # type: ignore[arg-type]
+                private_userdb=current_app.credential_db,
                 app_name_override="eduid_idp",
             )
             current_app.logger.info(f"Saved credential changes for user {pwauth.user}")

--- a/src/eduid/webapp/idp/views/tou.py
+++ b/src/eduid/webapp/idp/views/tou.py
@@ -68,7 +68,7 @@ def tou(
         try:
             res = save_and_sync_user(
                 tou_user,
-                private_userdb=current_app.tou_db,  # type: ignore[arg-type]
+                private_userdb=current_app.tou_db,
                 app_name_override="eduid_tou",
             )
         except UserOutOfSync:


### PR DESCRIPTION
# Use bounded TypeVar for save_and_sync_user, remove arg-type ignores

## Summary

Make `save_and_sync_user` generic over its user type, removing three pre-existing
`type: ignore[arg-type]` suppressions.

## Why

`save_and_sync_user` declared `private_userdb: UserDB[User]`, but callers pass
`UserDB[ToUUser]` and `UserDB[CredentialUser]`. These are incompatible due to generic
invariance, requiring `# type: ignore[arg-type]` at each call site.

A bounded TypeVar threads the user type through both parameters, making the types
line up without touching the call sites:

```python
def save_and_sync_user[U: User](
    user: U, private_userdb: UserDB[U] | None = None, ...
) -> bool:
```

When called with `(tou_user, private_userdb=current_app.tou_db)`, mypy infers
`U = ToUUser` and verifies that `ToUUserDB` (`UserDB[ToUUser]`) satisfies `UserDB[U]`.

## Changes

| File | Change |
|---|---|
| `webapp/common/api/utils.py` | `save_and_sync_user[U: User]`; `private_userdb: UserDB[U]` |
| `webapp/idp/views/tou.py` | Remove `# type: ignore[arg-type]` |
| `webapp/idp/views/pw_auth.py` | Remove `# type: ignore[arg-type]` |
| `webapp/idp/tests/test_idPUserDb.py` | Remove `# type: ignore[arg-type]` |
