### PR TITLE
continue auth flow after signup

### DIFF
--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -188,6 +188,7 @@ class Signup(TimestampedNS):
     tou: Tou = Field(default_factory=Tou)
     captcha: Captcha = Field(default_factory=Captcha)
     credentials: Credentials = Field(default_factory=Credentials)
+    idp_request_ref: RequestRef | None = None
 
 
 class Phone(SessionNSBase):

--- a/src/eduid/webapp/idp/app.py
+++ b/src/eduid/webapp/idp/app.py
@@ -87,6 +87,7 @@ def init_idp_app(name: str = "idp", test_config: Mapping[str, Any] | None = None
     from eduid.webapp.idp.views.next import next_views
     from eduid.webapp.idp.views.pw_auth import pw_auth_views
     from eduid.webapp.idp.views.saml import saml_views
+    from eduid.webapp.idp.views.signup_auth import signup_auth_views
     from eduid.webapp.idp.views.tou import tou_views
     from eduid.webapp.idp.views.use_other import other_device_views
 
@@ -97,6 +98,7 @@ def init_idp_app(name: str = "idp", test_config: Mapping[str, Any] | None = None
     app.register_blueprint(other_device_views)
     app.register_blueprint(pw_auth_views)
     app.register_blueprint(saml_views)
+    app.register_blueprint(signup_auth_views)
     app.register_blueprint(tou_views)
     app.register_blueprint(error_info_views)
 

--- a/src/eduid/webapp/idp/schemas.py
+++ b/src/eduid/webapp/idp/schemas.py
@@ -52,6 +52,10 @@ class NextResponseSchema(FluxStandardAction):
     payload = fields.Nested(NextResponsePayload)
 
 
+class SignupAuthRequestSchema(IdPRequest):
+    pass
+
+
 class PwAuthRequestSchema(IdPRequest):
     username = fields.Str(required=False)
     password = fields.Str(required=True)

--- a/src/eduid/webapp/idp/settings/common.py
+++ b/src/eduid/webapp/idp/settings/common.py
@@ -93,6 +93,9 @@ class IdPConfig(EduIDBaseAppConfig, TouConfigMixin, Fido2RpConfigMixin, AmConfig
     other_device_logins_ttl: timedelta = Field(default=timedelta(minutes=2))
     other_device_max_code_attempts: int = 3
     other_device_secret_key: str  # secretbox key for protecting the login-with-other-device shared ID
+    allow_new_signup_logins: bool = False
+    # How long after signup the IdP will trust the signup as authentication (skip re-auth)
+    new_signup_authn_lifetime: timedelta = Field(default=timedelta(seconds=300))
     # SPs that are allowed to request a login for a particular user (idpproxy for stepup, dashboard for chpass, ...)
     request_subject_allowed_entity_ids: list[str] = Field(default=[])
     known_devices_secret_key: str  # secretbox key for decrypting the data stored in the browser local storage

--- a/src/eduid/webapp/idp/tests/test_login.py
+++ b/src/eduid/webapp/idp/tests/test_login.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from datetime import datetime, timedelta
@@ -18,9 +19,17 @@ from eduid.userdb.mail import MailAddressList
 from eduid.vccs.client import VCCSClient
 from eduid.webapp.common.api.testing import CSRFTestClient
 from eduid.webapp.common.authn.utils import get_saml2_config
+from eduid.webapp.common.session.namespaces import LoginApplication, RequestRef
 from eduid.webapp.idp.helpers import IdPAction, IdPMsg
 from eduid.webapp.idp.other_device.data import OtherDeviceState
-from eduid.webapp.idp.tests.test_api import FinishedResultAPI, IdPAPITests, PwAuthResult, TestUser
+from eduid.webapp.idp.tests.test_api import (
+    FinishedResultAPI,
+    IdPAPITests,
+    LoginResultAPI,
+    NextResult,
+    PwAuthResult,
+    TestUser,
+)
 from eduid.workers.am import AmCelerySingleton
 
 logger = logging.getLogger(__name__)
@@ -1028,3 +1037,143 @@ class IdPTestLoginAPIManagedAccounts(IdPAPITests):
         assert "login request could not be processed" in response_text, (
             f"Expected error message in response: {response_text}"
         )
+
+
+class IdPTestNewSignup(IdPAPITests):
+    """Tests for the /signup_auth endpoint and its integration with /next."""
+
+    @pytest.fixture(scope="class")
+    def update_config(self) -> dict[str, Any]:
+        config = self._get_base_config()
+        config["allow_new_signup_logins"] = True
+        return config
+
+    def _get_ref(
+        self,
+        force_authn: bool = False,
+        authn_context: dict[str, Any] | None = None,
+    ) -> str:
+        """Create a SAML AuthnRequest and return the login ref."""
+        _ref_result = self._get_login_ref(
+            device=self.browser,
+            saml2_client=self.saml2_client,
+            authn_context=authn_context,
+            force_authn=force_authn,
+            assertion_consumer_service_url=None,
+        )
+        assert not isinstance(_ref_result, LoginResultAPI), f"Failed to get login ref: {_ref_result}"
+        ref, _resp = _ref_result
+        return ref
+
+    def _setup_signup_session(
+        self,
+        client: CSRFTestClient,
+        ref: str,
+        eppn: str,
+        user_created_at: datetime | None = None,
+        idp_request_ref: str | None = None,
+        login_source: LoginApplication | None = LoginApplication.signup,
+    ) -> None:
+        """Set signup session state on the client session."""
+        if user_created_at is None:
+            user_created_at = utc_now()
+        if idp_request_ref is None:
+            idp_request_ref = ref
+
+        with client.session_transaction() as sess:
+            sess.signup.user_created = True
+            sess.signup.user_created_at = user_created_at
+            if idp_request_ref is not None:
+                sess.signup.idp_request_ref = RequestRef(idp_request_ref)
+            sess.common.eppn = eppn
+            if login_source is not None:
+                sess.common.login_source = login_source
+
+    def _call_signup_auth(self, client: CSRFTestClient, ref: str) -> NextResult:
+        """Call /signup_auth with the given ref."""
+        with self.app.test_request_context():
+            with client.session_transaction() as sess:
+                data = {"ref": ref, "csrf_token": sess.get_csrf_token()}
+            response = client.post("/signup_auth", data=json.dumps(data), content_type=self.content_type_json)
+
+        logger.debug(f"signup_auth returned:\n{json.dumps(response.json, indent=4)}")
+        if response.is_json:
+            assert response.json is not None
+            if response.json.get("error"):
+                return NextResult(payload=self.get_response_payload(response), error=response.json)
+        return NextResult(payload=self.get_response_payload(response))
+
+    def _call_next(self, client: CSRFTestClient, ref: str) -> NextResult:
+        """Call /next with the given ref."""
+        with self.app.test_request_context():
+            with client.session_transaction() as sess:
+                data = {"ref": ref, "csrf_token": sess.get_csrf_token()}
+            response = client.post("/next", data=json.dumps(data), content_type=self.content_type_json)
+
+        logger.debug(f"Next endpoint returned:\n{json.dumps(response.json, indent=4)}")
+        if response.is_json:
+            assert response.json is not None
+            if response.json.get("error"):
+                return NextResult(payload=self.get_response_payload(response), error=response.json)
+        return NextResult(payload=self.get_response_payload(response))
+
+    def test_new_signup_accepted(self) -> None:
+        """signup_auth creates SSO session, then /next returns SAML response."""
+        self.add_test_user_tou()
+        ref = self._get_ref()
+
+        with self.session_cookie_anon(self.browser) as client:
+            self._setup_signup_session(client, ref=ref, eppn=self.test_user.eppn)
+
+            # Step 1: /signup_auth creates SSO session + sets cookie
+            auth_result = self._call_signup_auth(client, ref)
+            assert auth_result.error is None, f"signup_auth error: {auth_result.error}"
+            assert auth_result.payload.get("finished") is True
+
+            # Step 2: /next finds SSO session and returns SAML response
+            next_result = self._call_next(client, ref)
+            assert next_result.error is None, f"next error: {next_result.error}"
+            assert next_result.payload.get("action") == IdPAction.FINISHED.value
+            assert "SAMLResponse" in next_result.payload.get("parameters", {})
+
+    def test_new_signup_expired(self) -> None:
+        """Signup that is too old should be rejected by /signup_auth."""
+        self.add_test_user_tou()
+        ref = self._get_ref()
+
+        with self.session_cookie_anon(self.browser) as client:
+            self._setup_signup_session(
+                client, ref=ref, eppn=self.test_user.eppn, user_created_at=utc_now() - timedelta(minutes=10)
+            )
+            auth_result = self._call_signup_auth(client, ref)
+            assert auth_result.error is not None
+
+    def test_new_signup_force_authn(self) -> None:
+        """ForceAuthn should cause /signup_auth to reject."""
+        self.add_test_user_tou()
+        ref = self._get_ref(force_authn=True)
+
+        with self.session_cookie_anon(self.browser) as client:
+            self._setup_signup_session(client, ref=ref, eppn=self.test_user.eppn)
+            auth_result = self._call_signup_auth(client, ref)
+            assert auth_result.error is not None
+
+    def test_new_signup_wrong_ref(self) -> None:
+        """Mismatched idp_request_ref should cause /signup_auth to reject."""
+        self.add_test_user_tou()
+        ref = self._get_ref()
+
+        with self.session_cookie_anon(self.browser) as client:
+            self._setup_signup_session(client, ref=ref, eppn=self.test_user.eppn, idp_request_ref="wrong-ref")
+            auth_result = self._call_signup_auth(client, ref)
+            assert auth_result.error is not None
+
+    def test_new_signup_no_login_source(self) -> None:
+        """Without login_source=signup, /signup_auth should reject."""
+        self.add_test_user_tou()
+        ref = self._get_ref()
+
+        with self.session_cookie_anon(self.browser) as client:
+            self._setup_signup_session(client, ref=ref, eppn=self.test_user.eppn, login_source=None)
+            auth_result = self._call_signup_auth(client, ref)
+            assert auth_result.error is not None

--- a/src/eduid/webapp/idp/views/signup_auth.py
+++ b/src/eduid/webapp/idp/views/signup_auth.py
@@ -38,7 +38,7 @@ def signup_auth(ticket: LoginContext, sso_session: SSOSession | None) -> FluxDat
 
     if not current_app.conf.allow_new_signup_logins:
         current_app.logger.info("New signup logins are not enabled")
-        return error_response(message=IdPMsg.not_available)
+        return error_response(message=IdPMsg.must_authenticate)
 
     if session.common.login_source != LoginApplication.signup:
         current_app.logger.info("login_source is not signup")

--- a/src/eduid/webapp/idp/views/signup_auth.py
+++ b/src/eduid/webapp/idp/views/signup_auth.py
@@ -1,0 +1,130 @@
+from flask import Blueprint, jsonify, request
+from werkzeug.wrappers import Response as WerkzeugResponse
+
+from eduid.common.misc.timeutil import utc_now
+from eduid.userdb.credentials import FidoCredential
+from eduid.userdb.idp import IdPUser
+from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith
+from eduid.webapp.common.api.messages import FluxData, error_response
+from eduid.webapp.common.api.schemas.models import FluxSuccessResponse
+from eduid.webapp.common.session import session
+from eduid.webapp.common.session.namespaces import LoginApplication
+from eduid.webapp.idp.app import current_idp_app as current_app
+from eduid.webapp.idp.decorators import require_ticket, uses_sso_session
+from eduid.webapp.idp.helpers import IdPMsg, lookup_user
+from eduid.webapp.idp.idp_authn import AuthnData, FidoAuthnData
+from eduid.webapp.idp.login_context import LoginContext, LoginContextSAML
+from eduid.webapp.idp.mischttp import set_sso_cookie
+from eduid.webapp.idp.schemas import PwAuthResponseSchema, SignupAuthRequestSchema
+from eduid.webapp.idp.sso_session import SSOSession, record_authentication
+
+__author__ = "lundberg"
+
+signup_auth_views = Blueprint("signup_auth", __name__, url_prefix="")
+
+
+@signup_auth_views.route("/signup_auth", methods=["POST"])
+@UnmarshalWith(SignupAuthRequestSchema)
+@MarshalWith(PwAuthResponseSchema)
+@require_ticket
+@uses_sso_session
+def signup_auth(ticket: LoginContext, sso_session: SSOSession | None) -> FluxData | WerkzeugResponse:
+    """Authenticate a user who just completed signup, using their signup credentials."""
+    current_app.logger.debug("\n\n")
+    current_app.logger.debug(f"--- Signup authentication ({ticket.request_ref}) ---")
+
+    if not current_app.conf.login_bundle_url:
+        return error_response(message=IdPMsg.not_available)
+
+    if not current_app.conf.allow_new_signup_logins:
+        current_app.logger.info("New signup logins are not enabled")
+        return error_response(message=IdPMsg.not_available)
+
+    if session.common.login_source != LoginApplication.signup:
+        current_app.logger.info("login_source is not signup")
+        return error_response(message=IdPMsg.must_authenticate)
+
+    if not session.common.eppn:
+        current_app.logger.info("No eppn in session")
+        return error_response(message=IdPMsg.must_authenticate)
+
+    if session.signup.user_created_at is None:
+        current_app.logger.info("No user_created_at in signup session")
+        return error_response(message=IdPMsg.must_authenticate)
+
+    if session.signup.idp_request_ref != ticket.request_ref:
+        current_app.logger.debug(
+            f"Signup idp_request_ref {session.signup.idp_request_ref} != ticket {ticket.request_ref}"
+        )
+        return error_response(message=IdPMsg.must_authenticate)
+
+    age = utc_now() - session.signup.user_created_at
+    if age > current_app.conf.new_signup_authn_lifetime:
+        current_app.logger.debug(f"New signup too old ({age} > {current_app.conf.new_signup_authn_lifetime})")
+        return error_response(message=IdPMsg.must_authenticate)
+
+    if not isinstance(ticket, LoginContextSAML):
+        return error_response(message=IdPMsg.general_failure)
+
+    if ticket.reauthn_required:
+        current_app.logger.info("SP requires ForceAuthn, not accepting new signup as authentication")
+        return error_response(message=IdPMsg.must_authenticate)
+
+    # All checks passed
+    current_app.logger.info(f"Accepting new signup as authentication for {session.common.eppn}")
+
+    user = lookup_user(session.common.eppn)
+    if not user:
+        current_app.logger.error(f"New signup user {session.common.eppn} not found")
+        return error_response(message=IdPMsg.general_failure)
+
+    # Register signup credentials on the pending request and build AuthnData list
+    _authn_credentials = _register_signup_credentials(ticket, user)
+    if not _authn_credentials:
+        current_app.logger.error("No credentials found on new signup user")
+        return error_response(message=IdPMsg.general_failure)
+
+    # Create/update SSO session
+    sso_session = record_authentication(
+        ticket, session.common.eppn, sso_session, _authn_credentials, current_app.conf.sso_session_lifetime
+    )
+    current_app.logger.debug(f"Saving SSO session {sso_session}")
+    current_app.sso_sessions.save(sso_session)
+
+    session.idp.sso_cookie_val = sso_session.session_id
+
+    current_app.logger.info(
+        f"{ticket.request_ref}: signup_auth sso_session={sso_session.public_id}, user={session.common.eppn}"
+    )
+    current_app.stats.count("login_new_signup_accepted")
+
+    _flux_response = FluxSuccessResponse(request, payload={"finished": True})
+    resp = jsonify(PwAuthResponseSchema().dump(_flux_response.to_dict()))
+
+    return set_sso_cookie(current_app.conf.sso_cookie, sso_session.session_id, resp)
+
+
+def _register_signup_credentials(ticket: LoginContext, user: IdPUser) -> list[AuthnData]:
+    """Register the user's signup credentials on the pending request and return AuthnData for the SSO session."""
+    authn_credentials: list[AuthnData] = []
+    assert session.signup.user_created_at is not None  # checked by caller
+
+    for cred in user.credentials.to_list():
+        fido_data = None
+        if isinstance(cred, FidoCredential):
+            # Use the signup session's webauthn data for user_verified if available
+            wn = session.signup.credentials.webauthn
+            fido_data = FidoAuthnData(
+                user_present=wn.user_present if wn else True,
+                user_verified=wn.user_verified if wn else False,
+            )
+
+        authn_data = AuthnData(
+            cred_id=cred.key,
+            timestamp=session.signup.user_created_at,
+            fido=fido_data,
+        )
+        session.idp.log_credential_used(ticket.request_ref, cred, authn_data)
+        authn_credentials.append(authn_data)
+
+    return authn_credentials

--- a/src/eduid/webapp/idp/views/signup_auth.py
+++ b/src/eduid/webapp/idp/views/signup_auth.py
@@ -57,7 +57,7 @@ def signup_auth(ticket: LoginContext, sso_session: SSOSession | None) -> FluxDat
 
     age = utc_now() - session.signup.user_created_at
     if age > current_app.conf.new_signup_authn_lifetime:
-        current_app.logger.debug(f"New signup too old ({age} > {current_app.conf.new_signup_authn_lifetime})")
+        current_app.logger.info(f"New signup too old ({age} > {current_app.conf.new_signup_authn_lifetime})")
         return error_response(message=IdPMsg.must_authenticate)
 
     if not isinstance(ticket, LoginContextSAML):

--- a/src/eduid/webapp/idp/views/signup_auth.py
+++ b/src/eduid/webapp/idp/views/signup_auth.py
@@ -33,9 +33,6 @@ def signup_auth(ticket: LoginContext, sso_session: SSOSession | None) -> FluxDat
     current_app.logger.debug("\n\n")
     current_app.logger.debug(f"--- Signup authentication ({ticket.request_ref}) ---")
 
-    if not current_app.conf.login_bundle_url:
-        return error_response(message=IdPMsg.not_available)
-
     if not current_app.conf.allow_new_signup_logins:
         current_app.logger.info("New signup logins are not enabled")
         return error_response(message=IdPMsg.must_authenticate)

--- a/src/eduid/webapp/idp/views/signup_auth.py
+++ b/src/eduid/webapp/idp/views/signup_auth.py
@@ -61,7 +61,8 @@ def signup_auth(ticket: LoginContext, sso_session: SSOSession | None) -> FluxDat
         return error_response(message=IdPMsg.must_authenticate)
 
     if not isinstance(ticket, LoginContextSAML):
-        return error_response(message=IdPMsg.general_failure)
+        current_app.logger.warning(f"ticket {ticket.request_ref} not a LoginContextSAML instance: {type(ticket)}")
+        return error_response(message=IdPMsg.bad_ref)
 
     if ticket.reauthn_required:
         current_app.logger.info("SP requires ForceAuthn, not accepting new signup as authentication")

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -78,6 +78,8 @@ class SignupMsg(TranslatableMsg):
     invite_not_found = "signup.invite-not-found"
     # invite already completed
     invite_already_completed = "signup.invite-already-completed"
+    # IdP request ref not found in session
+    idp_request_ref_not_found = "signup.idp-request-ref-not-found"
 
     # backwards compatibility
     # partial success registering new account

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -58,6 +58,7 @@ class SignupStatusResponse(FluxStandardAction):
             captcha = fields.Nested(Captcha, required=True)
             credentials = fields.Nested(Credentials, required=True)
             user_created = fields.Boolean(required=True)
+            idp_request_ref = fields.String(required=False, load_default=None)
 
         state = fields.Nested(State, required=True)
 
@@ -177,3 +178,7 @@ class WebauthnRegisterCompleteRequest(EduidSchema, CSRFRequestMixin):
     response = fields.Dict(required=True)
     description = fields.String(required=True)
     client_extension_results = fields.Dict(required=False, data_key="clientExtensionResults")
+
+
+class ReturnToAuthRequest(EduidSchema, CSRFRequestMixin):
+    ref = fields.String(required=True)

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -871,6 +871,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
             "name": {"given_name": None, "surname": None},
             "tou": {"completed": False, "version": "2016-v1"},
             "user_created": False,
+            "idp_request_ref": None,
         }, f"actual state is {state}"
 
     def test_get_state_initial_logged_in(self) -> None:
@@ -891,6 +892,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
             "name": {"given_name": None, "surname": None},
             "tou": {"completed": False, "version": "2016-v1"},
             "user_created": False,
+            "idp_request_ref": None,
         }, f"actual state is {state}"
 
     def test_accept_tou(self) -> None:
@@ -1431,6 +1433,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
             "name": {"given_name": "Invite", "surname": "Invitesson"},
             "tou": {"completed": False, "version": "2016-v1"},
             "user_created": False,
+            "idp_request_ref": None,
         }, f"Actual state {normalised_data(state, exclude_keys=['expires_time_left', 'throttle_time_left', 'sent_at'])}"
 
     def test_complete_invite_new_user(self) -> None:

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -1557,3 +1557,79 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         client2 = self.app.get_scim_client_for("owner_b")
         assert not client2.is_closed
         assert client1 is not client2
