### PR TITLE
UserDB cleanup

### DIFF
--- a/src/eduid/userdb/proofing/db.py
+++ b/src/eduid/userdb/proofing/db.py
@@ -14,7 +14,7 @@ from eduid.userdb.proofing.state import (
     ProofingState,
 )
 from eduid.userdb.proofing.user import ProofingUser
-from eduid.userdb.userdb import AutoExpiringUserDB, UserSaveResult
+from eduid.userdb.userdb import AutoExpiringUserDB
 
 logger = logging.getLogger(__name__)
 
@@ -214,9 +214,6 @@ class ProofingUserDB(AutoExpiringUserDB[ProofingUser]):
         self, db_uri: str, db_name: str, collection: str = "profiles", auto_expire: timedelta | None = None
     ) -> None:
         super().__init__(db_uri, db_name, collection=collection, auto_expire=auto_expire)
-
-    def save(self, user: ProofingUser) -> UserSaveResult:
-        return super().save(user)
 
     @classmethod
     def user_from_dict(cls, data: TUserDbDocument) -> ProofingUser:

--- a/src/eduid/userdb/userdb.py
+++ b/src/eduid/userdb/userdb.py
@@ -357,21 +357,6 @@ class AmDB(UserDB[User]):
     def user_from_dict(cls, data: TUserDbDocument) -> User:
         return User.from_dict(data)
 
-    def save(self, user: User) -> UserSaveResult:
-        """
-        Save a User object to the database.
-        """
-        spec: dict[str, Any] = {"_id": user.user_id}
-
-        try:
-            result = self._save(user.to_dict(), spec, is_in_database=user.meta.is_in_database, meta=user.meta)
-        except DocumentOutOfSync as e:
-            raise UserOutOfSync("User out of sync") from e
-
-        user.modified_ts = result.ts
-
-        return UserSaveResult(success=bool(result))
-
     def get_unterminated_users_with_nin(
         self, projection: Mapping[str, Any] | None = None
     ) -> Generator[TUserDbDocument]:

--- a/src/eduid/webapp/authn/app.py
+++ b/src/eduid/webapp/authn/app.py
@@ -9,7 +9,9 @@ from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.authn.utils import get_saml2_config
 
 
-class AuthnApp(EduIDBaseApp[AuthnConfig]):
+class AuthnApp(EduIDBaseApp):
+    conf: AuthnConfig
+
     def __init__(self, config: AuthnConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/authn/tests/test_authn.py
+++ b/src/eduid/webapp/authn/tests/test_authn.py
@@ -303,7 +303,9 @@ class AuthnAPITestCase(AuthnAPITestBase):
                 return self.app.dispatch_request()
 
 
-class AuthnTestApp(AuthnBaseApp[AuthnConfig]):
+class AuthnTestApp(AuthnBaseApp):
+    conf: AuthnConfig
+
     def __init__(self, config: AuthnConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/bankid/app.py
+++ b/src/eduid/webapp/bankid/app.py
@@ -15,7 +15,9 @@ from eduid.webapp.common.authn.utils import get_saml2_config, no_authn_views
 __author__ = "lundberg"
 
 
-class BankIDApp(AuthnBaseApp[BankIDConfig]):
+class BankIDApp(AuthnBaseApp):
+    conf: BankIDConfig
+
     def __init__(self, config: BankIDConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/common/api/app.py
+++ b/src/eduid/webapp/common/api/app.py
@@ -45,16 +45,16 @@ if DEBUG:
     stderr.writelines("----- WARNING! EDUID_APP_DEBUG is enabled -----\n")
 
 
-class EduIDBaseApp[C: EduIDBaseAppConfig](Flask, metaclass=ABCMeta):
+class EduIDBaseApp(Flask, metaclass=ABCMeta):
     """
     Base class for eduID apps, initializing common features and facilities.
     """
 
-    conf: C
+    conf: EduIDBaseAppConfig
 
     def __init__(
         self,
-        config: C,
+        config: EduIDBaseAppConfig,
         init_central_userdb: bool = True,
         handle_exceptions: bool = True,
         **kwargs: Any,
@@ -170,7 +170,7 @@ class EduIDBaseApp[C: EduIDBaseAppConfig](Flask, metaclass=ABCMeta):
         return res
 
 
-def init_status_views(app: EduIDBaseApp[Any], config: EduIDBaseAppConfig) -> None:
+def init_status_views(app: EduIDBaseApp, config: EduIDBaseAppConfig) -> None:
     """
     Register status views for any app, and configure them as public.
     """

--- a/src/eduid/webapp/common/api/checks.py
+++ b/src/eduid/webapp/common/api/checks.py
@@ -23,10 +23,10 @@ if TYPE_CHECKING:
 __author__ = "lundberg"
 
 
-def get_current_app() -> EduIDBaseApp[EduIDBaseAppConfig]:
+def get_current_app() -> EduIDBaseApp:
     from eduid.webapp.common.api.app import EduIDBaseApp
 
-    _app = cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
+    _app = cast(EduIDBaseApp, flask_current_app)
     assert isinstance(_app.conf, EduIDBaseAppConfig)
     return _app
 

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -9,7 +9,7 @@ from collections.abc import Generator, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, Protocol, cast, runtime_checkable
 
 import pytest
 from flask.testing import FlaskClient
@@ -27,8 +27,6 @@ from eduid.userdb.element import ElementKey
 from eduid.userdb.fixtures.fido_credentials import u2f_credential, webauthn_credential
 from eduid.userdb.fixtures.users import UserFixtures
 from eduid.userdb.identity import IdentityType
-from eduid.userdb.logs.db import ProofingLog
-from eduid.userdb.proofing.state import NinProofingState
 from eduid.userdb.testing import MongoTemporaryInstance
 from eduid.userdb.userdb import UserDB
 from eduid.webapp.common.api.app import EduIDBaseApp
@@ -41,6 +39,13 @@ from eduid.webapp.common.session.testing import RedisTemporaryInstance
 from eduid.workers.msg.tasks import MessageSender
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class HasPrivateUserDB(Protocol):
+    """Protocol for apps that have a private_userdb attribute."""
+
+    private_userdb: UserDB[Any]
 
 TEST_CONFIG = {
     "debug": True,
@@ -155,8 +160,8 @@ class EduidAPITestCase[T: EduIDBaseApp](CommonTestCase):
 
         if self.copy_user_to_private:
             data = self.test_user.to_dict()
-            _private_userdb = getattr(self.app, "private_userdb")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
-            assert isinstance(_private_userdb, UserDB)
+            assert isinstance(self.app, HasPrivateUserDB), f"{type(self.app)} does not have private_userdb"
+            _private_userdb = self.app.private_userdb
             logging.info(f"Copying test-user {self.test_user} to private_userdb {_private_userdb}")
             _private_userdb.save(_private_userdb.user_from_dict(data=data))
 
@@ -564,44 +569,6 @@ class EduidAPITestCase[T: EduIDBaseApp](CommonTestCase):
             else:
                 logger.info(f"Test case got unexpected response ({response.status_code}):\n{response.data}")
             raise
-
-    def _check_nin_verified_ok(
-        self,
-        user: User,
-        proofing_state: NinProofingState,
-        number: str | None = None,
-        created_by: str | None = None,
-    ) -> None:
-        if number is None and (self.test_user is not None and self.test_user.identities.nin):
-            number = self.test_user.identities.nin.number
-
-        created_by_str = created_by or proofing_state.nin.created_by
-
-        assert user.identities.nin is not None
-        assert user.identities.nin.number == number
-        assert user.identities.nin.created_by == created_by_str
-        assert user.identities.nin.verified_by == proofing_state.nin.created_by
-        assert user.identities.nin.is_verified is True
-        assert user.identities.nin.proofing_method is not None
-        assert user.identities.nin.proofing_version is not None
-
-        _log = getattr(self.app, "proofing_log")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
-        assert isinstance(_log, ProofingLog)
-        assert _log.db_count() == 1
-
-    def _check_nin_not_verified(self, user: User, number: str | None = None, created_by: str | None = None) -> None:
-        if number is None and (self.test_user is not None and self.test_user.identities.nin):
-            number = self.test_user.identities.nin.number
-
-        assert user.identities.nin is not None
-        assert user.identities.nin.number == number
-        if created_by:
-            assert user.identities.nin.created_by == created_by
-        assert user.identities.nin.is_verified is False
-
-        _log = getattr(self.app, "proofing_log")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
-        assert isinstance(_log, ProofingLog)
-        assert _log.db_count() == 0
 
 
 class CSRFTestClient(FlaskClient):

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -47,6 +47,7 @@ class HasPrivateUserDB(Protocol):
 
     private_userdb: UserDB[Any]
 
+
 TEST_CONFIG = {
     "debug": True,
     "testing": True,

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -89,7 +89,7 @@ TEST_CONFIG = {
 }
 
 
-class EduidAPITestCase[T: EduIDBaseApp[Any]](CommonTestCase):
+class EduidAPITestCase[T: EduIDBaseApp](CommonTestCase):
     """
     Base Test case for eduID APIs.
 

--- a/src/eduid/webapp/common/api/tests/test_backdoor.py
+++ b/src/eduid/webapp/common/api/tests/test_backdoor.py
@@ -35,7 +35,9 @@ class BackdoorTestConfig(EduIDBaseAppConfig, MagicCookieMixin):
     pass
 
 
-class BackdoorTestApp(EduIDBaseApp[BackdoorTestConfig]):
+class BackdoorTestApp(EduIDBaseApp):
+    conf: BackdoorTestConfig
+
     def __init__(self, config: BackdoorTestConfig) -> None:
         super().__init__(config)
 

--- a/src/eduid/webapp/common/api/tests/test_decorators.py
+++ b/src/eduid/webapp/common/api/tests/test_decorators.py
@@ -19,7 +19,9 @@ class DecoratorTestConfig(EduIDBaseAppConfig):
     pass
 
 
-class DecoratorTestApp(EduIDBaseApp[DecoratorTestConfig]):
+class DecoratorTestApp(EduIDBaseApp):
+    conf: DecoratorTestConfig
+
     def __init__(self, config: DecoratorTestConfig) -> None:
         super().__init__(config)
 

--- a/src/eduid/webapp/common/api/tests/test_inputs.py
+++ b/src/eduid/webapp/common/api/tests/test_inputs.py
@@ -105,7 +105,7 @@ def values_view() -> Response:
     return _make_response(safe_param)
 
 
-class InputsTestApp(EduIDBaseApp[EduIDBaseAppConfig]):
+class InputsTestApp(EduIDBaseApp):
     def __init__(self, config: EduIDBaseAppConfig) -> None:
         super().__init__(config)
         self.session_interface = SessionFactory(config)

--- a/src/eduid/webapp/common/api/tests/test_logging.py
+++ b/src/eduid/webapp/common/api/tests/test_logging.py
@@ -11,7 +11,7 @@ __author__ = "lundberg"
 from eduid.common.config.parsers import load_config
 
 
-class LoggingTestApp(EduIDBaseApp[EduIDBaseAppConfig]):
+class LoggingTestApp(EduIDBaseApp):
     pass
 
 

--- a/src/eduid/webapp/common/api/tests/test_nin_helpers.py
+++ b/src/eduid/webapp/common/api/tests/test_nin_helpers.py
@@ -42,7 +42,9 @@ class HelpersTestConfig(EduIDBaseAppConfig, MsgConfigMixin):
     pass
 
 
-class HelpersTestApp(EduIDBaseApp[HelpersTestConfig]):
+class HelpersTestApp(EduIDBaseApp):
+    conf: HelpersTestConfig
+
     def __init__(self, name: str, test_config: Mapping[str, Any], **kwargs: Any) -> None:
         self.conf = load_config(typ=HelpersTestConfig, app_name=name, ns="webapp", test_config=test_config)
         super().__init__(self.conf, **kwargs)

--- a/src/eduid/webapp/common/api/tests/test_nin_helpers.py
+++ b/src/eduid/webapp/common/api/tests/test_nin_helpers.py
@@ -32,7 +32,7 @@ from eduid.webapp.common.api.helpers import (
     set_user_names_from_nin_proofing,
     verify_nin_for_user,
 )
-from eduid.webapp.common.api.testing import EduidAPITestCase
+from eduid.webapp.common.proofing.testing import ProofingTests
 from eduid.webapp.common.session.eduid_session import SessionFactory
 
 __author__ = "lundberg"
@@ -58,7 +58,7 @@ class HelpersTestApp(EduIDBaseApp):
         self.msg_relay = MsgRelay(self.conf)
 
 
-class NinHelpersTest(EduidAPITestCase[HelpersTestApp]):
+class NinHelpersTest(ProofingTests[HelpersTestApp]):
     def load_app(self, config: Mapping[str, Any]) -> HelpersTestApp:
         """
         Called from the parent class, so we can provide the appropriate flask

--- a/src/eduid/webapp/common/api/translation.py
+++ b/src/eduid/webapp/common/api/translation.py
@@ -1,10 +1,8 @@
 from importlib.resources import files
-from typing import Any
 
 from flask import current_app, request
 from flask_babel import Babel
 
-from eduid.common.config.base import EduIDBaseAppConfig
 from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.session import session
 
@@ -28,13 +26,12 @@ def get_user_locale() -> str | None:
     return lang
 
 
-def init_babel(app: EduIDBaseApp[Any]) -> Babel:
+def init_babel(app: EduIDBaseApp) -> Babel:
     """
     :param app: Flask app
     """
 
     _conf = app.conf
-    assert isinstance(_conf, EduIDBaseAppConfig)
     conf_translations_dirs = ";".join(_conf.flask.babel_translation_directories)
     # Add pkg_resource path to translation directory as the default location does not work
     pkg_translations_dir = str(files("eduid.webapp") / "translations")

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -67,7 +67,7 @@ def update_modified_ts(user: User) -> None:
         user.modified_ts = None
         return None
 
-    _private_userdb = get_from_current_app("private_userdb", UserDB[User])
+    _private_userdb = get_from_current_app("private_userdb", UserDB)
     private_user = _private_userdb.get_user_by_id(user_id)
     if private_user is None:
         logger.debug(f"User {user} not found in {_private_userdb}, setting modified_ts to None")

--- a/src/eduid/webapp/common/api/utils.py
+++ b/src/eduid/webapp/common/api/utils.py
@@ -22,7 +22,7 @@ from eduid.webapp.common.api.exceptions import ApiException
 if TYPE_CHECKING:
     from eduid.webapp.common.api.app import EduIDBaseApp
 
-    current_app = cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
+    current_app = cast(EduIDBaseApp, flask_current_app)
 else:
     current_app = flask_current_app
 

--- a/src/eduid/webapp/common/api/views/status.py
+++ b/src/eduid/webapp/common/api/views/status.py
@@ -16,7 +16,7 @@ from eduid.webapp.common.api.utils import get_from_current_app
 if TYPE_CHECKING:
     from eduid.webapp.common.api.app import EduIDBaseApp
 
-    current_app = cast(EduIDBaseApp[EduIDBaseAppConfig], flask_current_app)
+    current_app = cast(EduIDBaseApp, flask_current_app)
 else:
     current_app = flask_current_app
 

--- a/src/eduid/webapp/common/authn/middleware.py
+++ b/src/eduid/webapp/common/authn/middleware.py
@@ -11,7 +11,6 @@ from flask import Request, current_app
 from flask_cors.core import get_cors_headers, get_cors_options
 from werkzeug.wsgi import get_current_url
 
-from eduid.common.config.base import EduIDBaseAppConfig
 from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.api.messages import error_response
 from eduid.webapp.common.api.schemas.base import FluxStandardAction
@@ -21,7 +20,7 @@ from eduid.webapp.common.session.redis_session import NoSessionDataFoundExceptio
 no_context_logger = logging.getLogger(__name__)
 
 
-class AuthnBaseApp[C: EduIDBaseAppConfig](EduIDBaseApp[C], metaclass=ABCMeta):
+class AuthnBaseApp(EduIDBaseApp, metaclass=ABCMeta):
     """
     WSGI middleware that checks whether the request is authenticated,
     and in case it isn't, redirects to the authn service.
@@ -39,11 +38,7 @@ class AuthnBaseApp[C: EduIDBaseAppConfig](EduIDBaseApp[C], metaclass=ABCMeta):
         while next_path.endswith("/"):
             next_path = next_path[:-1]
 
-        conf = getattr(self, "conf", None)
-        if not isinstance(conf, EduIDBaseAppConfig):
-            raise RuntimeError(f"Could not find conf in {self}")
-
-        allowlist = conf.no_authn_urls
+        allowlist = self.conf.no_authn_urls
 
         no_context_logger.debug(f"Checking if URL path {next_path} matches no auth allow list: {allowlist}")
         for regex in allowlist:

--- a/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
+++ b/src/eduid/webapp/common/authn/tests/test_fido_tokens.py
@@ -50,7 +50,9 @@ def start_verification() -> str | dict[str, Any]:
     return result
 
 
-class MockFidoApp(EduIDBaseApp[MockFidoConfig]):
+class MockFidoApp(EduIDBaseApp):
+    conf: MockFidoConfig
+
     def __init__(self, config: MockFidoConfig) -> None:
         super().__init__(config)
 

--- a/src/eduid/webapp/common/authn/tests/test_middleware.py
+++ b/src/eduid/webapp/common/authn/tests/test_middleware.py
@@ -10,7 +10,7 @@ from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.common.authn.middleware import AuthnBaseApp
 
 
-class AuthnTestApp(AuthnBaseApp[EduIDBaseAppConfig]):
+class AuthnTestApp(AuthnBaseApp):
     def __init__(self, name: str, test_config: Mapping[str, Any], **kwargs: Any) -> None:
         # This should be an AuthnConfig instance, but an EduIDBaseAppConfig instance suffices for these
         # tests and we don't want eduid.webapp.common to depend on eduid.webapp.

--- a/src/eduid/webapp/common/authn/utils.py
+++ b/src/eduid/webapp/common/authn/utils.py
@@ -26,7 +26,7 @@ from eduid.webapp.common.session.namespaces import SP_AuthnRequest
 if TYPE_CHECKING:
     from eduid.webapp.common.authn.middleware import AuthnBaseApp
 
-    current_app = cast(AuthnBaseApp[EduIDBaseAppConfig], flask_current_app)
+    current_app = cast(AuthnBaseApp, flask_current_app)
 else:
     current_app = flask_current_app
 

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -1,7 +1,10 @@
-from eduid.common.config.base import EduIDBaseAppConfig, FrontendAction
+from typing import Protocol, runtime_checkable
+
+from eduid.common.config.base import FrontendAction
 from eduid.userdb.credentials import FidoCredential
 from eduid.userdb.identity import IdentityElement, IdentityProofingMethod
 from eduid.userdb.logs.db import ProofingLog
+from eduid.userdb.proofing.state import NinProofingState
 from eduid.userdb.user import User
 from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.api.messages import TranslatableMsg
@@ -10,6 +13,16 @@ from eduid.webapp.common.api.testing import CSRFTestClient, EduidAPITestCase, lo
 __author__ = "lundberg"
 
 
+@runtime_checkable
+class HasProofingLog(Protocol):
+    """Protocol for apps that have a proofing_log attribute."""
+
+    proofing_log: ProofingLog
+
+
+# T is bounded by EduIDBaseApp. HasProofingLog is used as a runtime narrowing check
+# where proofing_log is needed. A Protocol cannot inherit from a non-Protocol class,
+# so intersection type bounds (T: EduIDBaseApp & HasProofingLog) are not expressible.
 class ProofingTests[T: EduIDBaseApp](EduidAPITestCase[T]):
     def _verify_status(
         self,
@@ -34,7 +47,6 @@ class ProofingTests[T: EduIDBaseApp](EduidAPITestCase[T]):
 
         assert isinstance(self.app, EduIDBaseApp)
         _conf = self.app.conf
-        assert isinstance(_conf, EduIDBaseAppConfig)
         assert app_name == _conf.app_name, f"expected app_name {_conf.app_name} but got {app_name}"
 
         logger.debug(f"Verifying status for request {authn_id}")
@@ -81,10 +93,9 @@ class ProofingTests[T: EduIDBaseApp](EduidAPITestCase[T]):
                 f"User token was expected to be verified={token_verified}"
             )
 
-        _log = getattr(self.app, "proofing_log")  # noqa: B009 — not on EduIDBaseApp, varies by app subclass
-        assert isinstance(_log, ProofingLog)
-        assert _log.db_count() == num_proofings, (
-            f"Unexpected number of proofings in db. {_log.db_count()}, expected {num_proofings}"
+        assert isinstance(self.app, HasProofingLog), f"{type(self.app)} does not have proofing_log"
+        assert self.app.proofing_log.db_count() == num_proofings, (
+            f"Unexpected number of proofings in db. {self.app.proofing_log.db_count()}, expected {num_proofings}"
         )
 
         if identity is not None:
@@ -119,3 +130,39 @@ class ProofingTests[T: EduIDBaseApp](EduidAPITestCase[T]):
             assert user_locked_identity.unique_value == locked_identity.unique_value, (
                 f"locked identity {user_locked_identity.unique_value} not matching {locked_identity.unique_value}"
             )
+
+    def _check_nin_verified_ok(
+        self,
+        user: User,
+        proofing_state: NinProofingState,
+        number: str | None = None,
+        created_by: str | None = None,
+    ) -> None:
+        if number is None and (self.test_user is not None and self.test_user.identities.nin):
+            number = self.test_user.identities.nin.number
+
+        created_by_str = created_by or proofing_state.nin.created_by
+
+        assert user.identities.nin is not None
+        assert user.identities.nin.number == number
+        assert user.identities.nin.created_by == created_by_str
+        assert user.identities.nin.verified_by == proofing_state.nin.created_by
+        assert user.identities.nin.is_verified is True
+        assert user.identities.nin.proofing_method is not None
+        assert user.identities.nin.proofing_version is not None
+
+        assert isinstance(self.app, HasProofingLog), f"{type(self.app)} does not have proofing_log"
+        assert self.app.proofing_log.db_count() == 1
+
+    def _check_nin_not_verified(self, user: User, number: str | None = None, created_by: str | None = None) -> None:
+        if number is None and (self.test_user is not None and self.test_user.identities.nin):
+            number = self.test_user.identities.nin.number
+
+        assert user.identities.nin is not None
+        assert user.identities.nin.number == number
+        if created_by:
+            assert user.identities.nin.created_by == created_by
+        assert user.identities.nin.is_verified is False
+
+        assert isinstance(self.app, HasProofingLog), f"{type(self.app)} does not have proofing_log"
+        assert self.app.proofing_log.db_count() == 0

--- a/src/eduid/webapp/common/proofing/testing.py
+++ b/src/eduid/webapp/common/proofing/testing.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from eduid.common.config.base import EduIDBaseAppConfig, FrontendAction
 from eduid.userdb.credentials import FidoCredential
 from eduid.userdb.identity import IdentityElement, IdentityProofingMethod
@@ -12,7 +10,7 @@ from eduid.webapp.common.api.testing import CSRFTestClient, EduidAPITestCase, lo
 __author__ = "lundberg"
 
 
-class ProofingTests[T: EduIDBaseApp[Any]](EduidAPITestCase[T]):
+class ProofingTests[T: EduIDBaseApp](EduidAPITestCase[T]):
     def _verify_status(
         self,
         finish_url: str,

--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -6,7 +6,7 @@ import os
 import pprint
 from collections.abc import Iterator
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from flask import Flask, Request, Response
 from flask.sessions import SessionInterface, SessionMixin
@@ -99,7 +99,7 @@ class EduidSession(SessionMixin):
     """
 
     def __init__(
-        self, app: EduIDBaseApp[Any], meta: SessionMeta, base_session: RedisEncryptedSession, new: bool = False
+        self, app: EduIDBaseApp, meta: SessionMeta, base_session: RedisEncryptedSession, new: bool = False
     ) -> None:
         """
         :param app: the flask app

--- a/src/eduid/webapp/common/session/tests/test_eduid_session.py
+++ b/src/eduid/webapp/common/session/tests/test_eduid_session.py
@@ -19,7 +19,9 @@ class SessionTestConfig(EduIDBaseAppConfig):
     pass
 
 
-class SessionTestApp(AuthnBaseApp[SessionTestConfig]):
+class SessionTestApp(AuthnBaseApp):
+    conf: SessionTestConfig
+
     def __init__(self, config: SessionTestConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/eidas/app.py
+++ b/src/eduid/webapp/eidas/app.py
@@ -15,7 +15,9 @@ from eduid.webapp.eidas.settings.common import EidasConfig
 __author__ = "lundberg"
 
 
-class EidasApp(AuthnBaseApp[EidasConfig]):
+class EidasApp(AuthnBaseApp):
+    conf: EidasConfig
+
     def __init__(self, config: EidasConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/email/app.py
+++ b/src/eduid/webapp/email/app.py
@@ -12,7 +12,9 @@ from eduid.webapp.common.authn.middleware import AuthnBaseApp
 from eduid.webapp.email.settings.common import EmailConfig
 
 
-class EmailApp(AuthnBaseApp[EmailConfig]):
+class EmailApp(AuthnBaseApp):
+    conf: EmailConfig
+
     def __init__(self, config: EmailConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/freja_eid/app.py
+++ b/src/eduid/webapp/freja_eid/app.py
@@ -17,7 +17,9 @@ from eduid.webapp.freja_eid.settings.common import FrejaEIDConfig
 __author__ = "lundberg"
 
 
-class FrejaEIDApp(AuthnBaseApp[FrejaEIDConfig]):
+class FrejaEIDApp(AuthnBaseApp):
+    conf: FrejaEIDConfig
+
     def __init__(self, config: FrejaEIDConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/group_management/app.py
+++ b/src/eduid/webapp/group_management/app.py
@@ -15,7 +15,9 @@ from eduid.webapp.group_management.settings.common import GroupManagementConfig
 __author__ = "lundberg"
 
 
-class GroupManagementApp(AuthnBaseApp[GroupManagementConfig]):
+class GroupManagementApp(AuthnBaseApp):
+    conf: GroupManagementConfig
+
     def __init__(self, config: GroupManagementConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/idp/app.py
+++ b/src/eduid/webapp/idp/app.py
@@ -21,7 +21,9 @@ from eduid.webapp.idp.sso_cache import SSOSessionCache
 __author__ = "ft"
 
 
-class IdPApp(EduIDBaseApp[IdPConfig]):
+class IdPApp(EduIDBaseApp):
+    conf: IdPConfig
+
     def __init__(self, config: IdPConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/jsconfig/app.py
+++ b/src/eduid/webapp/jsconfig/app.py
@@ -8,7 +8,9 @@ from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.jsconfig.settings.common import JSConfigConfig
 
 
-class JSConfigApp(EduIDBaseApp[JSConfigConfig]):
+class JSConfigApp(EduIDBaseApp):
+    conf: JSConfigConfig
+
     def __init__(self, config: JSConfigConfig, **kwargs: Any) -> None:
         kwargs["init_central_userdb"] = False
         kwargs["static_folder"] = None

--- a/src/eduid/webapp/ladok/app.py
+++ b/src/eduid/webapp/ladok/app.py
@@ -14,7 +14,9 @@ from eduid.webapp.ladok.settings.common import LadokConfig
 __author__ = "lundberg"
 
 
-class LadokApp(AuthnBaseApp[LadokConfig]):
+class LadokApp(AuthnBaseApp):
+    conf: LadokConfig
+
     def __init__(self, config: LadokConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/letter_proofing/app.py
+++ b/src/eduid/webapp/letter_proofing/app.py
@@ -16,7 +16,9 @@ from eduid.webapp.letter_proofing.settings.common import LetterProofingConfig
 __author__ = "lundberg"
 
 
-class LetterProofingApp(AuthnBaseApp[LetterProofingConfig]):
+class LetterProofingApp(AuthnBaseApp):
+    conf: LetterProofingConfig
+
     def __init__(self, config: LetterProofingConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/letter_proofing/tests/test_app.py
+++ b/src/eduid/webapp/letter_proofing/tests/test_app.py
@@ -11,7 +11,7 @@ from eduid.common.config.base import EduidEnvironment
 from eduid.userdb import NinIdentity
 from eduid.userdb.element import ElementKey
 from eduid.userdb.identity import IdentityType
-from eduid.webapp.common.api.testing import EduidAPITestCase
+from eduid.webapp.common.proofing.testing import ProofingTests
 from eduid.webapp.letter_proofing.app import LetterProofingApp, init_letter_proofing_app
 from eduid.webapp.letter_proofing.helpers import LetterMsg
 
@@ -43,7 +43,7 @@ class MockResponse:
         return self._json_data
 
 
-class LetterProofingTests(EduidAPITestCase[LetterProofingApp]):
+class LetterProofingTests(ProofingTests[LetterProofingApp]):
     """Base TestCase for those tests that need a full environment setup"""
 
     api_users: ClassVar[list[str]] = ["hubba-baar"]

--- a/src/eduid/webapp/lookup_mobile_proofing/app.py
+++ b/src/eduid/webapp/lookup_mobile_proofing/app.py
@@ -15,7 +15,9 @@ from eduid.webapp.lookup_mobile_proofing.settings.common import MobileProofingCo
 __author__ = "lundberg"
 
 
-class MobileProofingApp(AuthnBaseApp[MobileProofingConfig]):
+class MobileProofingApp(AuthnBaseApp):
+    conf: MobileProofingConfig
+
     def __init__(self, config: MobileProofingConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/orcid/app.py
+++ b/src/eduid/webapp/orcid/app.py
@@ -14,7 +14,9 @@ from eduid.webapp.orcid.settings.common import OrcidConfig
 __author__ = "lundberg"
 
 
-class OrcidApp(AuthnBaseApp[OrcidConfig]):
+class OrcidApp(AuthnBaseApp):
+    conf: OrcidConfig
+
     def __init__(self, config: OrcidConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/personal_data/app.py
+++ b/src/eduid/webapp/personal_data/app.py
@@ -10,7 +10,9 @@ from eduid.webapp.common.authn.middleware import AuthnBaseApp
 from eduid.webapp.personal_data.settings import PersonalDataConfig
 
 
-class PersonalDataApp(AuthnBaseApp[PersonalDataConfig]):
+class PersonalDataApp(AuthnBaseApp):
+    conf: PersonalDataConfig
+
     def __init__(self, config: PersonalDataConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/phone/app.py
+++ b/src/eduid/webapp/phone/app.py
@@ -14,7 +14,9 @@ from eduid.webapp.common.authn.middleware import AuthnBaseApp
 from eduid.webapp.phone.settings.common import PhoneConfig
 
 
-class PhoneApp(AuthnBaseApp[PhoneConfig]):
+class PhoneApp(AuthnBaseApp):
+    conf: PhoneConfig
+
     def __init__(self, config: PhoneConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/reset_password/app.py
+++ b/src/eduid/webapp/reset_password/app.py
@@ -17,7 +17,9 @@ from eduid.webapp.reset_password.settings.common import ResetPasswordConfig
 __author__ = "eperez"
 
 
-class ResetPasswordApp(EduIDBaseApp[ResetPasswordConfig]):
+class ResetPasswordApp(EduIDBaseApp):
+    conf: ResetPasswordConfig
+
     def __init__(self, config: ResetPasswordConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/samleid/app.py
+++ b/src/eduid/webapp/samleid/app.py
@@ -15,7 +15,9 @@ from eduid.webapp.samleid.settings.common import SamlEidConfig
 __author__ = "lundberg"
 
 
-class SamlEidApp(AuthnBaseApp[SamlEidConfig]):
+class SamlEidApp(AuthnBaseApp):
+    conf: SamlEidConfig
+
     def __init__(self, config: SamlEidConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/security/app.py
+++ b/src/eduid/webapp/security/app.py
@@ -16,7 +16,9 @@ from eduid.webapp.common.authn.middleware import AuthnBaseApp
 from eduid.webapp.security.settings.common import SecurityConfig
 
 
-class SecurityApp(AuthnBaseApp[SecurityConfig]):
+class SecurityApp(AuthnBaseApp):
+    conf: SecurityConfig
+
     def __init__(self, config: SecurityConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/signup/app.py
+++ b/src/eduid/webapp/signup/app.py
@@ -17,7 +17,9 @@ from eduid.webapp.common.api.captcha import init_captcha
 from eduid.webapp.signup.settings.common import SignupConfig
 
 
-class SignupApp(EduIDBaseApp[SignupConfig]):
+class SignupApp(EduIDBaseApp):
+    conf: SignupConfig
+
     def __init__(self, config: SignupConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/support/app.py
+++ b/src/eduid/webapp/support/app.py
@@ -15,7 +15,9 @@ from eduid.webapp.common.api.exceptions import ApiException
 from eduid.webapp.support.settings.common import SupportConfig
 
 
-class SupportApp(EduIDBaseApp[SupportConfig]):
+class SupportApp(EduIDBaseApp):
+    conf: SupportConfig
+
     def __init__(self, config: SupportConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 

--- a/src/eduid/webapp/svipe_id/app.py
+++ b/src/eduid/webapp/svipe_id/app.py
@@ -15,7 +15,9 @@ from eduid.webapp.svipe_id.settings.common import SvipeIdConfig
 __author__ = "lundberg"
 
 
-class SvipeIdApp(AuthnBaseApp[SvipeIdConfig]):
+class SvipeIdApp(AuthnBaseApp):
+    conf: SvipeIdConfig
+
     def __init__(self, config: SvipeIdConfig, **kwargs: Any) -> None:
         super().__init__(config, **kwargs)
 


### PR DESCRIPTION
# UserDB cleanup: remove redundant save overrides, fix parameterized isinstance

## Why

Three independent issues found during architectural review of `UserDB`.

**`ProofingUserDB.save`** was a one-liner that only called `super().save(user)`. The
narrower parameter type (`ProofingUser` instead of `UserVar`) is already implied by
`class ProofingUserDB(AutoExpiringUserDB[ProofingUser])` — binding `UserVar =
ProofingUser` means the inherited `save(user: UserVar)` already is
`save(user: ProofingUser)`. The override added nothing.

**`AmDB.save`** was a near-copy of `UserDB.save` that accidentally omitted the
`isinstance(user, User)` guard. The 2022 "refactor all userdb save() functions" commit
simplified the override from complex version-tracking logic down to a plain save, but
dropped the defensive check in the process. Removing the override restores the guard
(a no-op for `user: User`, but consistent with the base class contract).

**`update_modified_ts`** called `get_from_current_app("private_userdb", UserDB[User])`,
passing a parameterized generic as the `klass` argument to `isinstance`. Parameterized
generics raise `TypeError` in `isinstance` since Python 3.9. The raw class `UserDB` is
the correct argument.
