### PR TITLE
Use only MockerFixture and remove mock

### DIFF
--- a/requirements/test_requirements.in
+++ b/requirements/test_requirements.in
@@ -4,7 +4,6 @@
 -r satosa_scim_requirements.in
 -r webapp_requirements.in
 -r worker_requirements.in
-mock
 mypy
 pip-tools
 pytest

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1200,10 +1200,6 @@ marshmallow-enum==1.5.1 \
     # via
     #   -c main.txt
     #   -r main.in
-mock==5.2.0 \
-    --hash=sha256:4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0 \
-    --hash=sha256:7ba87f72ca0e915175596069dbbcc7c75af7b5e9b9bc107ad6349ede0819982f
-    # via -r test_requirements.in
 motor==3.7.1 \
     --hash=sha256:27b4d46625c87928f331a6ca9d7c51c2f518ba0e270939d395bc1ddc89d64526 \
     --hash=sha256:8a63b9049e38eeeb56b4fdd57c3312a6d1f25d01db717fe7d82222393c410298

--- a/src/eduid/vccs/server/tests/test_password.py
+++ b/src/eduid/vccs/server/tests/test_password.py
@@ -1,6 +1,5 @@
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
+from pytest_mock import MockerFixture
 
 from eduid.vccs.server.config import NewHasherNotConfigured
 from eduid.vccs.server.db import KDF, CredType, PasswordCredential, Status, Version
@@ -8,6 +7,10 @@ from eduid.vccs.server.password import calculate_cred_hash
 
 
 class TestCalculateCredHash:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker: MockerFixture) -> None:
+        self.mocker = mocker
+
     def _make_cred(self, version: Version, key_label: str | None = None) -> PasswordCredential:
         return PasswordCredential(
             credential_id="test_cred_id",
@@ -24,11 +27,11 @@ class TestCalculateCredHash:
 
     async def test_v1_uses_hmac_sha1(self) -> None:
         cred = self._make_cred(Version.NDNv1)
-        hasher = MagicMock()
-        hasher.hmac_sha1 = AsyncMock(return_value=b"\x00" * 20)
-        hasher.hmac_sha256 = AsyncMock(return_value=b"\x00" * 32)
-        kdf = MagicMock()
-        kdf.pbkdf2_hmac_sha512 = MagicMock(return_value=b"\xab" * 64)
+        hasher = self.mocker.MagicMock()
+        hasher.hmac_sha1 = self.mocker.AsyncMock(return_value=b"\x00" * 20)
+        hasher.hmac_sha256 = self.mocker.AsyncMock(return_value=b"\x00" * 32)
+        kdf = self.mocker.MagicMock()
+        kdf.pbkdf2_hmac_sha512 = self.mocker.MagicMock(return_value=b"\xab" * 64)
 
         await calculate_cred_hash(user_id="test_user", H1="aa" * 16, cred=cred, hasher=hasher, kdf=kdf)
 
@@ -37,12 +40,12 @@ class TestCalculateCredHash:
 
     async def test_v2_uses_hmac_sha256(self) -> None:
         cred = self._make_cred(Version.NDNv2, key_label="test-key")
-        hasher = MagicMock()
-        hasher.hmac_sha1 = AsyncMock(return_value=b"\x00" * 20)
-        new_hasher = MagicMock()
-        new_hasher.hmac_sha256 = AsyncMock(return_value=b"\x00" * 32)
-        kdf = MagicMock()
-        kdf.pbkdf2_hmac_sha512 = MagicMock(return_value=b"\xab" * 64)
+        hasher = self.mocker.MagicMock()
+        hasher.hmac_sha1 = self.mocker.AsyncMock(return_value=b"\x00" * 20)
+        new_hasher = self.mocker.MagicMock()
+        new_hasher.hmac_sha256 = self.mocker.AsyncMock(return_value=b"\x00" * 32)
+        kdf = self.mocker.MagicMock()
+        kdf.pbkdf2_hmac_sha512 = self.mocker.MagicMock(return_value=b"\xab" * 64)
 
         await calculate_cred_hash(
             user_id="test_user", H1="aa" * 16, cred=cred, hasher=hasher, kdf=kdf, new_hasher=new_hasher
@@ -54,21 +57,23 @@ class TestCalculateCredHash:
 
     async def test_v2_without_key_label_raises(self) -> None:
         cred = self._make_cred(Version.NDNv2, key_label=None)
-        hasher = MagicMock()
-        kdf = MagicMock()
-        kdf.pbkdf2_hmac_sha512 = MagicMock(return_value=b"\xab" * 64)
+        hasher = self.mocker.MagicMock()
+        kdf = self.mocker.MagicMock()
+        kdf.pbkdf2_hmac_sha512 = self.mocker.MagicMock(return_value=b"\xab" * 64)
 
         with pytest.raises(ValueError, match="key_label"):
             await calculate_cred_hash(user_id="test_user", H1="aa" * 16, cred=cred, hasher=hasher, kdf=kdf)
 
     async def test_v1_and_v2_produce_different_hashes(self) -> None:
         """V1 and V2 should produce different H2 values for the same input."""
-        hasher = MagicMock()
-        hasher.hmac_sha1 = AsyncMock(return_value=b"\x01" * 20)
-        new_hasher = MagicMock()
-        new_hasher.hmac_sha256 = AsyncMock(return_value=b"\x02" * 32)
-        kdf = MagicMock()
-        kdf.pbkdf2_hmac_sha512 = MagicMock(side_effect=[b"\xab" * 64, b"\xcd" * 64, b"\xab" * 64, b"\xef" * 64])
+        hasher = self.mocker.MagicMock()
+        hasher.hmac_sha1 = self.mocker.AsyncMock(return_value=b"\x01" * 20)
+        new_hasher = self.mocker.MagicMock()
+        new_hasher.hmac_sha256 = self.mocker.AsyncMock(return_value=b"\x02" * 32)
+        kdf = self.mocker.MagicMock()
+        kdf.pbkdf2_hmac_sha512 = self.mocker.MagicMock(
+            side_effect=[b"\xab" * 64, b"\xcd" * 64, b"\xab" * 64, b"\xef" * 64]
+        )
 
         cred_v1 = self._make_cred(Version.NDNv1)
         h2_v1 = await calculate_cred_hash(user_id="test_user", H1="aa" * 16, cred=cred_v1, hasher=hasher, kdf=kdf)
@@ -83,13 +88,13 @@ class TestCalculateCredHash:
     async def test_v2_uses_new_hasher(self) -> None:
         """NDNv2 should use new_hasher.hmac_sha256, not the legacy hasher."""
         cred = self._make_cred(Version.NDNv2, key_label="test-key")
-        hasher = MagicMock()
-        hasher.hmac_sha1 = AsyncMock(return_value=b"\x00" * 20)
-        hasher.hmac_sha256 = AsyncMock(return_value=b"\x00" * 32)
-        new_hasher = MagicMock()
-        new_hasher.hmac_sha256 = AsyncMock(return_value=b"\xff" * 32)
-        kdf = MagicMock()
-        kdf.pbkdf2_hmac_sha512 = MagicMock(return_value=b"\xab" * 64)
+        hasher = self.mocker.MagicMock()
+        hasher.hmac_sha1 = self.mocker.AsyncMock(return_value=b"\x00" * 20)
+        hasher.hmac_sha256 = self.mocker.AsyncMock(return_value=b"\x00" * 32)
+        new_hasher = self.mocker.MagicMock()
+        new_hasher.hmac_sha256 = self.mocker.AsyncMock(return_value=b"\xff" * 32)
+        kdf = self.mocker.MagicMock()
+        kdf.pbkdf2_hmac_sha512 = self.mocker.MagicMock(return_value=b"\xab" * 64)
 
         await calculate_cred_hash(
             user_id="test_user", H1="aa" * 16, cred=cred, hasher=hasher, kdf=kdf, new_hasher=new_hasher
@@ -103,10 +108,10 @@ class TestCalculateCredHash:
     async def test_v2_without_new_hasher_raises(self) -> None:
         """NDNv2 without new_hasher should raise RuntimeError."""
         cred = self._make_cred(Version.NDNv2, key_label="test-key")
-        hasher = MagicMock()
-        hasher.hmac_sha1 = AsyncMock(return_value=b"\x00" * 20)
-        kdf = MagicMock()
-        kdf.pbkdf2_hmac_sha512 = MagicMock(return_value=b"\xab" * 64)
+        hasher = self.mocker.MagicMock()
+        hasher.hmac_sha1 = self.mocker.AsyncMock(return_value=b"\x00" * 20)
+        kdf = self.mocker.MagicMock()
+        kdf.pbkdf2_hmac_sha512 = self.mocker.MagicMock(return_value=b"\xab" * 64)
 
         with pytest.raises(NewHasherNotConfigured, match="new_hasher"):
             await calculate_cred_hash(user_id="test_user", H1="aa" * 16, cred=cred, hasher=hasher, kdf=kdf)
@@ -114,13 +119,13 @@ class TestCalculateCredHash:
     async def test_v1_ignores_new_hasher(self) -> None:
         """NDNv1 should use hasher.hmac_sha1, ignoring new_hasher entirely."""
         cred = self._make_cred(Version.NDNv1)
-        hasher = MagicMock()
-        hasher.hmac_sha1 = AsyncMock(return_value=b"\x00" * 20)
-        new_hasher = MagicMock()
-        new_hasher.hmac_sha256 = AsyncMock(return_value=b"\xff" * 32)
-        new_hasher.hmac_sha1 = AsyncMock(return_value=b"\xff" * 20)
-        kdf = MagicMock()
-        kdf.pbkdf2_hmac_sha512 = MagicMock(return_value=b"\xab" * 64)
+        hasher = self.mocker.MagicMock()
+        hasher.hmac_sha1 = self.mocker.AsyncMock(return_value=b"\x00" * 20)
+        new_hasher = self.mocker.MagicMock()
+        new_hasher.hmac_sha256 = self.mocker.AsyncMock(return_value=b"\xff" * 32)
+        new_hasher.hmac_sha1 = self.mocker.AsyncMock(return_value=b"\xff" * 20)
+        kdf = self.mocker.MagicMock()
+        kdf.pbkdf2_hmac_sha512 = self.mocker.MagicMock(return_value=b"\xab" * 64)
 
         await calculate_cred_hash(
             user_id="test_user", H1="aa" * 16, cred=cred, hasher=hasher, kdf=kdf, new_hasher=new_hasher

--- a/src/eduid/webapp/idp/tests/test_mfa_action.py
+++ b/src/eduid/webapp/idp/tests/test_mfa_action.py
@@ -1,6 +1,8 @@
 from collections.abc import Mapping
 from typing import cast
-from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
 
 from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.credentials import FidoCredential
@@ -16,6 +18,10 @@ from eduid.webapp.idp.tests.test_api import IdPAPITests
 class TestNeedSecurityKey(IdPAPITests):
     """Tests for the need_security_key function"""
 
+    @pytest.fixture(autouse=True)
+    def setup(self, setup_api: None, mocker: MockerFixture) -> None:
+        self.mocker = mocker
+
     def _get_idp_user(self) -> IdPUser:
         """Get the test user as an IdPUser from the IdP userdb"""
         user = self.app.userdb.lookup_user(self.test_user.eppn)
@@ -30,8 +36,8 @@ class TestNeedSecurityKey(IdPAPITests):
         """Create a mock LoginContext ticket with the specified credentials_used"""
         if credentials_used is None:
             credentials_used = {}
-        ticket = MagicMock(spec=LoginContext)
-        ticket.pending_request = MagicMock()
+        ticket = self.mocker.MagicMock(spec=LoginContext)
+        ticket.pending_request = self.mocker.MagicMock()
         ticket.pending_request.credentials_used = credentials_used
         return cast(LoginContext, ticket)
 

--- a/src/eduid/webapp/idp/tests/test_next_handlers.py
+++ b/src/eduid/webapp/idp/tests/test_next_handlers.py
@@ -1,8 +1,8 @@
 import logging
 from typing import cast
-from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.saml2 import EduidAuthnContextClass
@@ -31,19 +31,22 @@ from eduid.webapp.idp.views.next import (
 logger = logging.getLogger(__name__)
 
 
-def _mock_ticket() -> LoginContext:
-    """Create a minimal mock LoginContext for handler tests."""
-    ticket = MagicMock(spec=LoginContext)
-    ticket.reauthn_required = False
-    ticket.is_other_device_2 = False
-    ticket.known_device = None
-    ticket.known_device_info = None
-    ticket.service_info = None
-    return cast(LoginContext, ticket)
-
-
 class TestNextHandlers(IdPAPITests):
     """Unit tests for the individual handler functions extracted from next_view()."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, setup_api: None, mocker: MockerFixture) -> None:
+        self.mocker = mocker
+
+    def _mock_ticket(self) -> LoginContext:
+        """Create a minimal mock LoginContext for handler tests."""
+        ticket = self.mocker.MagicMock(spec=LoginContext)
+        ticket.reauthn_required = False
+        ticket.is_other_device_2 = False
+        ticket.known_device = None
+        ticket.known_device_info = None
+        ticket.service_info = None
+        return cast(LoginContext, ticket)
 
     def test_handle_unknown_device(self) -> None:
         with self.app.test_request_context():
@@ -53,7 +56,7 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_must_authenticate_no_eppn(self) -> None:
         """When eppn is None, should offer username+password auth."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=None)
         with self.app.test_request_context():
             result = _handle_must_authenticate(ticket, None, required_user)
@@ -63,7 +66,7 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_must_authenticate_with_eppn_no_webauthn(self) -> None:
         """When user has eppn but no webauthn, should offer username+password auth."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn="test-eppn")
         with self.app.test_request_context():
             result = _handle_must_authenticate(ticket, None, required_user)
@@ -75,7 +78,7 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_must_authenticate_with_real_user(self) -> None:
         """When user has eppn and credentials, action depends on their credential types."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
         with self.app.test_request_context():
             result = _handle_must_authenticate(ticket, None, required_user)
@@ -86,7 +89,7 @@ class TestNextHandlers(IdPAPITests):
     def test_handle_must_authenticate_with_security_key(self) -> None:
         """When user has a security key, should offer MFA auth."""
         self.add_test_user_security_key()
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
         with self.app.test_request_context():
             result = _handle_must_authenticate(ticket, None, required_user)
@@ -95,7 +98,7 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_mfa_required_no_fido_used(self) -> None:
         """When fido hasn't been used yet, should offer MFA auth."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
         _next = LoginNextResult(message=IdPMsg.mfa_required, authn_state=None)
         with self.app.test_request_context():
@@ -106,9 +109,9 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_mfa_required_fido_already_used(self) -> None:
         """When fido was already used, should offer password auth (no double security key)."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
-        authn_state = MagicMock(spec=AuthnState)
+        authn_state = self.mocker.MagicMock(spec=AuthnState)
         authn_state.fido_used = True
         _next = LoginNextResult(message=IdPMsg.mfa_required, authn_state=authn_state)
         with self.app.test_request_context():
@@ -118,7 +121,7 @@ class TestNextHandlers(IdPAPITests):
         assert result.payload["authn_options"]["webauthn"] is False
 
     def test_handle_security_key_required(self) -> None:
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
         with self.app.test_request_context():
             result = _handle_security_key_required(ticket, None, required_user)
@@ -127,7 +130,7 @@ class TestNextHandlers(IdPAPITests):
         assert result.payload["message"] == IdPMsg.mfa_required.value
 
     def test_handle_tou_required(self) -> None:
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
         with self.app.test_request_context():
             result = _handle_tou_required(ticket, None, required_user)
@@ -136,7 +139,7 @@ class TestNextHandlers(IdPAPITests):
         assert result.payload["message"] == IdPMsg.tou_required.value
 
     def test_handle_other_device(self) -> None:
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
         with self.app.test_request_context():
             result = _handle_other_device(ticket, None, required_user)
@@ -146,7 +149,7 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_proceed_no_sso_session(self) -> None:
         """Should return error when no SSO session is present."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
         _next = LoginNextResult(message=IdPMsg.proceed)
         with self.app.test_request_context():
@@ -156,9 +159,9 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_proceed_user_not_found(self) -> None:
         """Should return error when SSO session references a non-existent user."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn="nonexistent-eppn")
-        sso_session = MagicMock(spec=SSOSession)
+        sso_session = self.mocker.MagicMock(spec=SSOSession)
         sso_session.eppn = "nonexistent-eppn"
         _next = LoginNextResult(message=IdPMsg.proceed)
         with self.app.test_request_context():
@@ -168,9 +171,9 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_proceed_missing_authn_data(self) -> None:
         """Should raise RuntimeError when authn_info or authn_state is missing."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
-        sso_session = MagicMock(spec=SSOSession)
+        sso_session = self.mocker.MagicMock(spec=SSOSession)
         sso_session.eppn = self.test_user.eppn
         # authn_info and authn_state are both None by default
         _next = LoginNextResult(message=IdPMsg.proceed, authn_info=None, authn_state=None)
@@ -180,11 +183,11 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_proceed_unknown_ticket_type(self) -> None:
         """Should return error for a ticket that is neither SAML nor OtherDevice."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         required_user = RequiredUserResult(eppn=self.test_user.eppn)
-        sso_session = MagicMock(spec=SSOSession)
+        sso_session = self.mocker.MagicMock(spec=SSOSession)
         sso_session.eppn = self.test_user.eppn
-        authn_state = MagicMock(spec=AuthnState)
+        authn_state = self.mocker.MagicMock(spec=AuthnState)
         authn_info = AuthnInfo(class_ref=EduidAuthnContextClass.PASSWORD_PT, authn_attributes={}, instant=utc_now())
         _next = LoginNextResult(message=IdPMsg.proceed, authn_info=authn_info, authn_state=authn_state)
         with self.app.test_request_context():
@@ -194,7 +197,7 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_aborted_unknown_ticket_type(self) -> None:
         """Should return error for a ticket that is neither SAML nor OtherDevice."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         with self.app.test_request_context():
             result = _handle_aborted(ticket, None)
         assert result.status == FluxResponseStatus.ERROR
@@ -202,16 +205,16 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_aborted_other_device_abort_fails(self) -> None:
         """Should return error when other_device_db.abort() returns False."""
-        ticket = MagicMock(spec=LoginContextOtherDevice)
+        ticket = self.mocker.MagicMock(spec=LoginContextOtherDevice)
         ticket.reauthn_required = False
         ticket.is_other_device_2 = False
         ticket.known_device = None
         ticket.service_info = None
-        state = MagicMock()
+        state = self.mocker.MagicMock()
         state.state = OtherDeviceState.NEW
         ticket.other_device_req = state
         # Make abort fail
-        self.app.other_device_db.abort = MagicMock(return_value=False)  # type: ignore[method-assign]
+        self.mocker.patch.object(self.app.other_device_db, "abort", return_value=False)
         with self.app.test_request_context():
             result = _handle_aborted(cast(LoginContext, ticket), None)
         assert result.status == FluxResponseStatus.ERROR
@@ -219,12 +222,12 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_aborted_other_device_non_abortable_state(self) -> None:
         """Should return error when OtherDevice is in a non-abortable state (e.g. FINISHED)."""
-        ticket = MagicMock(spec=LoginContextOtherDevice)
+        ticket = self.mocker.MagicMock(spec=LoginContextOtherDevice)
         ticket.reauthn_required = False
         ticket.is_other_device_2 = False
         ticket.known_device = None
         ticket.service_info = None
-        state = MagicMock()
+        state = self.mocker.MagicMock()
         state.state = OtherDeviceState.FINISHED
         ticket.other_device_req = state
         with self.app.test_request_context():
@@ -234,7 +237,7 @@ class TestNextHandlers(IdPAPITests):
 
     def test_handle_assurance_failure_non_saml(self) -> None:
         """Should return error for a non-SAML ticket."""
-        ticket = _mock_ticket()
+        ticket = self._mock_ticket()
         with self.app.test_request_context():
             result = _handle_assurance_failure(ticket, None)
         assert result.status == FluxResponseStatus.ERROR

--- a/src/eduid/webapp/ladok/tests/test_app.py
+++ b/src/eduid/webapp/ladok/tests/test_app.py
@@ -1,7 +1,6 @@
 import json
 from collections.abc import Mapping
 from typing import Any, ClassVar
-from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -29,6 +28,18 @@ class MockResponse:
         return self._data
 
 
+def _get_university_data() -> dict[str, Any]:
+    return {
+        "data": {
+            "school_names": {
+                "ab": {"long_name_sv": "Lärosätesnamn", "long_name_en": "University Name"},
+                "cd": {"long_name_sv": "Annat Lärosätesnamn", "long_name_en": "Another University Name"},
+            }
+        },
+        "error": None,
+    }
+
+
 class LadokTests(EduidAPITestCase[LadokApp]):
     api_users: ClassVar[list[str]] = ["hubba-bubba", "hubba-baar"]
 
@@ -38,15 +49,7 @@ class LadokTests(EduidAPITestCase[LadokApp]):
         self.test_unverified_user_eppn = "hubba-baar"
         self.ladok_user_external_id = uuid4()
 
-        self.university_data = {
-            "data": {
-                "school_names": {
-                    "ab": {"long_name_sv": "Lärosätesnamn", "long_name_en": "University Name"},
-                    "cd": {"long_name_sv": "Annat Lärosätesnamn", "long_name_en": "Another University Name"},
-                }
-            },
-            "error": None,
-        }
+        self.university_data = _get_university_data()
 
         # remove Ladok data from test user
         user = self.app.central_userdb.get_user_by_eppn(eppn=self.test_user_eppn)
@@ -58,18 +61,7 @@ class LadokTests(EduidAPITestCase[LadokApp]):
         Called from the parent class, so we can provide the appropriate flask
         app for this test case.
         """
-        university_data = {
-            "data": {
-                "school_names": {
-                    "ab": {"long_name_sv": "Lärosätesnamn", "long_name_en": "University Name"},
-                    "cd": {"long_name_sv": "Annat Lärosätesnamn", "long_name_en": "Another University Name"},
-                }
-            },
-            "error": None,
-        }
-        with patch("requests.get") as mock_response:
-            mock_response.return_value = MockResponse(200, university_data)
-            return init_ladok_app("testing", config)
+        return init_ladok_app("testing", config)
 
     def _get_base_config(self) -> dict[str, Any]:
         config = super()._get_base_config()
@@ -80,7 +72,8 @@ class LadokTests(EduidAPITestCase[LadokApp]):
         return config
 
     @pytest.fixture(scope="class")
-    def update_config(self) -> dict[str, Any]:
+    def update_config(self, class_mocker: MockerFixture) -> dict[str, Any]:
+        class_mocker.patch("requests.get", return_value=MockResponse(200, _get_university_data()))
         return self._get_base_config()
 
     def _link_user(self, eppn: str, ladok_name: str) -> TestResponse:

--- a/src/eduid/webapp/orcid/tests/test_app.py
+++ b/src/eduid/webapp/orcid/tests/test_app.py
@@ -1,7 +1,6 @@
 import json
 from collections.abc import Mapping
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 from pytest_mock import MockerFixture
@@ -14,6 +13,12 @@ from eduid.webapp.common.api.testing import EduidAPITestCase
 from eduid.webapp.orcid.app import OrcidApp, init_orcid_app
 
 __author__ = "lundberg"
+
+
+class MockResponse:
+    def __init__(self, status_code: int, text: str) -> None:
+        self.status_code = status_code
+        self.text = text
 
 
 class OrcidTests(EduidAPITestCase[OrcidApp]):
@@ -51,6 +56,10 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
         Called from the parent class, so we can provide the appropriate flask
         app for this test case.
         """
+        return init_orcid_app("testing", config)
+
+    @pytest.fixture(scope="class")
+    def update_config(self, class_mocker: MockerFixture) -> dict[str, Any]:
         oidc_provider_config = {
             "token_endpoint_auth_signing_alg_values_supported": ["RS256"],
             "id_token_signing_alg_values_supported": ["RS256"],
@@ -66,18 +75,10 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
             "token_endpoint_auth_methods_supported": ["client_secret_basic"],
             "issuer": "https://example.com/op/",
         }
-
-        class MockResponse:
-            def __init__(self, status_code: int, text: str) -> None:
-                self.status_code = status_code
-                self.text = text
-
-        with patch("oic.oic.Client.http_request") as mock_response:
-            mock_response.return_value = MockResponse(200, json.dumps(oidc_provider_config))
-            return init_orcid_app("testing", config)
-
-    @pytest.fixture(scope="class")
-    def update_config(self) -> dict[str, Any]:
+        class_mocker.patch(
+            "oic.oic.Client.http_request",
+            return_value=MockResponse(200, json.dumps(oidc_provider_config)),
+        )
         config = self._get_base_config()
         config.update(
             {


### PR DESCRIPTION
## Summary

This updates the remaining targeted tests to use pytest-mock fixtures instead of direct unittest.mock usage, and removes the now-redundant mock dependency from the test requirements.

The change set specifically:
- replaces direct MagicMock, AsyncMock, and patch usage with mocker or class_mocker fixtures
- moves class-scoped startup patching into fixture-based setup where app initialization depends on patched external calls
- keeps the test mocking style consistent across the touched suites
- removes mock from the test requirements input and compiled lockfile