+
+    def test_return_to_auth(self) -> None:
+        """Happy path: store a pending IdP request ref in session."""
+        from eduid.webapp.common.session.namespaces import IdP_SAMLPendingRequest, RequestRef
+
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with self.app.test_request_context():
+                endpoint = url_for("signup.return_to_auth")
+                with client.session_transaction() as sess:
+                    sess.idp.pending_requests[RequestRef("test-ref")] = IdP_SAMLPendingRequest(
+                        request="<fake-saml-request>",
+                        binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                        relay_state="https://sp.example.com",
+                    )
+                    data = {
+                        "ref": "test-ref",
+                        "csrf_token": sess.get_csrf_token(),
+                    }
+
+            response = client.post(endpoint, data=json.dumps(data), content_type=self.content_type_json)
+
+        self._check_api_response(
+            response,
+            status=200,
+            type_="POST_SIGNUP_RETURN_TO_AUTH_SUCCESS",
+        )
+        payload = self.get_response_payload(response)
+        assert payload["state"]["idp_request_ref"] == "test-ref"
+
+    def test_return_to_auth_invalid_ref(self) -> None:
+        """Call with a ref that doesn't exist in pending_requests."""
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with self.app.test_request_context():
+                endpoint = url_for("signup.return_to_auth")
+                with client.session_transaction() as sess:
+                    data = {
+                        "ref": "nonexistent-ref",
+                        "csrf_token": sess.get_csrf_token(),
+                    }
+
+            response = client.post(endpoint, data=json.dumps(data), content_type=self.content_type_json)
+
+        self._check_api_response(
+            response,
+            status=200,
+            type_="POST_SIGNUP_RETURN_TO_AUTH_FAIL",
+            message=SignupMsg.idp_request_ref_not_found,
+        )
+
+    def test_return_to_auth_already_created(self) -> None:
+        """Reject setting idp_request_ref when user already created."""
+        from eduid.webapp.common.session.namespaces import IdP_SAMLPendingRequest, RequestRef
+
+        with self.session_cookie(self.browser, eppn=None) as client:
+            with self.app.test_request_context():
+                endpoint = url_for("signup.return_to_auth")
+                with client.session_transaction() as sess:
+                    sess.signup.user_created = True
+                    sess.idp.pending_requests[RequestRef("test-ref")] = IdP_SAMLPendingRequest(
+                        request="<fake-saml-request>",
+                        binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                        relay_state="https://sp.example.com",
+                    )
+                    data = {
+                        "ref": "test-ref",
+                        "csrf_token": sess.get_csrf_token(),
+                    }
+
+            response = client.post(endpoint, data=json.dumps(data), content_type=self.content_type_json)
+
+        self._check_api_response(
+            response,
+            status=200,
+            type_="POST_SIGNUP_RETURN_TO_AUTH_FAIL",
+            message=SignupMsg.user_already_exists,
+        )

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -1357,6 +1357,46 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         )
         assert res.reached_state == SignupState.S6_CREATE_USER
 
