### PR TITLE
Remove redundant `get_all_navet_data` mocks in webapp tests

### DIFF
--- a/src/eduid/webapp/eidas/tests/test_app.py
+++ b/src/eduid/webapp/eidas/tests/test_app.py
@@ -692,9 +692,7 @@ class EidasTests(ProofingTests[EidasApp]):
 
     def test_mfa_token_verify_no_verified_nin(self, mocker: MockerFixture) -> None:
         mock_reference_nin = mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         mock_reference_nin.return_value = None
 
@@ -854,9 +852,7 @@ class EidasTests(ProofingTests[EidasApp]):
 
     def test_nin_verify(self, mocker: MockerFixture) -> None:
         mock_reference_nin = mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         mock_reference_nin.return_value = None
 
@@ -957,9 +953,7 @@ class EidasTests(ProofingTests[EidasApp]):
 
     def test_mfa_login_unverified_nin(self, mocker: MockerFixture) -> None:
         mock_reference_nin = mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         mock_reference_nin.return_value = None
         eppn = self.test_unverified_user_eppn
@@ -1252,9 +1246,7 @@ class EidasTests(ProofingTests[EidasApp]):
 
     def test_nin_verify_no_backdoor_in_pro(self, mocker: MockerFixture) -> None:
         mock_reference_nin = mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         mock_reference_nin.return_value = None
 
@@ -1283,9 +1275,7 @@ class EidasTests(ProofingTests[EidasApp]):
 
     def test_nin_verify_no_backdoor_misconfigured(self, mocker: MockerFixture) -> None:
         mock_reference_nin = mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         mock_reference_nin.return_value = None
 
@@ -1381,9 +1371,7 @@ class EidasTests(ProofingTests[EidasApp]):
 
     def test_nin_staging_remap_verify(self, mocker: MockerFixture) -> None:
         mock_reference_nin = mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data")
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         mock_reference_nin.return_value = None
 

--- a/src/eduid/webapp/eidas/tests/test_app.py
+++ b/src/eduid/webapp/eidas/tests/test_app.py
@@ -596,9 +596,8 @@ class EidasTests(ProofingTests[EidasApp]):
         self._verify_user_parameters(eppn, token_verified=True, num_proofings=2, num_mfa_tokens=2)
 
     def test_webauthn_token_verify(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_user.eppn

--- a/src/eduid/webapp/freja_eid/tests/test_app.py
+++ b/src/eduid/webapp/freja_eid/tests/test_app.py
@@ -505,9 +505,8 @@ class FrejaEIDTests(ProofingTests[FrejaEIDApp]):
         )
 
     def test_verify_nin_identity_already_verified(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_user.eppn
@@ -736,9 +735,8 @@ class FrejaEIDTests(ProofingTests[FrejaEIDApp]):
         )
 
     def test_verify_foreign_identity_already_verified_nin(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_user.eppn
@@ -772,9 +770,8 @@ class FrejaEIDTests(ProofingTests[FrejaEIDApp]):
         )
 
     def test_verify_identity_expired_document(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.unverified_test_user.eppn
@@ -1104,9 +1101,8 @@ class FrejaEIDTests(ProofingTests[FrejaEIDApp]):
         self._verify_user_parameters(eppn, num_mfa_tokens=0, identity_verified=False, num_proofings=0)
 
     def test_mfa_login_unverified_identity_nin(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         eppn = self.test_unverified_user_eppn
 

--- a/src/eduid/webapp/samleid/tests/test_app.py
+++ b/src/eduid/webapp/samleid/tests/test_app.py
@@ -967,9 +967,7 @@ class NINMethodTests(SamlEidTests):
         mc: MethodConfig,
     ) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_unverified_user_eppn
@@ -1002,9 +1000,7 @@ class NINMethodTests(SamlEidTests):
         mc: MethodConfig,
     ) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_unverified_user_eppn
@@ -1119,9 +1115,7 @@ class NINMethodTests(SamlEidTests):
         mc: MethodConfig,
     ) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
         eppn = self.test_unverified_user_eppn
 
@@ -1215,9 +1209,7 @@ class NINMethodTests(SamlEidTests):
         mc: MethodConfig,
     ) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_unverified_user_eppn
@@ -1252,9 +1244,7 @@ class NINMethodTests(SamlEidTests):
         mc: MethodConfig,
     ) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_unverified_user_eppn
@@ -1369,9 +1359,7 @@ class NINMethodTests(SamlEidTests):
         mc: MethodConfig,
     ) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_unverified_user_eppn
@@ -1443,10 +1431,8 @@ class NINMethodTests(SamlEidTests):
         mc: MethodConfig,
     ) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
         """Test that identity verification fails when the SAML response has a wrong LOA (loa1 instead of loa3)"""
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_unverified_user_eppn

