### PR TITLE
Enable --no-implicit-reexport, straighten stale imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint:
 	ruff check
 
 typecheck:
-	MYPYPATH=$(SRCDIR) mypy --install-types --non-interactive --strict --implicit-reexport -p eduid
+	MYPYPATH=$(SRCDIR) mypy --install-types --non-interactive --strict -p eduid
 
 typecheck_strict: typecheck
 

--- a/src/eduid/common/config/parsers/yaml_parser.py
+++ b/src/eduid/common/config/parsers/yaml_parser.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from eduid.common.config.parsers import BaseConfigParser
+from eduid.common.config.parsers.base import BaseConfigParser
 from eduid.common.config.parsers.decorators import decrypt, interpolate
 
 

--- a/src/eduid/common/fastapi/log.py
+++ b/src/eduid/common/fastapi/log.py
@@ -2,9 +2,9 @@ import logging
 import pprint
 from logging.config import dictConfig
 
-from eduid.common.config.base import LoggingConfigMixin
+from eduid.common.config.base import LoggingConfigMixin, LoggingFilters
 from eduid.common.config.exceptions import BadConfiguration
-from eduid.common.logging import LocalContext, LoggingFilters, make_dict_config, merge_config
+from eduid.common.logging import LocalContext, make_dict_config, merge_config
 
 __author__ = "lundberg"
 

--- a/src/eduid/common/rpc/tests/test_msg_relay.py
+++ b/src/eduid/common/rpc/tests/test_msg_relay.py
@@ -8,7 +8,7 @@ from eduid.common.config.base import CeleryConfig, MsgConfigMixin
 from eduid.common.config.workers import MsgConfig
 from eduid.common.rpc.exceptions import NoAddressFound, NoNavetData
 from eduid.common.rpc.msg_relay import DeregisteredCauseCode, FullPostalAddress, MsgRelay, NavetData, RelationType
-from eduid.workers.msg import MsgCelerySingleton
+from eduid.workers.msg.common import MsgCelerySingleton
 from eduid.workers.msg.tasks import MessageSender
 
 __author__ = "lundberg"

--- a/src/eduid/common/rpc/worker.py
+++ b/src/eduid/common/rpc/worker.py
@@ -1,6 +1,6 @@
+from eduid.common.config.base import WorkerConfig
 from eduid.common.config.exceptions import BadConfiguration
 from eduid.common.config.parsers import load_config
-from eduid.common.config.workers import WorkerConfig
 
 
 def get_worker_config[T: WorkerConfig](name: str, config_class: type[T]) -> T:

--- a/src/eduid/graphdb/testing.py
+++ b/src/eduid/graphdb/testing.py
@@ -10,7 +10,7 @@ import pytest
 from neo4j.exceptions import ServiceUnavailable
 
 from eduid.graphdb.db import Neo4jDB
-from eduid.userdb.testing import EduidTemporaryInstance
+from eduid.userdb.testing.temp_instance import EduidTemporaryInstance
 
 __author__ = "lundberg"
 

--- a/src/eduid/queue/testing.py
+++ b/src/eduid/queue/testing.py
@@ -18,7 +18,8 @@ from eduid.queue.db import Payload, QueueDB, QueueItem, SenderInfo
 from eduid.queue.db.worker import AsyncQueueDB
 from eduid.queue.workers.base import QueueWorker
 from eduid.userdb.db import TUserDbDocument
-from eduid.userdb.testing import EduidTemporaryInstance, MongoTemporaryInstance
+from eduid.userdb.testing import MongoTemporaryInstance
+from eduid.userdb.testing.temp_instance import EduidTemporaryInstance
 
 __author__ = "lundberg"
 

--- a/src/eduid/scimapi/routers/users.py
+++ b/src/eduid/scimapi/routers/users.py
@@ -31,7 +31,8 @@ from eduid.userdb.scimapi import (
     ScimApiName,
     ScimApiPhoneNumber,
 )