+    def test_create_user_sp_flow(self) -> None:
+        """Test that when idp_request_ref is set, the signup session is preserved after create-user
+        and login_source is set to LoginApplication.signup."""
+        from eduid.webapp.common.session.namespaces import (
+            IdP_SAMLPendingRequest,
+            LoginApplication,
+            RequestRef,
+        )
+
+        given_name = "Testaren Test"
+        surname = "Test"
+        email = "test@example.com"
+        self._prepare_for_create_user(given_name=given_name, surname=surname, email=email)
+
+        # Set idp_request_ref in the signup session and add a matching pending request in idp namespace
+        with self.session_cookie_anon(self.browser) as client:
+            with client.session_transaction() as sess:
+                sess.idp.pending_requests[RequestRef("sp-ref")] = IdP_SAMLPendingRequest(
+                    request="<fake>",
+                    binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                    relay_state=None,
+                )
+                sess.signup.idp_request_ref = RequestRef("sp-ref")
+
+        response = self._create_user(expect_success=True)
+        assert response.reached_state == SignupState.S6_CREATE_USER
+
+        # Verify the response state contains idp_request_ref
+        state = self.get_response_payload(response.response)["state"]
+        assert state["idp_request_ref"] == "sp-ref"
+
+        # Verify the signup session is preserved (not deleted) and login_source is set
+        with self.session_cookie_anon(self.browser) as client:
+            with client.session_transaction() as sess:
+                assert sess.common.eppn is not None
+                assert sess.common.login_source == LoginApplication.signup
+                assert sess.signup.idp_request_ref == RequestRef("sp-ref")
+                assert sess.signup.user_created is True
+                assert sess.signup.user_created_at is not None
+
     def test_get_invite_data(self) -> None:
         invite = self._create_invite()
         primary_mail = invite.get_primary_mail_address()

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -410,14 +410,16 @@ def return_to_auth(ref: str) -> FluxData:
     return success_response(payload={"state": session.signup.to_dict()})
 
 