--- a/src/eduid/webapp/svipe_id/tests/test_app.py
+++ b/src/eduid/webapp/svipe_id/tests/test_app.py
@@ -432,9 +432,8 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
         )
 
     def test_verify_nin_identity_already_verified(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_user.eppn
@@ -633,9 +632,8 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
         )
 
     def test_verify_foreign_identity_already_verified_nin(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.test_user.eppn
@@ -665,9 +663,8 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
         )
 
     def test_verify_identity_expired_document(self, mocker: MockerFixture) -> None:
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
+        mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.unverified_test_user.eppn

--- a/src/eduid/webapp/svipe_id/tests/test_app.py
+++ b/src/eduid/webapp/svipe_id/tests/test_app.py
@@ -316,9 +316,7 @@ class SvipeIdTests(ProofingTests[SvipeIdApp]):
 
     def test_verify_nin_identity(self, mocker: MockerFixture) -> None:
         mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
-        mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
-        mock_get_all_navet_data.return_value = self._get_all_navet_data()
         mock_request_user_sync.side_effect = self.request_user_sync
 
         eppn = self.unverified_test_user.eppn


### PR DESCRIPTION
# Remove redundant `get_all_navet_data` mocks in webapp tests

## Why

In `eidas`, `bankid`, `samleid`, `svipe_id`, and `freja_eid`, the only production path to
`msg_relay.get_all_navet_data` is via the wrapper
[`get_reference_nin_from_navet_data`](src/eduid/webapp/common/api/utils.py#L320-L344).
When a test mocks the wrapper → `None`, the inner `get_all_navet_data` call short-circuits.
Any additional `mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")` in the
same test is unreachable dead weight. Follow-up to #947, which cleaned the bankid side.

Some other tests mocked only `get_all_navet_data` (not paired with the wrapper mock). Those
worked correctly because [`get_devel_all_navet_data`](src/eduid/workers/msg/tasks.py#L217) sets
`ReferenceNationalIdentityNumber = ""`, which is falsy, so the wrapper falls through to
`return None` — same outcome as mocking the wrapper directly. Unified to the wrapper-mock form
for consistency.

## Changes

### Pass 1 — remove redundant mock pairs (14 tests)

Each edit removes two lines:

```python
mock_get_all_navet_data = mocker.patch("eduid.common.rpc.msg_relay.MsgRelay.get_all_navet_data")
mock_get_all_navet_data.return_value = self._get_all_navet_data()
```

| File | Tests |
|---|---|
| [src/eduid/webapp/eidas/tests/test_app.py](src/eduid/webapp/eidas/tests/test_app.py) | `test_mfa_token_verify_no_verified_nin`, `test_nin_verify`, `test_mfa_login_unverified_nin`, `test_nin_verify_no_backdoor_in_pro`, `test_nin_verify_no_backdoor_misconfigured`, `test_nin_staging_remap_verify` |
| [src/eduid/webapp/samleid/tests/test_app.py](src/eduid/webapp/samleid/tests/test_app.py) | `test_webauthn_token_verify_backdoor`, `test_nin_verify`, `test_mfa_login_unverified_nin`, `test_nin_verify_no_backdoor_in_pro`, `test_nin_verify_no_backdoor_misconfigured`, `test_nin_staging_remap_verify`, `test_nin_verify_loa_mismatch` |
| [src/eduid/webapp/svipe_id/tests/test_app.py](src/eduid/webapp/svipe_id/tests/test_app.py) | `test_verify_nin_identity` |

### Pass 2 — consistency refactor (8 tests)

Replace indirect `get_all_navet_data` mock with direct wrapper mock:

```python
mocker.patch("eduid.webapp.common.api.helpers.get_reference_nin_from_navet_data", return_value=None)
```

| File | Tests |
|---|---|
| [src/eduid/webapp/eidas/tests/test_app.py](src/eduid/webapp/eidas/tests/test_app.py) | `test_webauthn_token_verify` |
| [src/eduid/webapp/svipe_id/tests/test_app.py](src/eduid/webapp/svipe_id/tests/test_app.py) | `test_verify_nin_identity_already_verified`, `test_verify_foreign_identity_already_verified_nin`, `test_verify_identity_expired_document` |
| [src/eduid/webapp/freja_eid/tests/test_app.py](src/eduid/webapp/freja_eid/tests/test_app.py) | `test_verify_nin_identity_already_verified`, `test_verify_foreign_identity_already_verified_nin`, `test_verify_identity_expired_document`, `test_mfa_login_unverified_identity_nin` |

All webapp proofing tests now uniformly mock `get_reference_nin_from_navet_data`.

## Left intact

- `lookup_mobile_proofing/tests/test_app.py` — prod code calls `get_all_navet_data` directly via `get_proofing_log_navet_data`.
- `security/tests/test_app.py` — `security.views` calls `msg_relay.get_all_navet_data` directly.
