### PR TITLE
Use `min()` instead of `sorted(...)[0]`

### DIFF
--- a/src/eduid/satosa/scimapi/scim_attributes.py
+++ b/src/eduid/satosa/scimapi/scim_attributes.py
@@ -146,7 +146,7 @@ class ScimAttributes(ResponseMicroService):  # type: ignore[misc]
         # TODO: handle multiple profiles beyond just picking the first one
         profiles = user.profiles.keys()
         if profiles:
-            _name = sorted(profiles)[0]
+            _name = min(profiles)
             logger.info(f"Applying attributes from SCIM user {user.scim_id}, profile {_name}")
             profile = user.profiles[_name]
 

--- a/src/eduid/userdb/user.py
+++ b/src/eduid/userdb/user.py
@@ -172,7 +172,7 @@ class User(BaseModel):
                 _nin = nin_list.primary.to_dict()
             else:
                 # else use the nin added first
-                _nin = sorted(nin_list.to_list_of_dicts(), key=itemgetter("created_ts"))[0]
+                _nin = min(nin_list.to_list_of_dicts(), key=itemgetter("created_ts"))
             _identities = data.pop("identities", [])
             existing_nin = [item for item in _identities if item.get("identity_type") == IdentityType.NIN.value]
             if not existing_nin:  # workaround for users that did not get their nins list removed due to a bug in am


### PR DESCRIPTION
# Use `min()` instead of `sorted(...)[0]` (SonarCloud S8517)

## Why

Two call sites sort an entire collection just to take the first element. `min()`
expresses the intent directly and is `O(n)` instead of `O(n log n)`. Semantics
unchanged.

## Changes

| File | Before | After |
|------|--------|-------|
| [src/eduid/userdb/user.py:176](src/eduid/userdb/user.py#L176) | `sorted(nin_list.to_list_of_dicts(), key=itemgetter("created_ts"))[0]` | `min(nin_list.to_list_of_dicts(), key=itemgetter("created_ts"))` |
| [src/eduid/satosa/scimapi/scim_attributes.py:149](src/eduid/satosa/scimapi/scim_attributes.py#L149) | `sorted(profiles)[0]` | `min(profiles)` |