-def _validate_create_user(use_password: bool, use_webauthn: bool, custom_password: str | None) -> FluxData | None:
-    """Validate preconditions for user creation. Returns error response or None if valid."""
+def _check_user_not_created() -> FluxData | None:
     if session.common.eppn or session.signup.user_created:
         current_app.logger.error("User already created")
         current_app.logger.debug(f"eppn: {session.common.eppn}")
         current_app.logger.debug(f"user created: {session.signup.user_created}")
         return error_response(message=SignupMsg.user_already_exists)
+    return None
 
+
+def _check_signup_steps_completed() -> FluxData | None:
     if not session.signup.captcha.completed:
         current_app.logger.error("Captcha not completed")
         return error_response(message=SignupMsg.captcha_not_completed)
@@ -427,6 +429,10 @@ def _validate_create_user(use_password: bool, use_webauthn: bool, custom_passwor
     if not session.signup.tou.completed:
         current_app.logger.error("ToU not completed")
         return error_response(message=SignupMsg.tou_not_completed)
+    return None
+
+
+def _check_credentials_selected(use_password: bool, use_webauthn: bool, custom_password: str | None) -> FluxData | None:
     if use_password and not session.signup.credentials.generated_password:
         current_app.logger.error("No generated_password generated")
         return error_response(message=SignupMsg.password_not_generated)
@@ -440,6 +446,15 @@ def _validate_create_user(use_password: bool, use_webauthn: bool, custom_passwor
         current_app.logger.error("Neither generated_password nor webauthn selected")
         return error_response(message=SignupMsg.credential_not_added)
     return None
+
+
+def _validate_create_user(use_password: bool, use_webauthn: bool, custom_password: str | None) -> FluxData | None:
+    """Validate preconditions for user creation. Returns error response or None if valid."""
+    return (
+        _check_user_not_created()
+        or _check_signup_steps_completed()
+        or _check_credentials_selected(use_password, use_webauthn, custom_password)
+    )
 
 
 @signup_views.route("/create-user", methods=["POST"])

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -25,7 +25,7 @@ from eduid.webapp.common.authn.webauthn import (
     verify_webauthn_registration,
 )
 from eduid.webapp.common.session import session
-from eduid.webapp.common.session.namespaces import RequestRef, WebauthnCredential, WebauthnRegistration
+from eduid.webapp.common.session.namespaces import LoginApplication, RequestRef, WebauthnCredential, WebauthnRegistration
 from eduid.webapp.signup.app import current_signup_app as current_app
 from eduid.webapp.signup.helpers import (
     EmailAlreadyVerifiedException,
@@ -499,6 +499,7 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
     session.signup.user_created_at = utc_now()
     session.signup.credentials.completed = True
     session.common.eppn = signup_user.eppn
+    session.common.login_source = LoginApplication.signup
     # create payload before clearing generated password
     state = session.signup.to_dict()
     if custom_password is not None:
@@ -509,7 +510,7 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
     del custom_password
     session.signup.credentials.generated_password = None
     # clear signup session if the user is done
-    if not session.signup.invite.initiated_signup:
+    if not session.signup.invite.initiated_signup and not session.signup.idp_request_ref:
         del session.signup
     current_app.stats.count(name="signup_complete")
     return success_response(payload={"state": state})

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -25,7 +25,12 @@ from eduid.webapp.common.authn.webauthn import (
     verify_webauthn_registration,
 )
 from eduid.webapp.common.session import session
-from eduid.webapp.common.session.namespaces import LoginApplication, RequestRef, WebauthnCredential, WebauthnRegistration
+from eduid.webapp.common.session.namespaces import (
+    LoginApplication,
+    RequestRef,
+    WebauthnCredential,
+    WebauthnRegistration,
+)
 from eduid.webapp.signup.app import current_signup_app as current_app
 from eduid.webapp.signup.helpers import (
     EmailAlreadyVerifiedException,

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -25,7 +25,7 @@ from eduid.webapp.common.authn.webauthn import (
     verify_webauthn_registration,
 )
 from eduid.webapp.common.session import session
-from eduid.webapp.common.session.namespaces import WebauthnCredential, WebauthnRegistration
+from eduid.webapp.common.session.namespaces import RequestRef, WebauthnCredential, WebauthnRegistration
 from eduid.webapp.signup.app import current_signup_app as current_app
 from eduid.webapp.signup.helpers import (
     EmailAlreadyVerifiedException,
@@ -46,6 +46,7 @@ from eduid.webapp.signup.schemas import (
     InviteCodeRequest,
     InviteDataResponse,
     NameAndEmailSchema,
+    ReturnToAuthRequest,
     SignupStatusResponse,
     VerifyEmailRequest,
     WebauthnRegisterBeginRequest,
@@ -379,6 +380,28 @@ def webauthn_register_complete(
     if result.mfa_approved:
         current_app.stats.count(name="webauthn_mfa_approved")
 
+    return success_response(payload={"state": session.signup.to_dict()})
+
+
+@signup_views.route("/return-to-auth", methods=["POST"])
+@UnmarshalWith(ReturnToAuthRequest)
+@MarshalWith(SignupStatusResponse)
+@require_not_logged_in
+def return_to_auth(ref: str) -> FluxData:
+    """Store a reference to a pending IdP SAML request for resumption after signup."""
+    current_app.logger.info("Setting IdP request ref for post-signup auth resumption")
+
+    if session.signup.user_created:
+        current_app.logger.info("User already created, too late to set idp_request_ref")
+        return error_response(message=SignupMsg.user_already_exists)
+
+    request_ref = RequestRef(ref)
+    if request_ref not in session.idp.pending_requests:
+        current_app.logger.info(f"Request ref {ref} not found in IdP pending requests")
+        return error_response(message=SignupMsg.idp_request_ref_not_found)
+
+    session.signup.idp_request_ref = request_ref
+    current_app.logger.info(f"Stored idp_request_ref: {request_ref}")
     return success_response(payload={"state": session.signup.to_dict()})
 
 

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -410,19 +410,9 @@ def return_to_auth(ref: str) -> FluxData:
     return success_response(payload={"state": session.signup.to_dict()})
 
 
-@signup_views.route("/create-user", methods=["POST"])
-@UnmarshalWith(CreateUserRequest)
-@MarshalWith(SignupStatusResponse)
-@require_not_logged_in
-def create_user(use_suggested_password: bool, use_webauthn: bool, custom_password: str | None = None) -> FluxData:
-    current_app.logger.info("Creating user")
-
-    use_password = False
-    if use_suggested_password or custom_password is not None:
-        use_password = True
-
+def _validate_create_user(use_password: bool, use_webauthn: bool, custom_password: str | None) -> FluxData | None:
+    """Validate preconditions for user creation. Returns error response or None if valid."""
     if session.common.eppn or session.signup.user_created:
-        # do not try to create a new user if the user already exists
         current_app.logger.error("User already created")
         current_app.logger.debug(f"eppn: {session.common.eppn}")
         current_app.logger.debug(f"user created: {session.signup.user_created}")
@@ -440,16 +430,30 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
     if use_password and not session.signup.credentials.generated_password:
         current_app.logger.error("No generated_password generated")
         return error_response(message=SignupMsg.password_not_generated)
-    if use_password and custom_password is not None:
-        if not is_valid_custom_password(custom_password):
-            current_app.logger.error("Weak custom password")
-            return error_response(message=SignupMsg.weak_custom_password)
+    if use_password and custom_password is not None and not is_valid_custom_password(custom_password):
+        current_app.logger.error("Weak custom password")
+        return error_response(message=SignupMsg.weak_custom_password)
     if use_webauthn and not session.signup.credentials.webauthn:
         current_app.logger.error("No webauthn registered")
         return error_response(message=SignupMsg.webauthn_registration_failed)
     if not use_password and not use_webauthn:
         current_app.logger.error("Neither generated_password nor webauthn selected")
         return error_response(message=SignupMsg.credential_not_added)
+    return None
+
+
+@signup_views.route("/create-user", methods=["POST"])
+@UnmarshalWith(CreateUserRequest)
+@MarshalWith(SignupStatusResponse)
+@require_not_logged_in
+def create_user(use_suggested_password: bool, use_webauthn: bool, custom_password: str | None = None) -> FluxData:
+    current_app.logger.info("Creating user")
+
+    use_password = use_suggested_password or custom_password is not None
+
+    error = _validate_create_user(use_password, use_webauthn, custom_password)
+    if error is not None:
+        return error
 
     assert session.signup.name.given_name is not None  # please mypy
     assert session.signup.name.surname is not None  # please mypy


### PR DESCRIPTION
  Backend support for resuming a SAML SP login after signup. Three new endpoints and one new session field.                                   
                                                                                                                                              
  ## Flow                                                                                                                                     
           
  SP → IdP /sso/redirect → Frontend /login/{ref}
                                │
                      User clicks "Create account"
                                │                                                                                                             
                      POST signup /return-to-auth {ref}
                                │                                                                                                             
                      ... normal signup flow ...
                                │
                      POST signup /create-user
                      (response state has idp_request_ref)
                                │
                      POST idp /signup_auth {ref}
                      (returns {finished: true} + sets SSO cookie)                                                                            
                                │
                      POST idp /next {ref}                                                                                                    
                      (returns FINISHED with SAMLResponse as usual)

  ## What the frontend needs to do
                                                                                                                                              
  1. **On login page "Create account" click**: Call `POST /return-to-auth` on the signup app with `{ref}` (the current login RequestRef from
  the URL). Do this before starting the signup flow.                                                                                          
           
  2. **After `/create-user` success**: Check `state.idp_request_ref` in the response. If set, the user came from an SP login — don't go to the  default post-signup destination.
                                                                                                                                              
  3. **Instead, call `POST /signup_auth`** on the IdP with `{ref: state.idp_request_ref}`. Same shape as a `/pw_auth` or `/mfa_auth` call.    
  Returns `{finished: true}` on success.
                                                                                                                                              
  4. **Then call `POST /next`** with the same ref, as usual. The SSO session is now set and the normal login pipeline takes over — you'll get back `FINISHED` with `SAMLResponse` + `target` to POST to the SP.
                                                                                                                                              
  ## New endpoints

  | Endpoint | App | Request | Success response |
  |----------|-----|---------|-----------------|
  | `POST /return-to-auth` | signup | `{ref, csrf_token}` | Standard signup state response with `idp_request_ref` set |                       
  | `POST /signup_auth` | idp | `{ref, csrf_token}` | `{finished: true}` (same schema as `/pw_auth`) |
                                                                                                                                              
  ## New field in signup state
                                                                                                                                              
  `state.idp_request_ref` — string or null. When non-null, frontend should redirect back to IdP after signup instead of the default destination.

  ## Error cases                                                                                                                              
   
  - `/return-to-auth` with invalid ref → `signup.idp-request-ref-not-found`                                                                   
  - `/return-to-auth` after user already created → `signup.user-already-exists`
  - `/signup_auth` when signup is too old (>5 min) → `login.must_authenticate` (user must log in normally)
  - `/signup_auth` when SP requires ForceAuthn → `login.must_authenticate`                                                                    
  - `/signup_auth` when feature is disabled → `login.must_authenticate`
                                                                                                                                              
  ## Feature flag                                                                                                                             
   
  `allow_new_signup_logins` (IdP config, default: `false`). Frontend should handle the case where `/signup_auth` returns an error by falling back to showing the normal login form.