-from eduid.userdb.scimapi.userdb import ScimApiProfile, ScimApiUser
+from eduid.userdb.scimapi.common import ScimApiProfile
+from eduid.userdb.scimapi.userdb import ScimApiUser
 
 users_router = APIRouter(
     route_class=ScimApiRoute,

--- a/src/eduid/scimapi/testing.py
+++ b/src/eduid/scimapi/testing.py
@@ -22,8 +22,9 @@ from eduid.scimapi.app import init_api
 from eduid.scimapi.config import ScimApiConfig
 from eduid.scimapi.context import Context
 from eduid.userdb.scimapi import ScimApiEvent, ScimApiGroup, ScimApiLinkedAccount, ScimApiName
+from eduid.userdb.scimapi.common import ScimApiProfile
 from eduid.userdb.scimapi.invitedb import ScimApiInvite
-from eduid.userdb.scimapi.userdb import ScimApiProfile, ScimApiUser
+from eduid.userdb.scimapi.userdb import ScimApiUser
 from eduid.userdb.signup import SignupInviteDB
 from eduid.userdb.testing import MongoTemporaryInstance
 

--- a/src/eduid/scimapi/tests/test_scimuser.py
+++ b/src/eduid/scimapi/tests/test_scimuser.py
@@ -20,7 +20,8 @@ from eduid.common.utils import make_etag
 from eduid.scimapi.testing import ScimApiTestCase
 from eduid.scimapi.utils import filter_none
 from eduid.userdb.scimapi import EventStatus, ScimApiGroup, ScimApiLinkedAccount, ScimApiName
-from eduid.userdb.scimapi.userdb import ScimApiProfile, ScimApiUser
+from eduid.userdb.scimapi.common import ScimApiProfile
+from eduid.userdb.scimapi.userdb import ScimApiUser
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/userdb/authninfo.py
+++ b/src/eduid/userdb/authninfo.py
@@ -6,8 +6,8 @@ from enum import StrEnum
 
 from eduid.userdb import User
 from eduid.userdb.credentials import U2F, Password, Webauthn
+from eduid.userdb.db import BaseDB
 from eduid.userdb.element import ElementKey
-from eduid.userdb.userdb import BaseDB
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/userdb/db/__init__.py
+++ b/src/eduid/userdb/db/__init__.py
@@ -1,5 +1,6 @@
 # Keep existing imports working
-from eduid.userdb.db.sync_db import BaseDB, MongoDB, SaveResult, TUserDbDocument
+from eduid.userdb.db.base import TUserDbDocument
+from eduid.userdb.db.sync_db import BaseDB, MongoDB, SaveResult
 
 __all__ = [
     "BaseDB",

--- a/src/eduid/userdb/maccapi/userdb.py
+++ b/src/eduid/userdb/maccapi/userdb.py
@@ -4,8 +4,7 @@ from datetime import datetime
 from pydantic import field_validator
 
 from eduid.userdb.db import TUserDbDocument
-from eduid.userdb.element import UserDBValueError
-from eduid.userdb.exceptions import EduIDDBError
+from eduid.userdb.exceptions import EduIDDBError, UserDBValueError
 from eduid.userdb.idp import IdPUser
 from eduid.userdb.user import User
 from eduid.userdb.userdb import UserDB

--- a/src/eduid/userdb/scimapi/__init__.py
+++ b/src/eduid/userdb/scimapi/__init__.py
@@ -6,6 +6,7 @@ from eduid.userdb.scimapi.common import (
     ScimApiName,
     ScimApiPhoneNumber,
     ScimApiProfile,
+    ScimApiResourceBase,
 )
 from eduid.userdb.scimapi.eventdb import (
     EventLevel,
@@ -13,7 +14,6 @@ from eduid.userdb.scimapi.eventdb import (
     ScimApiEvent,
     ScimApiEventDB,
     ScimApiEventResource,
-    ScimApiResourceBase,
 )
 from eduid.userdb.scimapi.groupdb import GroupExtensions, ScimApiGroup, ScimApiGroupDB
 from eduid.userdb.scimapi.userdb import ScimApiUser, ScimApiUserDB

--- a/src/eduid/userdb/signup/invitedb.py
+++ b/src/eduid/userdb/signup/invitedb.py
@@ -3,11 +3,10 @@ from dataclasses import replace
 from typing import Any
 
 from eduid.common.misc.timeutil import utc_now
-from eduid.userdb.db import SaveResult
+from eduid.userdb.db import BaseDB, SaveResult
 from eduid.userdb.exceptions import MultipleDocumentsReturned
 from eduid.userdb.signup import Invite, SCIMReference
 from eduid.userdb.signup.invite import InviteReference
-from eduid.userdb.userdb import BaseDB
 
 __author__ = "lundberg"
 

--- a/src/eduid/userdb/support/db.py
+++ b/src/eduid/userdb/support/db.py
@@ -3,14 +3,14 @@ from typing import Any
 
 from bson import ObjectId
 
-from eduid.userdb.db import TUserDbDocument
+from eduid.userdb.db import BaseDB, TUserDbDocument
 from eduid.userdb.exceptions import UserDoesNotExist
 from eduid.userdb.proofing import LetterProofingState
 from eduid.userdb.signup import SignupUserDB
 from eduid.userdb.support import models
 from eduid.userdb.support.models import GenericFilterDict
 from eduid.userdb.support.user import SupportUser
-from eduid.userdb.userdb import BaseDB, UserDB
+from eduid.userdb.userdb import UserDB
 
 __author__ = "lundberg"
 

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -12,8 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from eduid.userdb.credentials import CredentialList
 from eduid.userdb.db import BaseDB, TUserDbDocument
-from eduid.userdb.element import UserDBValueError
-from eduid.userdb.exceptions import UserDoesNotExist, UserIsRevoked
+from eduid.userdb.exceptions import UserDBValueError, UserDoesNotExist, UserIsRevoked
 from eduid.userdb.identity import EIDASIdentity, EIDASLoa, IdentityList, IdentityType
 from eduid.userdb.ladok import Ladok
 from eduid.userdb.locked_identity import LockedIdentityList

--- a/src/eduid/webapp/authn/tests/test_authn.py
+++ b/src/eduid/webapp/authn/tests/test_authn.py
@@ -25,7 +25,8 @@ from eduid.webapp.common.authn.cache import OutstandingQueriesCache
 from eduid.webapp.common.authn.middleware import AuthnBaseApp
 from eduid.webapp.common.authn.tests.responses import auth_response, logout_request, logout_response
 from eduid.webapp.common.authn.utils import no_authn_views
-from eduid.webapp.common.session import EduidSession, session
+from eduid.webapp.common.session import session
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import AuthnRequestRef
 
 logger = logging.getLogger(__name__)

--- a/src/eduid/webapp/authn/views.py
+++ b/src/eduid/webapp/authn/views.py
@@ -33,7 +33,8 @@ from eduid.webapp.common.authn.acs_registry import ACSArgs, get_action
 from eduid.webapp.common.authn.cache import IdentityCache, StateCache
 from eduid.webapp.common.authn.eduid_saml2 import get_authn_request, process_assertion, saml_logout
 from eduid.webapp.common.authn.utils import get_location
-from eduid.webapp.common.session import EduidSession, session
+from eduid.webapp.common.session import session
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import AuthnRequestRef, SP_AuthnRequest
 
 assert acs_actions  # make sure nothing optimises away the import of this, as it is needed to execute @acs_actions

--- a/src/eduid/webapp/bankid/acs_actions.py
+++ b/src/eduid/webapp/bankid/acs_actions.py
@@ -16,7 +16,7 @@ from eduid.webapp.common.session.namespaces import SP_AuthnRequest
 
 __author__ = "lundberg"
 
-from eduid.webapp.bankid.saml_session_info import BaseSessionInfo
+from eduid.common.models.saml_models import BaseSessionInfo
 
 
 def common_saml_checks(args: ACSArgs) -> ACSResult | None:

--- a/src/eduid/webapp/bankid/tests/test_app.py
+++ b/src/eduid/webapp/bankid/tests/test_app.py
@@ -23,7 +23,7 @@ from eduid.webapp.common.api.testing import CSRFTestClient
 from eduid.webapp.common.authn.cache import OutstandingQueriesCache
 from eduid.webapp.common.proofing.messages import ProofingMsg
 from eduid.webapp.common.proofing.testing import ProofingTests
-from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import AuthnRequestRef
 
 __author__ = "lundberg"

--- a/src/eduid/webapp/common/api/testing.py
+++ b/src/eduid/webapp/common/api/testing.py
@@ -33,7 +33,7 @@ from eduid.webapp.common.api.app import EduIDBaseApp
 from eduid.webapp.common.api.messages import AuthnStatusMsg, TranslatableMsg
 from eduid.webapp.common.api.schemas.authn_status import AuthnActionStatus
 from eduid.webapp.common.authn.acs_enums import AuthnAcsAction
-from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import SP_AuthnRequest
 from eduid.webapp.common.session.testing import RedisTemporaryInstance
 from eduid.workers.msg.tasks import MessageSender

--- a/src/eduid/webapp/common/authn/eduid_saml2.py
+++ b/src/eduid/webapp/common/authn/eduid_saml2.py
@@ -9,6 +9,7 @@ from dateutil.parser import parse as dt_parse
 from flask import abort, make_response, redirect, request
 from saml2 import BINDING_HTTP_POST, BINDING_HTTP_REDIRECT
 from saml2.client import Saml2Client
+from saml2.config import SPConfig
 from saml2.ident import decode
 from saml2.response import AuthnResponse, LogoutResponse, StatusError, UnsolicitedResponse
 from saml2.saml import Subject
@@ -25,8 +26,9 @@ from eduid.webapp.common.api.errors import EduidErrorsContext, goto_errors_respo
 from eduid.webapp.common.api.utils import sanitise_redirect_url, sanitize_for_log
 from eduid.webapp.common.authn.cache import IdentityCache, OutstandingQueriesCache, StateCache
 from eduid.webapp.common.authn.session_info import SessionInfo
-from eduid.webapp.common.authn.utils import SPConfig, get_saml_attribute
-from eduid.webapp.common.session import EduidSession, session
+from eduid.webapp.common.authn.utils import get_saml_attribute
+from eduid.webapp.common.session import session
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import AuthnRequestRef, SP_AuthnRequest, SPAuthnData
 
 logger = logging.getLogger(__name__)

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
-from fido2.server import Fido2Server, PublicKeyCredentialRpEntity
+from fido2.server import Fido2Server, PublicKeyCredentialRpEntity  # type: ignore[attr-defined]
 from fido2.webauthn import (
     AttestationConveyancePreference,
     AttestationObject,

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -9,13 +9,14 @@ from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
-from fido2.server import Fido2Server, PublicKeyCredentialRpEntity  # type: ignore[attr-defined]
+from fido2.server import Fido2Server
 from fido2.webauthn import (
     AttestationConveyancePreference,
     AttestationObject,
     AttestedCredentialData,
     AuthenticatorAttachment,
     AuthenticatorData,
+    PublicKeyCredentialRpEntity,
     RegistrationResponse,
 )
 from fido_mds import Attestation, FidoMetadataStore

--- a/src/eduid/webapp/common/session/testing.py
+++ b/src/eduid/webapp/common/session/testing.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import redis
 
-from eduid.userdb.testing import EduidTemporaryInstance
+from eduid.userdb.testing.temp_instance import EduidTemporaryInstance
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/webapp/common/session/tests/test_namespaces.py
+++ b/src/eduid/webapp/common/session/tests/test_namespaces.py
@@ -7,8 +7,7 @@ from eduid.common.config.base import FrontendAction
 from eduid.common.config.parsers import load_config
 from eduid.common.testing_base import normalised_data
 from eduid.webapp.common.api.testing import EduidAPITestCase
-from eduid.webapp.common.session.eduid_session import EduidSession
-from eduid.webapp.common.session.eduid_session import SessionFactory
+from eduid.webapp.common.session.eduid_session import EduidSession, SessionFactory
 from eduid.webapp.common.session.meta import SessionMeta
 from eduid.webapp.common.session.namespaces import AuthnRequestRef, SP_AuthnRequest
 from eduid.webapp.common.session.tests.test_eduid_session import SessionTestApp, SessionTestConfig

--- a/src/eduid/webapp/common/session/tests/test_namespaces.py
+++ b/src/eduid/webapp/common/session/tests/test_namespaces.py
@@ -7,7 +7,7 @@ from eduid.common.config.base import FrontendAction
 from eduid.common.config.parsers import load_config
 from eduid.common.testing_base import normalised_data
 from eduid.webapp.common.api.testing import EduidAPITestCase
-from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.eduid_session import SessionFactory
 from eduid.webapp.common.session.meta import SessionMeta
 from eduid.webapp.common.session.namespaces import AuthnRequestRef, SP_AuthnRequest

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -1,3 +1,4 @@
+from eduid.common.models.saml_models import BaseSessionInfo
 from eduid.userdb import User
 from eduid.userdb.credentials.fido import FidoCredential
 from eduid.webapp.common.api.decorators import require_user
@@ -13,7 +14,6 @@ from eduid.webapp.common.session.namespaces import SP_AuthnRequest
 from eduid.webapp.eidas.app import current_eidas_app as current_app
 from eduid.webapp.eidas.helpers import EidasMsg
 from eduid.webapp.eidas.proofing import get_proofing_functions
-from eduid.webapp.eidas.saml_session_info import BaseSessionInfo
 
 __author__ = "lundberg"
 

--- a/src/eduid/webapp/eidas/proofing.py
+++ b/src/eduid/webapp/eidas/proofing.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from eduid.common.config.base import ProofingConfigMixin
+from eduid.common.models.saml_models import BaseSessionInfo
 from eduid.common.rpc.exceptions import AmTaskFailed
 from eduid.userdb import EIDASIdentity, User
 from eduid.userdb.credentials import Credential
@@ -33,7 +34,7 @@ from eduid.webapp.common.proofing.base import (
 from eduid.webapp.common.proofing.methods import ProofingMethod
 from eduid.webapp.eidas.app import current_eidas_app as current_app
 from eduid.webapp.eidas.helpers import EidasMsg
-from eduid.webapp.eidas.saml_session_info import BaseSessionInfo, ForeignEidSessionInfo, NinSessionInfo
+from eduid.webapp.eidas.saml_session_info import ForeignEidSessionInfo, NinSessionInfo
 
 
 @dataclass

--- a/src/eduid/webapp/eidas/tests/test_app.py
+++ b/src/eduid/webapp/eidas/tests/test_app.py
@@ -22,7 +22,7 @@ from eduid.webapp.common.authn.acs_enums import AuthnAcsAction
 from eduid.webapp.common.authn.cache import OutstandingQueriesCache
 from eduid.webapp.common.proofing.messages import ProofingMsg
 from eduid.webapp.common.proofing.testing import ProofingTests
-from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import AuthnRequestRef, SP_AuthnRequest
 from eduid.webapp.eidas.app import EidasApp, init_eidas_app
 from eduid.webapp.eidas.helpers import EidasMsg

--- a/src/eduid/webapp/group_management/helpers.py
+++ b/src/eduid/webapp/group_management/helpers.py
@@ -10,13 +10,12 @@ from eduid.queue.client import init_queue_item
 from eduid.queue.db.message.payload import EduidGroupInviteCancelEmail, EduidGroupInviteEmail
 from eduid.userdb import User
 from eduid.userdb.exceptions import EduIDDBError
-from eduid.userdb.group_management import GroupInviteState
+from eduid.userdb.group_management import GroupInviteState, GroupRole
 from eduid.userdb.scimapi import ScimApiGroup
 from eduid.userdb.scimapi.userdb import ScimApiUser
 from eduid.webapp.common.api.messages import TranslatableMsg
 from eduid.webapp.common.api.translation import get_user_locale
 from eduid.webapp.group_management.app import current_group_management_app as current_app
-from eduid.webapp.group_management.schemas import GroupRole
 
 __author__ = "lundberg"
 

--- a/src/eduid/webapp/group_management/tests/test_app.py
+++ b/src/eduid/webapp/group_management/tests/test_app.py
@@ -12,12 +12,12 @@ from eduid.graphdb.groupdb import User as GraphUser
 from eduid.graphdb.testing import Neo4jTemporaryInstance
 from eduid.userdb import User
 from eduid.userdb.element import ElementKey
+from eduid.userdb.group_management import GroupRole
 from eduid.userdb.scimapi import GroupExtensions, ScimApiGroup
 from eduid.userdb.scimapi.userdb import ScimApiUser
 from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.group_management.app import GroupManagementApp, init_group_management_app
 from eduid.webapp.group_management.helpers import GroupManagementMsg
-from eduid.webapp.group_management.schemas import GroupRole
 
 __author__ = "lundberg"
 

--- a/src/eduid/webapp/idp/tests/test_login.py
+++ b/src/eduid/webapp/idp/tests/test_login.py
@@ -30,7 +30,7 @@ from eduid.webapp.idp.tests.test_api import (
     PwAuthResult,
     TestUser,
 )
-from eduid.workers.am import AmCelerySingleton
+from eduid.workers.am.common import AmCelerySingleton
 
 logger = logging.getLogger(__name__)
 

--- a/src/eduid/webapp/idp/views/misc.py
+++ b/src/eduid/webapp/idp/views/misc.py
@@ -6,12 +6,13 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith
 from eduid.webapp.common.api.messages import FluxData, success_response
 from eduid.webapp.common.api.schemas.models import FluxSuccessResponse
+from eduid.webapp.common.session import session
 from eduid.webapp.common.session.namespaces import IdP_SAMLPendingRequest
 from eduid.webapp.idp.app import current_idp_app as current_app
 from eduid.webapp.idp.decorators import require_ticket, uses_sso_session
 from eduid.webapp.idp.login import get_ticket
 from eduid.webapp.idp.login_context import LoginContext, LoginContextSAML
-from eduid.webapp.idp.sso_session import SSOSession, session
+from eduid.webapp.idp.sso_session import SSOSession
 
 __author__ = "ft"
 

--- a/src/eduid/webapp/samleid/tests/test_app.py
+++ b/src/eduid/webapp/samleid/tests/test_app.py
@@ -28,7 +28,7 @@ from eduid.webapp.common.authn.acs_enums import AuthnAcsAction
 from eduid.webapp.common.authn.cache import OutstandingQueriesCache
 from eduid.webapp.common.proofing.messages import ProofingMsg
 from eduid.webapp.common.proofing.testing import ProofingTests
-from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import AuthnRequestRef, SP_AuthnRequest
 from eduid.webapp.samleid.app import SamlEidApp, init_samleid_app
 from eduid.webapp.samleid.helpers import SamlEidMsg

--- a/src/eduid/webapp/security/helpers.py
+++ b/src/eduid/webapp/security/helpers.py
@@ -8,6 +8,7 @@ from fido2.webauthn import AuthenticatorAttachment
 
 from eduid.common.config.base import EduidEnvironment
 from eduid.common.misc.timeutil import utc_now
+from eduid.common.proofing_utils import set_user_names_from_official_address
 from eduid.common.rpc.msg_relay import FullPostalAddress, NavetData
 from eduid.common.utils import generate_password
 from eduid.queue.client import init_queue_item
@@ -17,7 +18,6 @@ from eduid.userdb.identity import IdentityType
 from eduid.userdb.logs.element import NameUpdateProofing
 from eduid.userdb.security import SecurityUser
 from eduid.userdb.user import User
-from eduid.webapp.common.api.helpers import set_user_names_from_official_address
 from eduid.webapp.common.api.messages import TranslatableMsg
 from eduid.webapp.common.api.translation import get_user_locale
 from eduid.webapp.common.session import session

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -27,7 +27,7 @@ from eduid.webapp.common.authn.webauthn import (
     get_webauthn_server,
     is_authenticator_mfa_approved,
 )
-from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import WebauthnRegistration, WebauthnState
 from eduid.webapp.security.app import SecurityApp, security_init_app
 

--- a/src/eduid/webapp/signup/tests/test_webauthn.py
+++ b/src/eduid/webapp/signup/tests/test_webauthn.py
@@ -14,7 +14,7 @@ from eduid.common.config.base import EduidEnvironment
 from eduid.userdb.credentials import Password, Webauthn
 from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.common.authn.webauthn import get_webauthn_server
-from eduid.webapp.common.session import EduidSession
+from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import WebauthnCredential, WebauthnRegistration, WebauthnState
 from eduid.webapp.signup.app import SignupApp, signup_init_app
 from eduid.webapp.signup.helpers import SignupMsg

--- a/src/eduid/workers/am/fetcher_registry.py
+++ b/src/eduid/workers/am/fetcher_registry.py
@@ -8,7 +8,7 @@ See the file LICENSE.txt for full license statement.
 from collections.abc import Iterable
 
 import eduid.workers.am.ams
-from eduid.workers.am.ams import AttributeFetcher
+from eduid.workers.am.ams.common import AttributeFetcher
 
 
 class AFRegistry:

--- a/src/eduid/workers/am/testing.py
+++ b/src/eduid/workers/am/testing.py
@@ -24,7 +24,7 @@ from eduid.userdb.exceptions import UserDoesNotExist
 from eduid.userdb.identity import IdentityType
 from eduid.userdb.proofing import ProofingUser
 from eduid.userdb.userdb import UserDB
-from eduid.workers.am.ams import AttributeFetcher
+from eduid.workers.am.ams.common import AttributeFetcher
 from eduid.workers.am.common import AmCelerySingleton
 
 logger = logging.getLogger(__name__)

--- a/src/eduid/workers/amapi/app.py
+++ b/src/eduid/workers/amapi/app.py
@@ -1,11 +1,11 @@
 from typing import Any
 
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 
 from eduid.common.config.parsers import load_config
 from eduid.common.fastapi.exceptions import (
     HTTPErrorDetail,
-    RequestValidationError,
     http_error_detail_handler,
     unexpected_error_handler,
     validation_exception_handler,

--- a/src/eduid/workers/celery_typing.py
+++ b/src/eduid/workers/celery_typing.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+__all__ = ["Task"]
+
 if TYPE_CHECKING:
     from celery import Task
 else:


### PR DESCRIPTION
# Enable --no-implicit-reexport, straighten stale imports

## Why

`--implicit-reexport` was silencing mypy's check that re-exported names be declared
explicitly. Dropping it surfaced 43 errors across 42 files. All the same pattern:
callers reaching a name through a module that happens to re-export it, when the
canonical location is elsewhere. 24 package modules already declare explicit
`__all__` reexports (e.g. `userdb/__init__.py`, `userdb/credentials/__init__.py`)
and stay clean — this PR handles only names **not** covered by any such
declaration. Rather than paper over with more `__all__`, the callers are
straightened to import from where names actually live.

## Stale imports straightened (20 re-exports, ~39 caller sites)

| Name | Was imported from | Actually lives in |
|------|-------------------|-------------------|
| `BaseDB` | `userdb.userdb` | `userdb.db` |
| `UserDBValueError` | `userdb.element` | `userdb.exceptions` |
| `BaseSessionInfo` (eidas/bankid) | `webapp.{eidas,bankid}.saml_session_info` | `common.models.saml_models` |
| `GroupRole` | `webapp.group_management.schemas` | `userdb.group_management` |
| `session` (sso) | `webapp.idp.sso_session` | `webapp.common.session` |
| `TUserDbDocument` | `userdb.db.sync_db` | `userdb.db.base` |
| `WorkerConfig` | `common.config.workers` | `common.config.base` |
| `LoggingFilters` | `common.logging` | `common.config.base` |
| `SPConfig` | `webapp.common.authn.utils` | `saml2.config` |
| `RequestValidationError` | `common.fastapi.exceptions` | `fastapi.exceptions` |
| `ScimApiProfile` | `userdb.scimapi.userdb` | `userdb.scimapi.common` |
| `ScimApiResourceBase` | `userdb.scimapi.eventdb` | `userdb.scimapi.common` |
| `set_user_names_from_official_address` | `webapp.common.api.helpers` | `common.proofing_utils` |
| `EduidSession` | `webapp.common.session` | `webapp.common.session.eduid_session` |
| `EduidTemporaryInstance` | `userdb.testing` | `userdb.testing.temp_instance` |
| `AttributeFetcher` | `workers.am.ams` | `workers.am.ams.common` |
| `BaseConfigParser` | `common.config.parsers` | `common.config.parsers.base` |
| `MsgCelerySingleton` | `workers.msg` | `workers.msg.common` |
| `AmCelerySingleton` | `workers.am` | `workers.am.common` |
| `PublicKeyCredentialRpEntity` | `fido2.server` | `fido2.webauthn` |

## `__all__` added (1 module)

- `workers/celery_typing.py` — `Task`. Defined in-module (conditional wrapper over
  celery's `Task`), not re-exported. Legitimate explicit API declaration.

## Other

- `--implicit-reexport` removed from Makefile typecheck command
