### PR TITLE
Generic `ContextRequest`, drop `assert`s in scimapi / maccapi

### DIFF
--- a/src/eduid/common/fastapi/context_request.py
+++ b/src/eduid/common/fastapi/context_request.py
@@ -12,28 +12,30 @@ class Context:
         return asdict(self)
 
 
-class ContextRequest(Request):
-    def __init__(self, context_class: type[Context], *args: Any, **kwargs: Any) -> None:
+class ContextRequest[C: Context](Request):
+    def __init__(self, context_class: type[C], *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.contextClass = context_class
+        self.contextClass: type[C] = context_class
 
     @property
-    def context(self) -> Context:
+    def context(self) -> C:
         try:
-            return cast(Context, self.state.context)
+            return cast(C, self.state.context)
         except AttributeError:
             # Lazy init of self.state.context
             self.state.context = self.contextClass()
             return self.context
 
     @context.setter
-    def context(self, context: Context) -> None:
+    def context(self, context: C) -> None:
         self.state.context = context
 
 
 class ContextRequestMixin:
     @staticmethod
-    def make_context_request(request: Request | ContextRequest, context_class: type[Context]) -> ContextRequest:
+    def make_context_request[C: Context](
+        request: Request | ContextRequest[C], context_class: type[C]
+    ) -> ContextRequest[C]:
         if not isinstance(request, ContextRequest):
             request = ContextRequest(context_class=context_class, scope=request.scope, receive=request.receive)
         return request
@@ -50,7 +52,7 @@ class ContextRequestRoute(APIRoute, ContextRequestMixin):
     def get_route_handler(self) -> Callable[..., Any]:
         original_route_handler = super().get_route_handler()
 
-        async def context_route_handler(request: Request | ContextRequest) -> Response:
+        async def context_route_handler(request: Request | ContextRequest[Context]) -> Response:
             request = self.make_context_request(request=request, context_class=self.contextClass)
             return await original_route_handler(request)
 

--- a/src/eduid/common/fastapi/context_request.py
+++ b/src/eduid/common/fastapi/context_request.py
@@ -12,7 +12,7 @@ class Context:
         return asdict(self)
 
 
-class ContextRequest[C: Context](Request):
+class ContextRequest[C: Context = Context](Request):
     def __init__(self, context_class: type[C], *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.contextClass: type[C] = context_class
@@ -33,12 +33,10 @@ class ContextRequest[C: Context](Request):
 
 class ContextRequestMixin:
     @staticmethod
-    def make_context_request[C: Context](
-        request: Request | ContextRequest[C], context_class: type[C]
-    ) -> ContextRequest[C]:
-        if not isinstance(request, ContextRequest):
-            request = ContextRequest(context_class=context_class, scope=request.scope, receive=request.receive)
-        return request
+    def make_context_request[C: Context](request: Request, context_class: type[C]) -> ContextRequest[C]:
+        if isinstance(request, ContextRequest):
+            return cast(ContextRequest[C], request)
+        return ContextRequest(context_class=context_class, scope=request.scope, receive=request.receive)
 
 
 class ContextRequestRoute(APIRoute, ContextRequestMixin):

--- a/src/eduid/maccapi/context_request.py
+++ b/src/eduid/maccapi/context_request.py
@@ -1,4 +1,4 @@
-from eduid.common.fastapi.context_request import Context, ContextRequestRoute
+from eduid.common.fastapi.context_request import Context, ContextRequest, ContextRequestRoute
 
 
 class MaccAPIContext(Context):
@@ -14,6 +14,10 @@ class MaccAPIContext(Context):
         if self.manager_eppn is None:
             raise RuntimeError("manager_eppn not initialised")
         return self.manager_eppn
+
+
+class MaccAPIRequest(ContextRequest[MaccAPIContext]):
+    """Concrete subclass so FastAPI's param inspector sees a plain Request subclass."""
 
 
 class MaccAPIRoute(ContextRequestRoute):

--- a/src/eduid/maccapi/context_request.py
+++ b/src/eduid/maccapi/context_request.py
@@ -5,6 +5,16 @@ class MaccAPIContext(Context):
     manager_eppn: str | None = None
     data_owner: str | None = None
 
+    def require_data_owner(self) -> str:
+        if self.data_owner is None:
+            raise RuntimeError("data_owner not initialised")
+        return self.data_owner
+
+    def require_manager_eppn(self) -> str:
+        if self.manager_eppn is None:
+            raise RuntimeError("manager_eppn not initialised")
+        return self.manager_eppn
+
 
 class MaccAPIRoute(ContextRequestRoute):
     contextClass = MaccAPIContext

--- a/src/eduid/maccapi/middleware.py
+++ b/src/eduid/maccapi/middleware.py
@@ -91,7 +91,6 @@ class AuthenticationMiddleware(BaseHTTPMiddleware, ContextRequestMixin):
             self.context.logger.error(f"Data owner {data_owner!r} not configured")
             return return_error_response(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown data_owner")
 
-        assert isinstance(request.context, MaccAPIContext)  # please mypy
         request.context.data_owner = data_owner
         request.context.manager_eppn = token.saml_eppn
 

--- a/src/eduid/maccapi/routers/users.py
+++ b/src/eduid/maccapi/routers/users.py
@@ -1,8 +1,7 @@
 from fastapi import APIRouter, Response, status
 
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.utils import generate_password
-from eduid.maccapi.context_request import MaccAPIContext, MaccAPIRoute
+from eduid.maccapi.context_request import MaccAPIRequest, MaccAPIRoute
 from eduid.maccapi.helpers import (
     UnableToAddPassword,
     add_api_event,
@@ -30,7 +29,7 @@ users_router = APIRouter(route_class=MaccAPIRoute, prefix="/Users")
 
 
 @users_router.get("/", response_model_exclude_none=True)
-async def get_users(request: ContextRequest[MaccAPIContext]) -> UserListResponse:
+async def get_users(request: MaccAPIRequest) -> UserListResponse:
     """
     return all users that the calling user has access to in current context
     """
@@ -45,7 +44,7 @@ async def get_users(request: ContextRequest[MaccAPIContext]) -> UserListResponse
 
 @users_router.post("/create", response_model_exclude_none=True)
 async def add_user(
-    request: ContextRequest[MaccAPIContext], create_request: UserCreateRequest, response: Response
+    request: MaccAPIRequest, create_request: UserCreateRequest, response: Response
 ) -> UserCreatedResponse:
     """
     add a new user to the current context
@@ -90,7 +89,7 @@ async def add_user(
 
 @users_router.post("/remove", response_model_exclude_none=True)
 async def remove_user(
-    request: ContextRequest[MaccAPIContext], remove_request: UserRemoveRequest, response: Response
+    request: MaccAPIRequest, remove_request: UserRemoveRequest, response: Response
 ) -> UserRemovedResponse:
     """
     remove a user from the current context
@@ -131,7 +130,7 @@ async def remove_user(
 
 @users_router.post("/reset_password")
 async def reset_password(
-    request: ContextRequest[MaccAPIContext], reset_request: UserResetPasswordRequest, response: Response
+    request: MaccAPIRequest, reset_request: UserResetPasswordRequest, response: Response
 ) -> UserResetPasswordResponse:
     """
     reset a user's password

--- a/src/eduid/maccapi/routers/users.py
+++ b/src/eduid/maccapi/routers/users.py
@@ -34,8 +34,7 @@ async def get_users(request: ContextRequest[MaccAPIContext]) -> UserListResponse
     """
     return all users that the calling user has access to in current context
     """
-    assert request.context.data_owner is not None  # please mypy
-    managed_accounts = list_users(context=request.app.context, data_owner=request.context.data_owner)
+    managed_accounts = list_users(context=request.app.context, data_owner=request.context.require_data_owner())
 
     users = [ApiUser(eppn=user.eppn, given_name=user.given_name, surname=user.surname) for user in managed_accounts]
 
@@ -55,11 +54,9 @@ async def add_user(
 
     password = generate_password()
     presentable_password = make_presentable_password(password)
-    assert request.context.data_owner is not None  # please mypy
-    assert request.context.manager_eppn is not None  # please mypy
     managed_account: ManagedAccount = create_and_sync_user(
         context=request.app.context,
-        data_owner=request.context.data_owner,
+        data_owner=request.context.require_data_owner(),
         given_name=create_request.given_name,
         surname=create_request.surname,
         password=password,
@@ -71,8 +68,8 @@ async def add_user(
         context=request.app.context,
         eppn=managed_account.eppn,
         action="created user",
-        action_by=request.context.manager_eppn,
-        data_owner=request.context.data_owner,
+        action_by=request.context.require_manager_eppn(),
+        data_owner=request.context.require_data_owner(),
     )
 
     add_user_response = UserCreatedResponse(
@@ -102,18 +99,16 @@ async def remove_user(
     request.app.context.logger.debug(f"remove_user: {remove_request}")
 
     try:
-        assert request.context.data_owner is not None  # please mypy
-        assert request.context.manager_eppn is not None  # please mypy
         managed_account: ManagedAccount = deactivate_user(
-            context=request.app.context, eppn=remove_request.eppn, data_owner=request.context.data_owner
+            context=request.app.context, eppn=remove_request.eppn, data_owner=request.context.require_data_owner()
         )
 
         add_api_event(
             context=request.app.context,
             eppn=remove_request.eppn,
             action="deactivated user",
-            action_by=request.context.manager_eppn,
-            data_owner=request.context.data_owner,
+            action_by=request.context.require_manager_eppn(),
+            data_owner=request.context.require_data_owner(),
         )
 
         api_user = ApiUser(
@@ -147,17 +142,15 @@ async def reset_password(
     new_password = generate_password()
     presentable_password = make_presentable_password(new_password)
     try:
-        assert request.context.data_owner is not None  # please mypy
-        assert request.context.manager_eppn is not None  # please mypy
-        managed_account = get_user(context=request.app.context, eppn=eppn, data_owner=request.context.data_owner)
+        managed_account = get_user(context=request.app.context, eppn=eppn, data_owner=request.context.require_data_owner())
         replace_password(context=request.app.context, eppn=eppn, new_password=new_password)
 
         add_api_event(
             context=request.app.context,
             eppn=reset_request.eppn,
             action="reset password for user",
-            action_by=request.context.manager_eppn,
-            data_owner=request.context.data_owner,
+            action_by=request.context.require_manager_eppn(),
+            data_owner=request.context.require_data_owner(),
         )
 
         api_user = ApiUser(

--- a/src/eduid/maccapi/routers/users.py
+++ b/src/eduid/maccapi/routers/users.py
@@ -30,12 +30,10 @@ users_router = APIRouter(route_class=MaccAPIRoute, prefix="/Users")
 
 
 @users_router.get("/", response_model_exclude_none=True)
-async def get_users(request: ContextRequest) -> UserListResponse:
+async def get_users(request: ContextRequest[MaccAPIContext]) -> UserListResponse:
     """
     return all users that the calling user has access to in current context
     """
-
-    assert isinstance(request.context, MaccAPIContext)  # please mypy
     assert request.context.data_owner is not None  # please mypy
     managed_accounts = list_users(context=request.app.context, data_owner=request.context.data_owner)
 
@@ -48,7 +46,7 @@ async def get_users(request: ContextRequest) -> UserListResponse:
 
 @users_router.post("/create", response_model_exclude_none=True)
 async def add_user(
-    request: ContextRequest, create_request: UserCreateRequest, response: Response
+    request: ContextRequest[MaccAPIContext], create_request: UserCreateRequest, response: Response
 ) -> UserCreatedResponse:
     """
     add a new user to the current context
@@ -57,8 +55,6 @@ async def add_user(
 
     password = generate_password()
     presentable_password = make_presentable_password(password)
-
-    assert isinstance(request.context, MaccAPIContext)  # please mypy
     assert request.context.data_owner is not None  # please mypy
     assert request.context.manager_eppn is not None  # please mypy
     managed_account: ManagedAccount = create_and_sync_user(
@@ -97,7 +93,7 @@ async def add_user(
 
 @users_router.post("/remove", response_model_exclude_none=True)
 async def remove_user(
-    request: ContextRequest, remove_request: UserRemoveRequest, response: Response
+    request: ContextRequest[MaccAPIContext], remove_request: UserRemoveRequest, response: Response
 ) -> UserRemovedResponse:
     """
     remove a user from the current context
@@ -106,7 +102,6 @@ async def remove_user(
     request.app.context.logger.debug(f"remove_user: {remove_request}")
 
     try:
-        assert isinstance(request.context, MaccAPIContext)  # please mypy
         assert request.context.data_owner is not None  # please mypy
         assert request.context.manager_eppn is not None  # please mypy
         managed_account: ManagedAccount = deactivate_user(
@@ -141,7 +136,7 @@ async def remove_user(
 
 @users_router.post("/reset_password")
 async def reset_password(
-    request: ContextRequest, reset_request: UserResetPasswordRequest, response: Response
+    request: ContextRequest[MaccAPIContext], reset_request: UserResetPasswordRequest, response: Response
 ) -> UserResetPasswordResponse:
     """
     reset a user's password
@@ -152,7 +147,6 @@ async def reset_password(
     new_password = generate_password()
     presentable_password = make_presentable_password(new_password)
     try:
-        assert isinstance(request.context, MaccAPIContext)  # please mypy
         assert request.context.data_owner is not None  # please mypy
         assert request.context.manager_eppn is not None  # please mypy
         managed_account = get_user(context=request.app.context, eppn=eppn, data_owner=request.context.data_owner)

--- a/src/eduid/scimapi/context.py
+++ b/src/eduid/scimapi/context.py
@@ -13,6 +13,7 @@ from eduid.common.models.scim_base import SCIMResourceType
 from eduid.common.utils import make_etag, urlappend
 from eduid.queue.db.message import MessageDB
 from eduid.scimapi.config import ScimApiConfig
+from eduid.scimapi.context_request import ScimApiContext
 from eduid.scimapi.notifications import NotificationRelay
 from eduid.scimapi.utils import load_jwks
 from eduid.userdb.scimapi import ScimApiEventDB, ScimApiGroup, ScimApiGroupDB
@@ -116,7 +117,9 @@ class Context:
     def resource_url(self, resource_type: SCIMResourceType, scim_id: UUID) -> str:
         return self.url_for(resource_type.value + "s", str(scim_id))
 
-    def check_version(self, req: ContextRequest, db_obj: ScimApiGroup | ScimApiUser | ScimApiInvite) -> bool:
+    def check_version(
+        self, req: ContextRequest[ScimApiContext], db_obj: ScimApiGroup | ScimApiUser | ScimApiInvite
+    ) -> bool:
         if req.headers.get("IF-MATCH") == make_etag(db_obj.version):
             return True
         self.logger.error("Version mismatch")

--- a/src/eduid/scimapi/context_request.py
+++ b/src/eduid/scimapi/context_request.py
@@ -2,7 +2,7 @@ __author__ = "lundberg"
 
 
 from eduid.common.config.base import DataOwnerName
-from eduid.common.fastapi.context_request import Context, ContextRequestRoute
+from eduid.common.fastapi.context_request import Context, ContextRequest, ContextRequestRoute
 from eduid.userdb.scimapi import ScimApiEventDB, ScimApiGroupDB
 from eduid.userdb.scimapi.invitedb import ScimApiInviteDB
 from eduid.userdb.scimapi.userdb import ScimApiUserDB
@@ -39,6 +39,10 @@ class ScimApiContext(Context):
         if self.eventdb is None:
             raise RuntimeError("eventdb not initialised")
         return self.eventdb
+
+
+class ScimApiRequest(ContextRequest[ScimApiContext]):
+    """Concrete subclass so FastAPI's param inspector sees a plain Request subclass."""
 
 
 class ScimApiRoute(ContextRequestRoute):

--- a/src/eduid/scimapi/context_request.py
+++ b/src/eduid/scimapi/context_request.py
@@ -15,6 +15,31 @@ class ScimApiContext(Context):
     invitedb: ScimApiInviteDB | None = None
     eventdb: ScimApiEventDB | None = None
 
+    def require_data_owner(self) -> DataOwnerName:
+        if self.data_owner is None:
+            raise RuntimeError("data_owner not initialised")
+        return self.data_owner
+
+    def require_userdb(self) -> ScimApiUserDB:
+        if self.userdb is None:
+            raise RuntimeError("userdb not initialised")
+        return self.userdb
+
+    def require_groupdb(self) -> ScimApiGroupDB:
+        if self.groupdb is None:
+            raise RuntimeError("groupdb not initialised")
+        return self.groupdb
+
+    def require_invitedb(self) -> ScimApiInviteDB:
+        if self.invitedb is None:
+            raise RuntimeError("invitedb not initialised")
+        return self.invitedb
+
+    def require_eventdb(self) -> ScimApiEventDB:
+        if self.eventdb is None:
+            raise RuntimeError("eventdb not initialised")
+        return self.eventdb
+
 
 class ScimApiRoute(ContextRequestRoute):
     contextClass = ScimApiContext

--- a/src/eduid/scimapi/middleware.py
+++ b/src/eduid/scimapi/middleware.py
@@ -79,8 +79,6 @@ class AuthenticationMiddleware(BaseMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         req = self.make_context_request(request=request, context_class=ScimApiContext)
 
-        assert isinstance(req.context, ScimApiContext)  # please mypy
-
         if self._is_no_auth_path(req.url):
             return await call_next(req)
 

--- a/src/eduid/scimapi/routers/events.py
+++ b/src/eduid/scimapi/routers/events.py
@@ -31,8 +31,7 @@ async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: s
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching event {scim_id}")
-    assert req.context.eventdb is not None  # please mypy
-    db_event = req.context.eventdb.get_event_by_scim_id(scim_id)
+    db_event = req.context.require_eventdb().get_event_by_scim_id(scim_id)
     if not db_event:
         raise NotFound(detail="Event not found")
     return db_event_to_response(req, resp, db_event)
@@ -94,9 +93,7 @@ async def on_post(
         _timestamp = create_request.nutid_event_v1.timestamp
     _expires_at = utc_now() + timedelta(days=1)
 
-    assert req.context.data_owner is not None  # please mypy
-    assert req.context.eventdb is not None  # please mypy
-
+    data_owner = req.context.require_data_owner()
     event = ScimApiEvent(
         resource=ScimApiEventResource(
             resource_type=create_request.nutid_event_v1.resource.resource_type,
@@ -106,12 +103,12 @@ async def on_post(
             external_id=referenced.external_id,
         ),
         level=create_request.nutid_event_v1.level,
-        source=req.context.data_owner,
+        source=data_owner,
         data=create_request.nutid_event_v1.data,
         expires_at=_expires_at,
         timestamp=_timestamp,
     )
-    req.context.eventdb.save(event)
+    req.context.require_eventdb().save(event)
 
     # Send notification
     message = req.app.context.notification_relay.format_message(
@@ -119,7 +116,7 @@ async def on_post(
     )
 
     req.app.context.notification_relay.notify(
-        data_owner=req.context.data_owner, message=message, context=req.app.context
+        data_owner=data_owner, message=message, context=req.app.context
     )
 
     return db_event_to_response(req, resp, event)

--- a/src/eduid/scimapi/routers/events.py
+++ b/src/eduid/scimapi/routers/events.py
@@ -2,11 +2,10 @@ from datetime import timedelta
 
 from fastapi import Response
 
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import SCIMResourceType
 from eduid.scimapi.api_router import APIRouter
-from eduid.scimapi.context_request import ScimApiContext, ScimApiRoute
+from eduid.scimapi.context_request import ScimApiRequest, ScimApiRoute
 from eduid.scimapi.exceptions import BadRequest, ErrorDetail, NotFound
 from eduid.scimapi.models.event import EventCreateRequest, EventResponse
 from eduid.scimapi.routers.utils.events import db_event_to_response, get_scim_referenced
@@ -27,7 +26,7 @@ events_router = APIRouter(
 
 
 @events_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str | None = None) -> EventResponse:
+async def on_get(req: ScimApiRequest, resp: Response, scim_id: str | None = None) -> EventResponse:
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching event {scim_id}")
@@ -39,7 +38,7 @@ async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: s
 
 @events_router.post("/", response_model_exclude_none=True)
 async def on_post(
-    req: ContextRequest[ScimApiContext], resp: Response, create_request: EventCreateRequest
+    req: ScimApiRequest, resp: Response, create_request: EventCreateRequest
 ) -> EventResponse:
     """
     POST /Events  HTTP/1.1

--- a/src/eduid/scimapi/routers/events.py
+++ b/src/eduid/scimapi/routers/events.py
@@ -27,11 +27,10 @@ events_router = APIRouter(
 
 
 @events_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get(req: ContextRequest, resp: Response, scim_id: str | None = None) -> EventResponse:
+async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str | None = None) -> EventResponse:
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching event {scim_id}")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.eventdb is not None  # please mypy
     db_event = req.context.eventdb.get_event_by_scim_id(scim_id)
     if not db_event:
@@ -40,7 +39,9 @@ async def on_get(req: ContextRequest, resp: Response, scim_id: str | None = None
 
 
 @events_router.post("/", response_model_exclude_none=True)
-async def on_post(req: ContextRequest, resp: Response, create_request: EventCreateRequest) -> EventResponse:
+async def on_post(
+    req: ContextRequest[ScimApiContext], resp: Response, create_request: EventCreateRequest
+) -> EventResponse:
     """
     POST /Events  HTTP/1.1
     Host: example.com
@@ -93,7 +94,6 @@ async def on_post(req: ContextRequest, resp: Response, create_request: EventCrea
         _timestamp = create_request.nutid_event_v1.timestamp
     _expires_at = utc_now() + timedelta(days=1)
 
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.data_owner is not None  # please mypy
     assert req.context.eventdb is not None  # please mypy
 

--- a/src/eduid/scimapi/routers/groups.py
+++ b/src/eduid/scimapi/routers/groups.py
@@ -29,8 +29,7 @@ groups_router = APIRouter(
 
 @groups_router.get("/")
 async def on_get_all(req: ContextRequest[ScimApiContext]) -> ListResponse:
-    assert req.context.groupdb is not None  # please mypy
-    db_groups = req.context.groupdb.get_groups()
+    db_groups = req.context.require_groupdb().get_groups()
     resources = [{"id": str(db_group.scim_id), "displayName": db_group.graph.display_name} for db_group in db_groups]
     return ListResponse(total_results=len(db_groups), resources=resources)
 
@@ -67,8 +66,7 @@ async def on_get_one(req: ContextRequest[ScimApiContext], resp: Response, scim_i
     }
     """
     req.app.context.logger.info(f"Fetching group {scim_id}")
-    assert req.context.groupdb is not None  # please mypy
-    db_group = req.context.groupdb.get_group_by_scim_id(scim_id)
+    db_group = req.context.require_groupdb().get_group_by_scim_id(scim_id)
     req.app.context.logger.debug(f"Found group: {db_group}")
     if not db_group:
         raise NotFound(detail="Group not found")
@@ -136,8 +134,7 @@ async def on_put(
         raise BadRequest(detail="Id mismatch")
 
     req.app.context.logger.info(f"Fetching group {scim_id}")
-    assert req.context.groupdb is not None  # please mypy
-    db_group = req.context.groupdb.get_group_by_scim_id(str(update_request.id))
+    db_group = req.context.require_groupdb().get_group_by_scim_id(str(update_request.id))
     req.app.context.logger.debug(f"Found group: {db_group}")
     if not db_group:
         raise NotFound(detail="Group not found")
@@ -147,29 +144,26 @@ async def on_put(
         raise BadRequest(detail="Version mismatch")
 
     # Check that members exists in their respective db
-    assert req.context.userdb is not None  # please mypy
     req.app.context.logger.info("Checking if group and user members exists")
     for member in update_request.members:
         if member.is_group:
-            if not req.context.groupdb.group_exists(str(member.value)):
+            if not req.context.require_groupdb().group_exists(str(member.value)):
                 req.app.context.logger.error(f"Group {member.value} not found")
                 raise BadRequest(detail=f"Group {member.value} not found")
         if member.is_user:
-            if not req.context.userdb.user_exists(scim_id=str(member.value)):
+            if not req.context.require_userdb().user_exists(scim_id=str(member.value)):
                 req.app.context.logger.error(f"User {member.value} not found")
                 raise BadRequest(detail=f"User {member.value} not found")
 
-    updated_group, changed = req.context.groupdb.update_group(update_request=update_request, db_group=db_group)
+    updated_group, changed = req.context.require_groupdb().update_group(update_request=update_request, db_group=db_group)
     # Load the group from the database to ensure results are consistent with subsequent GETs.
     # For example, timestamps have higher resolution in updated_group than after a load.
-    db_group = req.context.groupdb.get_group_by_scim_id(str(updated_group.scim_id))
+    db_group = req.context.require_groupdb().get_group_by_scim_id(str(updated_group.scim_id))
     assert db_group  # please mypy
-
-    assert req.context.data_owner is not None  # please mypy
     if changed:
         add_api_event(
             context=req.app.context,
-            data_owner=req.context.data_owner,
+            data_owner=req.context.require_data_owner(),
             db_obj=db_group,
             resource_type=SCIMResourceType.GROUP,
             level=EventLevel.INFO,
@@ -213,17 +207,14 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
     """
     req.app.context.logger.info("Creating group")
     req.app.context.logger.debug(create_request)
-    assert req.context.groupdb is not None  # please mypy
-    created_group = req.context.groupdb.create_group(create_request=create_request)
+    created_group = req.context.require_groupdb().create_group(create_request=create_request)
     # Load the group from the database to ensure results are consistent with subsequent GETs.
     # For example, timestamps have higher resolution in created_group than after a load.
-    db_group = req.context.groupdb.get_group_by_scim_id(str(created_group.scim_id))
+    db_group = req.context.require_groupdb().get_group_by_scim_id(str(created_group.scim_id))
     assert db_group  # please mypy
-
-    assert req.context.data_owner is not None  # please mypy
     add_api_event(
         context=req.app.context,
-        data_owner=req.context.data_owner,
+        data_owner=req.context.require_data_owner(),
         db_obj=db_group,
         resource_type=SCIMResourceType.GROUP,
         level=EventLevel.INFO,
@@ -243,8 +234,7 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
 )
 async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting group {scim_id}")
-    assert req.context.groupdb is not None  # please mypy
-    db_group = req.context.groupdb.get_group_by_scim_id(scim_id=scim_id)
+    db_group = req.context.require_groupdb().get_group_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found group: {db_group}")
     if not db_group:
         raise NotFound(detail="Group not found")
@@ -253,12 +243,10 @@ async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
     if not req.app.context.check_version(req, db_group):
         raise BadRequest(detail="Version mismatch")
 
-    res = req.context.groupdb.remove_group(db_group)
-
-    assert req.context.data_owner is not None  # please mypy
+    res = req.context.require_groupdb().remove_group(db_group)
     add_api_event(
         context=req.app.context,
-        data_owner=req.context.data_owner,
+        data_owner=req.context.require_data_owner(),
         db_obj=db_group,
         resource_type=SCIMResourceType.GROUP,
         level=EventLevel.INFO,

--- a/src/eduid/scimapi/routers/groups.py
+++ b/src/eduid/scimapi/routers/groups.py
@@ -28,8 +28,7 @@ groups_router = APIRouter(
 
 
 @groups_router.get("/")
-async def on_get_all(req: ContextRequest) -> ListResponse:
-    assert isinstance(req.context, ScimApiContext)  # please mypy
+async def on_get_all(req: ContextRequest[ScimApiContext]) -> ListResponse:
     assert req.context.groupdb is not None  # please mypy
     db_groups = req.context.groupdb.get_groups()
     resources = [{"id": str(db_group.scim_id), "displayName": db_group.graph.display_name} for db_group in db_groups]
@@ -37,7 +36,7 @@ async def on_get_all(req: ContextRequest) -> ListResponse:
 
 
 @groups_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get_one(req: ContextRequest, resp: Response, scim_id: str) -> GroupResponse:
+async def on_get_one(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str) -> GroupResponse:
     """
     GET /Groups/c3819cbe-c893-4070-824c-fe3d0db8f955  HTTP/1.1
     Host: example.com
@@ -68,8 +67,6 @@ async def on_get_one(req: ContextRequest, resp: Response, scim_id: str) -> Group
     }
     """
     req.app.context.logger.info(f"Fetching group {scim_id}")
-
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     db_group = req.context.groupdb.get_group_by_scim_id(scim_id)
     req.app.context.logger.debug(f"Found group: {db_group}")
@@ -80,7 +77,7 @@ async def on_get_one(req: ContextRequest, resp: Response, scim_id: str) -> Group
 
 @groups_router.put("/{scim_id}", response_model_exclude_none=True)
 async def on_put(
-    req: ContextRequest, resp: Response, scim_id: str, update_request: GroupUpdateRequest
+    req: ContextRequest[ScimApiContext], resp: Response, scim_id: str, update_request: GroupUpdateRequest
 ) -> GroupResponse:
     """
     PUT /Groups/c3819cbe-c893-4070-824c-fe3d0db8f955  HTTP/1.1
@@ -139,7 +136,6 @@ async def on_put(
         raise BadRequest(detail="Id mismatch")
 
     req.app.context.logger.info(f"Fetching group {scim_id}")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     db_group = req.context.groupdb.get_group_by_scim_id(str(update_request.id))
     req.app.context.logger.debug(f"Found group: {db_group}")
@@ -185,7 +181,7 @@ async def on_put(
 
 
 @groups_router.post("/", response_model_exclude_none=True)
-async def on_post(req: ContextRequest, resp: Response, create_request: GroupCreateRequest) -> GroupResponse:
+async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_request: GroupCreateRequest) -> GroupResponse:
     """
     POST /Groups  HTTP/1.1
     Host: example.com
@@ -217,7 +213,6 @@ async def on_post(req: ContextRequest, resp: Response, create_request: GroupCrea
     """
     req.app.context.logger.info("Creating group")
     req.app.context.logger.debug(create_request)
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     created_group = req.context.groupdb.create_group(create_request=create_request)
     # Load the group from the database to ensure results are consistent with subsequent GETs.
@@ -246,9 +241,8 @@ async def on_post(req: ContextRequest, resp: Response, create_request: GroupCrea
     status_code=204,
     responses={204: {"description": "No Content"}},
 )
-async def on_delete(req: ContextRequest, scim_id: str) -> None:
+async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting group {scim_id}")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     db_group = req.context.groupdb.get_group_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found group: {db_group}")
@@ -276,7 +270,7 @@ async def on_delete(req: ContextRequest, scim_id: str) -> None:
 
 
 @groups_router.post("/.search", response_model_exclude_none=True)
-async def search(req: ContextRequest, query: SearchRequest) -> ListResponse:
+async def search(req: ContextRequest[ScimApiContext], query: SearchRequest) -> ListResponse:
     """
     POST /Groups/.search
     Host: scim.eduid.se

--- a/src/eduid/scimapi/routers/groups.py
+++ b/src/eduid/scimapi/routers/groups.py
@@ -159,7 +159,8 @@ async def on_put(
     # Load the group from the database to ensure results are consistent with subsequent GETs.
     # For example, timestamps have higher resolution in updated_group than after a load.
     db_group = req.context.require_groupdb().get_group_by_scim_id(str(updated_group.scim_id))
-    assert db_group  # please mypy
+    if db_group is None:
+        raise RuntimeError(f"Group {updated_group.scim_id} missing after update")
     if changed:
         add_api_event(
             context=req.app.context,
@@ -211,7 +212,8 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
     # Load the group from the database to ensure results are consistent with subsequent GETs.
     # For example, timestamps have higher resolution in created_group than after a load.
     db_group = req.context.require_groupdb().get_group_by_scim_id(str(created_group.scim_id))
-    assert db_group  # please mypy
+    if db_group is None:
+        raise RuntimeError(f"Group {created_group.scim_id} missing after create")
     add_api_event(
         context=req.app.context,
         data_owner=req.context.require_data_owner(),

--- a/src/eduid/scimapi/routers/groups.py
+++ b/src/eduid/scimapi/routers/groups.py
@@ -1,9 +1,8 @@
 from fastapi import Response
 
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.models.scim_base import ListResponse, SCIMResourceType, SearchRequest
 from eduid.scimapi.api_router import APIRouter
-from eduid.scimapi.context_request import ScimApiContext, ScimApiRoute
+from eduid.scimapi.context_request import ScimApiRequest, ScimApiRoute
 from eduid.scimapi.exceptions import BadRequest, ErrorDetail, NotFound
 from eduid.scimapi.models.group import GroupCreateRequest, GroupResponse, GroupUpdateRequest
 from eduid.scimapi.routers.utils.events import add_api_event
@@ -28,14 +27,14 @@ groups_router = APIRouter(
 
 
 @groups_router.get("/")
-async def on_get_all(req: ContextRequest[ScimApiContext]) -> ListResponse:
+async def on_get_all(req: ScimApiRequest) -> ListResponse:
     db_groups = req.context.require_groupdb().get_groups()
     resources = [{"id": str(db_group.scim_id), "displayName": db_group.graph.display_name} for db_group in db_groups]
     return ListResponse(total_results=len(db_groups), resources=resources)
 
 
 @groups_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get_one(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str) -> GroupResponse:
+async def on_get_one(req: ScimApiRequest, resp: Response, scim_id: str) -> GroupResponse:
     """
     GET /Groups/c3819cbe-c893-4070-824c-fe3d0db8f955  HTTP/1.1
     Host: example.com
@@ -75,7 +74,7 @@ async def on_get_one(req: ContextRequest[ScimApiContext], resp: Response, scim_i
 
 @groups_router.put("/{scim_id}", response_model_exclude_none=True)
 async def on_put(
-    req: ContextRequest[ScimApiContext], resp: Response, scim_id: str, update_request: GroupUpdateRequest
+    req: ScimApiRequest, resp: Response, scim_id: str, update_request: GroupUpdateRequest
 ) -> GroupResponse:
     """
     PUT /Groups/c3819cbe-c893-4070-824c-fe3d0db8f955  HTTP/1.1
@@ -176,7 +175,7 @@ async def on_put(
 
 
 @groups_router.post("/", response_model_exclude_none=True)
-async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_request: GroupCreateRequest) -> GroupResponse:
+async def on_post(req: ScimApiRequest, resp: Response, create_request: GroupCreateRequest) -> GroupResponse:
     """
     POST /Groups  HTTP/1.1
     Host: example.com
@@ -234,7 +233,7 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
     status_code=204,
     responses={204: {"description": "No Content"}},
 )
-async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
+async def on_delete(req: ScimApiRequest, scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting group {scim_id}")
     db_group = req.context.require_groupdb().get_group_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found group: {db_group}")
@@ -260,7 +259,7 @@ async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
 
 
 @groups_router.post("/.search", response_model_exclude_none=True)
-async def search(req: ContextRequest[ScimApiContext], query: SearchRequest) -> ListResponse:
+async def search(req: ScimApiRequest, query: SearchRequest) -> ListResponse:
     """
     POST /Groups/.search
     Host: scim.eduid.se

--- a/src/eduid/scimapi/routers/invites.py
+++ b/src/eduid/scimapi/routers/invites.py
@@ -36,11 +36,10 @@ invites_router = APIRouter(
 
 
 @invites_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get(req: ContextRequest, resp: Response, scim_id: str | None = None) -> InviteResponse:
+async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str | None = None) -> InviteResponse:
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching invite {scim_id}")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.invitedb is not None  # please mypy
     db_invite = req.context.invitedb.get_invite_by_scim_id(scim_id)
     if not db_invite:
@@ -54,7 +53,7 @@ async def on_get(req: ContextRequest, resp: Response, scim_id: str | None = None
 
 @invites_router.put("/{scim_id}", response_model_exclude_none=True)
 async def on_put(
-    req: ContextRequest, resp: Response, update_request: InviteUpdateRequest, scim_id: str
+    req: ContextRequest[ScimApiContext], resp: Response, update_request: InviteUpdateRequest, scim_id: str
 ) -> InviteResponse:
     if scim_id != str(update_request.id):
         req.app.context.logger.error("Id mismatch")
@@ -62,7 +61,6 @@ async def on_put(
         raise BadRequest(detail="Id mismatch")
 
     req.app.context.logger.info(f"Updating invite {scim_id}")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.invitedb is not None  # please mypy
     db_invite = req.context.invitedb.get_invite_by_scim_id(scim_id)
     if not db_invite:
@@ -106,7 +104,7 @@ async def on_put(
 
 
 @invites_router.post("/", response_model_exclude_none=True)
-async def on_post(req: ContextRequest, resp: Response, create_request: InviteCreateRequest) -> InviteResponse:
+async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_request: InviteCreateRequest) -> InviteResponse:
     """
     POST /Invites  HTTP/1.1
     Host: example.com
@@ -177,8 +175,6 @@ async def on_post(req: ContextRequest, resp: Response, create_request: InviteCre
     )
     if signup_invite.send_email:
         send_invite_mail(req, signup_invite)
-
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.data_owner is not None  # please mypy
     add_api_event(
         context=req.app.context,
@@ -195,9 +191,8 @@ async def on_post(req: ContextRequest, resp: Response, create_request: InviteCre
 
 
 @invites_router.delete("/{scim_id}", status_code=204, responses={204: {"description": "No Content"}})
-async def on_delete(req: ContextRequest, scim_id: str) -> None:
+async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting invite {scim_id}")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.invitedb is not None  # please mypy
     db_invite = req.context.invitedb.get_invite_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found invite: {db_invite}")
@@ -233,7 +228,7 @@ async def on_delete(req: ContextRequest, scim_id: str) -> None:
 
 
 @invites_router.post("/.search", response_model_exclude_none=True)
-async def search(req: ContextRequest, query: SearchRequest) -> ListResponse:
+async def search(req: ContextRequest[ScimApiContext], query: SearchRequest) -> ListResponse:
     """
     POST /Invites/.search
     Host: scim.eduid.se

--- a/src/eduid/scimapi/routers/invites.py
+++ b/src/eduid/scimapi/routers/invites.py
@@ -2,11 +2,10 @@ from dataclasses import replace
 
 from fastapi import Response
 
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.models.scim_base import ListResponse, SCIMResourceType, SearchRequest
 from eduid.common.models.scim_invite import InviteCreateRequest, InviteResponse, InviteUpdateRequest
 from eduid.scimapi.api_router import APIRouter
-from eduid.scimapi.context_request import ScimApiContext, ScimApiRoute
+from eduid.scimapi.context_request import ScimApiRequest, ScimApiRoute
 from eduid.scimapi.exceptions import BadRequest, ErrorDetail, NotFound
 from eduid.scimapi.routers.utils.events import add_api_event
 from eduid.scimapi.routers.utils.invites import (
@@ -36,7 +35,7 @@ invites_router = APIRouter(
 
 
 @invites_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str | None = None) -> InviteResponse:
+async def on_get(req: ScimApiRequest, resp: Response, scim_id: str | None = None) -> InviteResponse:
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching invite {scim_id}")
@@ -52,7 +51,7 @@ async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: s
 
 @invites_router.put("/{scim_id}", response_model_exclude_none=True)
 async def on_put(
-    req: ContextRequest[ScimApiContext], resp: Response, update_request: InviteUpdateRequest, scim_id: str
+    req: ScimApiRequest, resp: Response, update_request: InviteUpdateRequest, scim_id: str
 ) -> InviteResponse:
     if scim_id != str(update_request.id):
         req.app.context.logger.error("Id mismatch")
@@ -100,7 +99,7 @@ async def on_put(
 
 
 @invites_router.post("/", response_model_exclude_none=True)
-async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_request: InviteCreateRequest) -> InviteResponse:
+async def on_post(req: ScimApiRequest, resp: Response, create_request: InviteCreateRequest) -> InviteResponse:
     """
     POST /Invites  HTTP/1.1
     Host: example.com
@@ -186,7 +185,7 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
 
 
 @invites_router.delete("/{scim_id}", status_code=204, responses={204: {"description": "No Content"}})
-async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
+async def on_delete(req: ScimApiRequest, scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting invite {scim_id}")
     db_invite = req.context.require_invitedb().get_invite_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found invite: {db_invite}")
@@ -220,7 +219,7 @@ async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
 
 
 @invites_router.post("/.search", response_model_exclude_none=True)
-async def search(req: ContextRequest[ScimApiContext], query: SearchRequest) -> ListResponse:
+async def search(req: ScimApiRequest, query: SearchRequest) -> ListResponse:
     """
     POST /Invites/.search
     Host: scim.eduid.se

--- a/src/eduid/scimapi/routers/invites.py
+++ b/src/eduid/scimapi/routers/invites.py
@@ -40,8 +40,7 @@ async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: s
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching invite {scim_id}")
-    assert req.context.invitedb is not None  # please mypy
-    db_invite = req.context.invitedb.get_invite_by_scim_id(scim_id)
+    db_invite = req.context.require_invitedb().get_invite_by_scim_id(scim_id)
     if not db_invite:
         raise NotFound(detail="Invite not found")
     ref = create_signup_ref(req, db_invite)
@@ -61,8 +60,7 @@ async def on_put(
         raise BadRequest(detail="Id mismatch")
 
     req.app.context.logger.info(f"Updating invite {scim_id}")
-    assert req.context.invitedb is not None  # please mypy
-    db_invite = req.context.invitedb.get_invite_by_scim_id(scim_id)
+    db_invite = req.context.require_invitedb().get_invite_by_scim_id(scim_id)
     if not db_invite:
         raise NotFound(detail="Invite not found")
     ref = create_signup_ref(req, db_invite)
@@ -79,8 +77,6 @@ async def on_put(
         signup_invite = replace(signup_invite, completed_ts=update_request.nutid_invite_v1.completed)
         db_invite = replace(db_invite, completed=update_request.nutid_invite_v1.completed)
         invite_changed = True
-
-    assert req.context.data_owner is not None  # please mypy
     if invite_changed:
         save_invite(
             req=req,
@@ -90,7 +86,7 @@ async def on_put(
         )
         add_api_event(
             context=req.app.context,
-            data_owner=req.context.data_owner,
+            data_owner=req.context.require_data_owner(),
             db_obj=db_invite,
             resource_type=SCIMResourceType.INVITE,
             level=EventLevel.INFO,
@@ -175,10 +171,9 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
     )
     if signup_invite.send_email:
         send_invite_mail(req, signup_invite)
-    assert req.context.data_owner is not None  # please mypy
     add_api_event(
         context=req.app.context,
-        data_owner=req.context.data_owner,
+        data_owner=req.context.require_data_owner(),
         db_obj=db_invite,
         resource_type=SCIMResourceType.INVITE,
         level=EventLevel.INFO,
@@ -193,8 +188,7 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
 @invites_router.delete("/{scim_id}", status_code=204, responses={204: {"description": "No Content"}})
 async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting invite {scim_id}")
-    assert req.context.invitedb is not None  # please mypy
-    db_invite = req.context.invitedb.get_invite_by_scim_id(scim_id=scim_id)
+    db_invite = req.context.require_invitedb().get_invite_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found invite: {db_invite}")
 
     if not db_invite:
@@ -211,12 +205,10 @@ async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
         req.app.context.signup_invitedb.remove_document(signup_invite.invite_id)
 
     # Remove scim invite
-    res = req.context.invitedb.remove(db_invite)
-
-    assert req.context.data_owner is not None  # please mypy
+    res = req.context.require_invitedb().remove(db_invite)
     add_api_event(
         context=req.app.context,
-        data_owner=req.context.data_owner,
+        data_owner=req.context.require_data_owner(),
         db_obj=db_invite,
         resource_type=SCIMResourceType.INVITE,
         level=EventLevel.INFO,

--- a/src/eduid/scimapi/routers/users.py
+++ b/src/eduid/scimapi/routers/users.py
@@ -50,8 +50,7 @@ async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: s
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching user {scim_id}")
-    assert req.context.userdb is not None
-    db_user = req.context.userdb.get_user_by_scim_id(scim_id)
+    db_user = req.context.require_userdb().get_user_by_scim_id(scim_id)
     if not db_user:
         raise NotFound(detail="User not found")
 
@@ -126,8 +125,7 @@ async def on_put(req: ContextRequest[ScimApiContext], resp: Response, update_req
         req.app.context.logger.error("Id mismatch")
         req.app.context.logger.debug(f"{scim_id} != {update_request.id}")
         raise BadRequest(detail="Id mismatch")
-    assert req.context.userdb is not None  # please mypy
-    db_user = req.context.userdb.get_user_by_scim_id(scim_id)
+    db_user = req.context.require_userdb().get_user_by_scim_id(scim_id)
     if not db_user:
         raise NotFound(detail="User not found")
 
@@ -151,11 +149,10 @@ async def on_put(req: ContextRequest[ScimApiContext], resp: Response, update_req
 
     req.app.context.logger.debug(f"Core changed: {core_changed}, nutid_changed: {nutid_changed}")
     if core_changed or nutid_changed:
-        assert req.context.data_owner is not None  # please mypy
         save_user(req, db_user)
         add_api_event(
             context=req.app.context,
-            data_owner=req.context.data_owner,
+            data_owner=req.context.require_data_owner(),
             db_obj=db_user,
             resource_type=SCIMResourceType.USER,
             level=EventLevel.INFO,
@@ -247,10 +244,9 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
     )
 
     save_user(req, db_user)
-    assert req.context.data_owner is not None  # please mypy
     add_api_event(
         context=req.app.context,
-        data_owner=req.context.data_owner,
+        data_owner=req.context.require_data_owner(),
         db_obj=db_user,
         resource_type=SCIMResourceType.USER,
         level=EventLevel.INFO,
@@ -270,8 +266,7 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
 )
 async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting user {scim_id}")
-    assert req.context.userdb is not None  # please mypy
-    db_user = req.context.userdb.get_user_by_scim_id(scim_id=scim_id)
+    db_user = req.context.require_userdb().get_user_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found user: {db_user}")
     if not db_user:
         raise NotFound(detail="User not found")
@@ -288,12 +283,10 @@ async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
         req.app.context.logger.exception("Max retries reached when removing user from groups")
         raise Conflict(detail="Database object out of sync, please retry") from e
 
-    res = req.context.userdb.remove(db_user)
-
-    assert req.context.data_owner is not None  # please mypy
+    res = req.context.require_userdb().remove(db_user)
     add_api_event(
         context=req.app.context,
-        data_owner=req.context.data_owner,
+        data_owner=req.context.require_data_owner(),
         db_obj=db_user,
         resource_type=SCIMResourceType.USER,
         level=EventLevel.INFO,

--- a/src/eduid/scimapi/routers/users.py
+++ b/src/eduid/scimapi/routers/users.py
@@ -46,11 +46,10 @@ users_router = APIRouter(
 
 
 @users_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get(req: ContextRequest, resp: Response, scim_id: str | None = None) -> UserResponse:
+async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str | None = None) -> UserResponse:
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching user {scim_id}")
-    assert isinstance(req.context, ScimApiContext)
     assert req.context.userdb is not None
     db_user = req.context.userdb.get_user_by_scim_id(scim_id)
     if not db_user:
@@ -120,15 +119,13 @@ def _apply_nutid_updates(
 
 
 @users_router.put("/{scim_id}", response_model_exclude_none=True)
-async def on_put(req: ContextRequest, resp: Response, update_request: UserUpdateRequest, scim_id: str) -> UserResponse:
+async def on_put(req: ContextRequest[ScimApiContext], resp: Response, update_request: UserUpdateRequest, scim_id: str) -> UserResponse:
     req.app.context.logger.info(f"Updating user {scim_id}")
     req.app.context.logger.debug(update_request)
     if scim_id != str(update_request.id):
         req.app.context.logger.error("Id mismatch")
         req.app.context.logger.debug(f"{scim_id} != {update_request.id}")
         raise BadRequest(detail="Id mismatch")
-
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.userdb is not None  # please mypy
     db_user = req.context.userdb.get_user_by_scim_id(scim_id)
     if not db_user:
@@ -172,7 +169,7 @@ async def on_put(req: ContextRequest, resp: Response, update_request: UserUpdate
 
 
 @users_router.post("/", response_model_exclude_none=True)
-async def on_post(req: ContextRequest, resp: Response, create_request: UserCreateRequest) -> UserResponse:
+async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_request: UserCreateRequest) -> UserResponse:
     """
     POST /Users  HTTP/1.1
     Host: example.com
@@ -250,7 +247,6 @@ async def on_post(req: ContextRequest, resp: Response, create_request: UserCreat
     )
 
     save_user(req, db_user)
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.data_owner is not None  # please mypy
     add_api_event(
         context=req.app.context,
@@ -272,8 +268,7 @@ async def on_post(req: ContextRequest, resp: Response, create_request: UserCreat
     status_code=204,
     responses={204: {"description": "No Content"}},
 )
-async def on_delete(req: ContextRequest, scim_id: str) -> None:
-    assert isinstance(req.context, ScimApiContext)  # please mypy
+async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting user {scim_id}")
     assert req.context.userdb is not None  # please mypy
     db_user = req.context.userdb.get_user_by_scim_id(scim_id=scim_id)
@@ -310,7 +305,7 @@ async def on_delete(req: ContextRequest, scim_id: str) -> None:
 
 
 @users_router.post("/.search", response_model_exclude_none=True)
-async def search(req: ContextRequest, query: SearchRequest) -> ListResponse:
+async def search(req: ContextRequest[ScimApiContext], query: SearchRequest) -> ListResponse:
     """
     POST /Users/.search
     Host: scim.eduid.se

--- a/src/eduid/scimapi/routers/users.py
+++ b/src/eduid/scimapi/routers/users.py
@@ -83,7 +83,8 @@ def _apply_core_updates(db_user: ScimApiUser, update_request: UserUpdateRequest)
 def _apply_nutid_updates(
     db_user: ScimApiUser, update_request: UserUpdateRequest, logger: logging.Logger
 ) -> tuple[ScimApiUser, bool]:
-    assert update_request.nutid_user_v1 is not None
+    if update_request.nutid_user_v1 is None:
+        raise BadRequest(detail="nutid_user_v1 extension is required")
     changed = False
 
     profile_changed = False

--- a/src/eduid/scimapi/routers/users.py
+++ b/src/eduid/scimapi/routers/users.py
@@ -5,11 +5,10 @@ from dataclasses import replace
 
 from fastapi import Response
 
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.models.scim_base import ListResponse, SCIMResourceType, SCIMSchema, SearchRequest
 from eduid.common.models.scim_user import UserCreateRequest, UserResponse, UserUpdateRequest
 from eduid.scimapi.api_router import APIRouter
-from eduid.scimapi.context_request import ScimApiContext, ScimApiRoute
+from eduid.scimapi.context_request import ScimApiRequest, ScimApiRoute
 from eduid.scimapi.exceptions import BadRequest, Conflict, ErrorDetail, MaxRetriesReached, NotFound
 from eduid.scimapi.routers.utils.events import add_api_event
 from eduid.scimapi.routers.utils.users import (
@@ -46,7 +45,7 @@ users_router = APIRouter(
 
 
 @users_router.get("/{scim_id}", response_model_exclude_none=True)
-async def on_get(req: ContextRequest[ScimApiContext], resp: Response, scim_id: str | None = None) -> UserResponse:
+async def on_get(req: ScimApiRequest, resp: Response, scim_id: str | None = None) -> UserResponse:
     if scim_id is None:
         raise BadRequest(detail="Not implemented")
     req.app.context.logger.info(f"Fetching user {scim_id}")
@@ -119,7 +118,7 @@ def _apply_nutid_updates(
 
 
 @users_router.put("/{scim_id}", response_model_exclude_none=True)
-async def on_put(req: ContextRequest[ScimApiContext], resp: Response, update_request: UserUpdateRequest, scim_id: str) -> UserResponse:
+async def on_put(req: ScimApiRequest, resp: Response, update_request: UserUpdateRequest, scim_id: str) -> UserResponse:
     req.app.context.logger.info(f"Updating user {scim_id}")
     req.app.context.logger.debug(update_request)
     if scim_id != str(update_request.id):
@@ -167,7 +166,7 @@ async def on_put(req: ContextRequest[ScimApiContext], resp: Response, update_req
 
 
 @users_router.post("/", response_model_exclude_none=True)
-async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_request: UserCreateRequest) -> UserResponse:
+async def on_post(req: ScimApiRequest, resp: Response, create_request: UserCreateRequest) -> UserResponse:
     """
     POST /Users  HTTP/1.1
     Host: example.com
@@ -265,7 +264,7 @@ async def on_post(req: ContextRequest[ScimApiContext], resp: Response, create_re
     status_code=204,
     responses={204: {"description": "No Content"}},
 )
-async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
+async def on_delete(req: ScimApiRequest, scim_id: str) -> None:
     req.app.context.logger.info(f"Deleting user {scim_id}")
     db_user = req.context.require_userdb().get_user_by_scim_id(scim_id=scim_id)
     req.app.context.logger.debug(f"Found user: {db_user}")
@@ -299,7 +298,7 @@ async def on_delete(req: ContextRequest[ScimApiContext], scim_id: str) -> None:
 
 
 @users_router.post("/.search", response_model_exclude_none=True)
-async def search(req: ContextRequest[ScimApiContext], query: SearchRequest) -> ListResponse:
+async def search(req: ScimApiRequest, query: SearchRequest) -> ListResponse:
     """
     POST /Users/.search
     Host: scim.eduid.se

--- a/src/eduid/scimapi/routers/utils/events.py
+++ b/src/eduid/scimapi/routers/utils/events.py
@@ -101,7 +101,8 @@ def add_api_event(
         data={"v": 1, "status": status.value, "message": message},
     )
     event_db = context.get_eventdb(data_owner=data_owner)
-    assert event_db  # please mypy
+    if event_db is None:
+        raise RuntimeError(f"No eventdb for data_owner {data_owner}")
     event_db.save(_event)
 
     # Send notification

--- a/src/eduid/scimapi/routers/utils/events.py
+++ b/src/eduid/scimapi/routers/utils/events.py
@@ -21,7 +21,7 @@ from eduid.common.misc.timeutil import utc_now
 __author__ = "lundberg"
 
 
-def db_event_to_response(req: ContextRequest, resp: Response, db_event: ScimApiEvent) -> EventResponse:
+def db_event_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_event: ScimApiEvent) -> EventResponse:
     location = req.app.context.resource_url(SCIMResourceType.EVENT, db_event.scim_id)
     meta = Meta(
         location=location,
@@ -61,8 +61,7 @@ def db_event_to_response(req: ContextRequest, resp: Response, db_event: ScimApiE
     return event_response
 
 
-def get_scim_referenced(req: ContextRequest, resource: NutidEventResource) -> ScimApiResourceBase | None:
-    assert isinstance(req.context, ScimApiContext)  # please mypy
+def get_scim_referenced(req: ContextRequest[ScimApiContext], resource: NutidEventResource) -> ScimApiResourceBase | None:
     assert req.context.userdb is not None  # please mypy
     assert req.context.groupdb is not None  # please mypy
     assert req.context.invitedb is not None  # please mypy

--- a/src/eduid/scimapi/routers/utils/events.py
+++ b/src/eduid/scimapi/routers/utils/events.py
@@ -62,15 +62,12 @@ def db_event_to_response(req: ContextRequest[ScimApiContext], resp: Response, db
 
 
 def get_scim_referenced(req: ContextRequest[ScimApiContext], resource: NutidEventResource) -> ScimApiResourceBase | None:
-    assert req.context.userdb is not None  # please mypy
-    assert req.context.groupdb is not None  # please mypy
-    assert req.context.invitedb is not None  # please mypy
     if resource.resource_type == SCIMResourceType.USER:
-        return req.context.userdb.get_user_by_scim_id(str(resource.scim_id))
+        return req.context.require_userdb().get_user_by_scim_id(str(resource.scim_id))
     elif resource.resource_type == SCIMResourceType.GROUP:
-        return req.context.groupdb.get_group_by_scim_id(str(resource.scim_id))
+        return req.context.require_groupdb().get_group_by_scim_id(str(resource.scim_id))
     elif resource.resource_type == SCIMResourceType.INVITE:
-        return req.context.invitedb.get_invite_by_scim_id(str(resource.scim_id))
+        return req.context.require_invitedb().get_invite_by_scim_id(str(resource.scim_id))
     elif resource.resource_type == SCIMResourceType.EVENT:
         raise BadRequest(detail="Events can not refer to other events")
     raise BadRequest(detail=f"Events for resource {resource.resource_type.value} not implemented")

--- a/src/eduid/scimapi/routers/utils/events.py
+++ b/src/eduid/scimapi/routers/utils/events.py
@@ -5,10 +5,9 @@ from uuid import uuid4
 from fastapi import Response
 
 from eduid.common.config.base import DataOwnerName
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.models.scim_base import Meta, SCIMResourceType, SCIMSchema
 from eduid.common.utils import make_etag, urlappend
-from eduid.scimapi.context_request import ScimApiContext
+from eduid.scimapi.context_request import ScimApiRequest
 from eduid.scimapi.exceptions import BadRequest
 from eduid.scimapi.models.event import EventResponse, NutidEventExtensionV1, NutidEventResource
 from eduid.userdb.scimapi import EventLevel, EventStatus, ScimApiEvent, ScimApiEventResource, ScimApiResourceBase
@@ -21,7 +20,7 @@ from eduid.common.misc.timeutil import utc_now
 __author__ = "lundberg"
 
 
-def db_event_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_event: ScimApiEvent) -> EventResponse:
+def db_event_to_response(req: ScimApiRequest, resp: Response, db_event: ScimApiEvent) -> EventResponse:
     location = req.app.context.resource_url(SCIMResourceType.EVENT, db_event.scim_id)
     meta = Meta(
         location=location,
@@ -61,7 +60,7 @@ def db_event_to_response(req: ContextRequest[ScimApiContext], resp: Response, db
     return event_response
 
 
-def get_scim_referenced(req: ContextRequest[ScimApiContext], resource: NutidEventResource) -> ScimApiResourceBase | None:
+def get_scim_referenced(req: ScimApiRequest, resource: NutidEventResource) -> ScimApiResourceBase | None:
     if resource.resource_type == SCIMResourceType.USER:
         return req.context.require_userdb().get_user_by_scim_id(str(resource.scim_id))
     elif resource.resource_type == SCIMResourceType.GROUP:

--- a/src/eduid/scimapi/routers/utils/groups.py
+++ b/src/eduid/scimapi/routers/utils/groups.py
@@ -61,8 +61,8 @@ def db_group_to_response(req: ContextRequest[ScimApiContext], resp: Response, db
 def filter_display_name(
     req: ContextRequest[ScimApiContext],
     search_filter: SearchFilter,
-    skip: int | None = None,
-    limit: int | None = None,
+    skip: int,
+    limit: int,
 ) -> tuple[list[ScimApiGroup], int]:
     if search_filter.op != "eq":
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
@@ -70,8 +70,6 @@ def filter_display_name(
         raise BadRequest(scim_type="invalidFilter", detail="Invalid displayName")
 
     req.app.context.logger.debug(f"Searching for group with display name {search_filter.val!r}")
-    assert skip is not None  # please mypy
-    assert limit is not None  # please mypy
     groups, count = req.context.require_groupdb().get_groups_by_property(
         key="display_name", value=search_filter.val, skip=skip, limit=limit
     )
@@ -101,8 +99,8 @@ def filter_lastmodified(
 def filter_extensions_data(
     req: ContextRequest[ScimApiContext],
     search_filter: SearchFilter,
-    skip: int | None = None,
-    limit: int | None = None,
+    skip: int,
+    limit: int,
 ) -> tuple[list[ScimApiGroup], int]:
     if search_filter.op != "eq":
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
@@ -114,8 +112,6 @@ def filter_extensions_data(
     req.app.context.logger.debug(
         f"Searching for groups with {search_filter.attr} {search_filter.op} {search_filter.val!r}"
     )
-    assert skip is not None  # please mypy
-    assert limit is not None  # please mypy
     groups, count = req.context.require_groupdb().get_groups_by_property(
         key=search_filter.attr, value=search_filter.val, skip=skip, limit=limit
     )

--- a/src/eduid/scimapi/routers/utils/groups.py
+++ b/src/eduid/scimapi/routers/utils/groups.py
@@ -27,7 +27,7 @@ def get_group_members(req: Request, db_group: ScimApiGroup) -> list[GroupMember]
     return members
 
 
-def db_group_to_response(req: ContextRequest, resp: Response, db_group: ScimApiGroup) -> GroupResponse:
+def db_group_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_group: ScimApiGroup) -> GroupResponse:
     members = get_group_members(req, db_group)
     location = req.app.context.url_for("Groups", str(db_group.scim_id))
     meta = Meta(
@@ -59,7 +59,7 @@ def db_group_to_response(req: ContextRequest, resp: Response, db_group: ScimApiG
 
 
 def filter_display_name(
-    req: ContextRequest,
+    req: ContextRequest[ScimApiContext],
     search_filter: SearchFilter,
     skip: int | None = None,
     limit: int | None = None,
@@ -70,7 +70,6 @@ def filter_display_name(
         raise BadRequest(scim_type="invalidFilter", detail="Invalid displayName")
 
     req.app.context.logger.debug(f"Searching for group with display name {search_filter.val!r}")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     assert skip is not None  # please mypy
     assert limit is not None  # please mypy
@@ -85,7 +84,7 @@ def filter_display_name(
 
 
 def filter_lastmodified(
-    req: ContextRequest, search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
+    req: ContextRequest[ScimApiContext], search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
 ) -> tuple[list[ScimApiGroup], int]:
     if search_filter.op not in ["gt", "ge"]:
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
@@ -95,7 +94,6 @@ def filter_lastmodified(
         _parsed = datetime.fromisoformat(search_filter.val)
     except Exception as e:
         raise BadRequest(scim_type="invalidFilter", detail="Invalid datetime") from e
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     return req.context.groupdb.get_groups_by_last_modified(
         operator=search_filter.op, value=_parsed, skip=skip, limit=limit
@@ -103,7 +101,7 @@ def filter_lastmodified(
 
 
 def filter_extensions_data(
-    req: ContextRequest,
+    req: ContextRequest[ScimApiContext],
     search_filter: SearchFilter,
     skip: int | None = None,
     limit: int | None = None,
@@ -118,7 +116,6 @@ def filter_extensions_data(
     req.app.context.logger.debug(
         f"Searching for groups with {search_filter.attr} {search_filter.op} {search_filter.val!r}"
     )
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     assert skip is not None  # please mypy
     assert limit is not None  # please mypy

--- a/src/eduid/scimapi/routers/utils/groups.py
+++ b/src/eduid/scimapi/routers/utils/groups.py
@@ -4,10 +4,9 @@ from uuid import UUID
 
 from fastapi import Request, Response
 
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.models.scim_base import Meta, SCIMResourceType, SCIMSchema
 from eduid.common.utils import make_etag
-from eduid.scimapi.context_request import ScimApiContext
+from eduid.scimapi.context_request import ScimApiRequest
 from eduid.scimapi.exceptions import BadRequest
 from eduid.scimapi.models.group import GroupMember, GroupResponse, NutidGroupExtensionV1
 from eduid.scimapi.search import SearchFilter
@@ -27,7 +26,7 @@ def get_group_members(req: Request, db_group: ScimApiGroup) -> list[GroupMember]
     return members
 
 
-def db_group_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_group: ScimApiGroup) -> GroupResponse:
+def db_group_to_response(req: ScimApiRequest, resp: Response, db_group: ScimApiGroup) -> GroupResponse:
     members = get_group_members(req, db_group)
     location = req.app.context.url_for("Groups", str(db_group.scim_id))
     meta = Meta(
@@ -59,7 +58,7 @@ def db_group_to_response(req: ContextRequest[ScimApiContext], resp: Response, db
 
 
 def filter_display_name(
-    req: ContextRequest[ScimApiContext],
+    req: ScimApiRequest,
     search_filter: SearchFilter,
     skip: int,
     limit: int,
@@ -81,7 +80,7 @@ def filter_display_name(
 
 
 def filter_lastmodified(
-    req: ContextRequest[ScimApiContext], search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
+    req: ScimApiRequest, search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
 ) -> tuple[list[ScimApiGroup], int]:
     if search_filter.op not in ["gt", "ge"]:
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
@@ -97,7 +96,7 @@ def filter_lastmodified(
 
 
 def filter_extensions_data(
-    req: ContextRequest[ScimApiContext],
+    req: ScimApiRequest,
     search_filter: SearchFilter,
     skip: int,
     limit: int,

--- a/src/eduid/scimapi/routers/utils/groups.py
+++ b/src/eduid/scimapi/routers/utils/groups.py
@@ -70,10 +70,9 @@ def filter_display_name(
         raise BadRequest(scim_type="invalidFilter", detail="Invalid displayName")
 
     req.app.context.logger.debug(f"Searching for group with display name {search_filter.val!r}")
-    assert req.context.groupdb is not None  # please mypy
     assert skip is not None  # please mypy
     assert limit is not None  # please mypy
-    groups, count = req.context.groupdb.get_groups_by_property(
+    groups, count = req.context.require_groupdb().get_groups_by_property(
         key="display_name", value=search_filter.val, skip=skip, limit=limit
     )
 
@@ -94,8 +93,7 @@ def filter_lastmodified(
         _parsed = datetime.fromisoformat(search_filter.val)
     except Exception as e:
         raise BadRequest(scim_type="invalidFilter", detail="Invalid datetime") from e
-    assert req.context.groupdb is not None  # please mypy
-    return req.context.groupdb.get_groups_by_last_modified(
+    return req.context.require_groupdb().get_groups_by_last_modified(
         operator=search_filter.op, value=_parsed, skip=skip, limit=limit
     )
 
@@ -116,10 +114,9 @@ def filter_extensions_data(
     req.app.context.logger.debug(
         f"Searching for groups with {search_filter.attr} {search_filter.op} {search_filter.val!r}"
     )
-    assert req.context.groupdb is not None  # please mypy
     assert skip is not None  # please mypy
     assert limit is not None  # please mypy
-    groups, count = req.context.groupdb.get_groups_by_property(
+    groups, count = req.context.require_groupdb().get_groups_by_property(
         key=search_filter.attr, value=search_filter.val, skip=skip, limit=limit
     )
     return groups, count

--- a/src/eduid/scimapi/routers/utils/invites.py
+++ b/src/eduid/scimapi/routers/utils/invites.py
@@ -45,9 +45,11 @@ def create_signup_invite(
         for number in create_request.nutid_invite_v1.phone_numbers
     ]
 
-    # please mypy (schema validation makes sure they are not None)
-    assert create_request.nutid_invite_v1.inviter_name is not None
-    assert create_request.nutid_invite_v1.send_email is not None
+    # schema validation makes sure they are not None — belt-and-braces check
+    if create_request.nutid_invite_v1.inviter_name is None:
+        raise BadRequest(detail="inviter_name is required")
+    if create_request.nutid_invite_v1.send_email is None:
+        raise BadRequest(detail="send_email is required")
 
     signup_invite = SignupInvite(
         invite_code=invite_code,

--- a/src/eduid/scimapi/routers/utils/invites.py
+++ b/src/eduid/scimapi/routers/utils/invites.py
@@ -7,7 +7,6 @@ from typing import Any
 from fastapi import Request, Response
 from pymongo.errors import DuplicateKeyError
 
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.misc.timeutil import utc_now
 from eduid.common.models.scim_base import Email, Meta, Name, PhoneNumber, SCIMResourceType, SCIMSchema, SearchRequest
 from eduid.common.models.scim_invite import InviteCreateRequest, InviteResponse, NutidInviteExtensionV1
@@ -15,7 +14,7 @@ from eduid.common.models.scim_user import NutidUserExtensionV1, Profile
 from eduid.common.utils import get_short_hash, make_etag
 from eduid.queue.db import QueueItem, SenderInfo
 from eduid.queue.db.message import EduidInviteEmail
-from eduid.scimapi.context_request import ScimApiContext
+from eduid.scimapi.context_request import ScimApiRequest
 from eduid.scimapi.exceptions import BadRequest
 from eduid.scimapi.search import SearchFilter
 from eduid.scimapi.utils import get_unique_hash
@@ -27,7 +26,7 @@ __author__ = "lundberg"
 
 
 def create_signup_invite(
-    req: ContextRequest[ScimApiContext], create_request: InviteCreateRequest, db_invite: ScimApiInvite
+    req: ScimApiRequest, create_request: InviteCreateRequest, db_invite: ScimApiInvite
 ) -> SignupInvite:
     invite_reference = SCIMReference(data_owner=req.context.require_data_owner(), scim_id=db_invite.scim_id)
 
@@ -118,11 +117,11 @@ def db_invite_to_response(
     return scim_invite
 
 
-def create_signup_ref(req: ContextRequest[ScimApiContext], db_invite: ScimApiInvite) -> SCIMReference:
+def create_signup_ref(req: ScimApiRequest, db_invite: ScimApiInvite) -> SCIMReference:
     return SCIMReference(data_owner=req.context.require_data_owner(), scim_id=db_invite.scim_id)
 
 
-def send_invite_mail(req: ContextRequest[ScimApiContext], signup_invite: SignupInvite) -> bool:
+def send_invite_mail(req: ScimApiRequest, signup_invite: SignupInvite) -> bool:
     try:
         email = next(email.email for email in signup_invite.mail_addresses if email.primary)
     except StopIteration:
@@ -163,7 +162,7 @@ def invites_to_resources_dicts(query: SearchRequest, invites: Sequence[ScimApiIn
 
 
 def save_invite(
-    req: ContextRequest[ScimApiContext],
+    req: ScimApiRequest,
     db_invite: ScimApiInvite,
     signup_invite: SignupInvite,
     signup_invite_is_in_database: bool,
@@ -188,7 +187,7 @@ def save_invite(
 
 
 def filter_lastmodified(
-    req: ContextRequest[ScimApiContext], search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
+    req: ScimApiRequest, search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
 ) -> tuple[list[ScimApiInvite], int]:
     if search_filter.op not in ["gt", "ge"]:
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")

--- a/src/eduid/scimapi/routers/utils/invites.py
+++ b/src/eduid/scimapi/routers/utils/invites.py
@@ -27,9 +27,8 @@ __author__ = "lundberg"
 
 
 def create_signup_invite(
-    req: ContextRequest, create_request: InviteCreateRequest, db_invite: ScimApiInvite
+    req: ContextRequest[ScimApiContext], create_request: InviteCreateRequest, db_invite: ScimApiInvite
 ) -> SignupInvite:
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.data_owner is not None  # please mypy
     invite_reference = SCIMReference(data_owner=req.context.data_owner, scim_id=db_invite.scim_id)
 
@@ -118,13 +117,12 @@ def db_invite_to_response(
     return scim_invite
 
 
-def create_signup_ref(req: ContextRequest, db_invite: ScimApiInvite) -> SCIMReference:
-    assert isinstance(req.context, ScimApiContext)  # please mypy
+def create_signup_ref(req: ContextRequest[ScimApiContext], db_invite: ScimApiInvite) -> SCIMReference:
     assert req.context.data_owner is not None  # please mypy
     return SCIMReference(data_owner=req.context.data_owner, scim_id=db_invite.scim_id)
 
 
-def send_invite_mail(req: ContextRequest, signup_invite: SignupInvite) -> bool:
+def send_invite_mail(req: ContextRequest[ScimApiContext], signup_invite: SignupInvite) -> bool:
     try:
         email = next(email.email for email in signup_invite.mail_addresses if email.primary)
     except StopIteration:
@@ -165,13 +163,12 @@ def invites_to_resources_dicts(query: SearchRequest, invites: Sequence[ScimApiIn
 
 
 def save_invite(
-    req: ContextRequest,
+    req: ContextRequest[ScimApiContext],
     db_invite: ScimApiInvite,
     signup_invite: SignupInvite,
     signup_invite_is_in_database: bool,
 ) -> None:
     try:
-        assert isinstance(req.context, ScimApiContext)  # please mypy
         assert req.context.invitedb is not None  # please mypy
         req.context.invitedb.save(db_invite)
     except DuplicateKeyError as e:
@@ -192,13 +189,12 @@ def save_invite(
 
 
 def filter_lastmodified(
-    req: ContextRequest, search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
+    req: ContextRequest[ScimApiContext], search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
 ) -> tuple[list[ScimApiInvite], int]:
     if search_filter.op not in ["gt", "ge"]:
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
     if not isinstance(search_filter.val, str):
         raise BadRequest(scim_type="invalidFilter", detail="Invalid datetime")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.invitedb is not None  # please mypy
     return req.context.invitedb.get_invites_by_last_modified(
         operator=search_filter.op, value=datetime.fromisoformat(search_filter.val), skip=skip, limit=limit

--- a/src/eduid/scimapi/routers/utils/invites.py
+++ b/src/eduid/scimapi/routers/utils/invites.py
@@ -29,8 +29,7 @@ __author__ = "lundberg"
 def create_signup_invite(
     req: ContextRequest[ScimApiContext], create_request: InviteCreateRequest, db_invite: ScimApiInvite
 ) -> SignupInvite:
-    assert req.context.data_owner is not None  # please mypy
-    invite_reference = SCIMReference(data_owner=req.context.data_owner, scim_id=db_invite.scim_id)
+    invite_reference = SCIMReference(data_owner=req.context.require_data_owner(), scim_id=db_invite.scim_id)
 
     if create_request.nutid_invite_v1.send_email is False:
         # Generate a shorter code if the code will reach the invitee on paper or other analog media
@@ -118,8 +117,7 @@ def db_invite_to_response(
 
 
 def create_signup_ref(req: ContextRequest[ScimApiContext], db_invite: ScimApiInvite) -> SCIMReference:
-    assert req.context.data_owner is not None  # please mypy
-    return SCIMReference(data_owner=req.context.data_owner, scim_id=db_invite.scim_id)
+    return SCIMReference(data_owner=req.context.require_data_owner(), scim_id=db_invite.scim_id)
 
 
 def send_invite_mail(req: ContextRequest[ScimApiContext], signup_invite: SignupInvite) -> bool:
@@ -169,8 +167,7 @@ def save_invite(
     signup_invite_is_in_database: bool,
 ) -> None:
     try:
-        assert req.context.invitedb is not None  # please mypy
-        req.context.invitedb.save(db_invite)
+        req.context.require_invitedb().save(db_invite)
     except DuplicateKeyError as e:
         if e.details is None:
             raise
@@ -195,7 +192,6 @@ def filter_lastmodified(
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
     if not isinstance(search_filter.val, str):
         raise BadRequest(scim_type="invalidFilter", detail="Invalid datetime")
-    assert req.context.invitedb is not None  # please mypy
-    return req.context.invitedb.get_invites_by_last_modified(
+    return req.context.require_invitedb().get_invites_by_last_modified(
         operator=search_filter.op, value=datetime.fromisoformat(search_filter.val), skip=skip, limit=limit
     )

--- a/src/eduid/scimapi/routers/utils/users.py
+++ b/src/eduid/scimapi/routers/utils/users.py
@@ -7,11 +7,10 @@ from fastapi import Response
 from pymongo.errors import DuplicateKeyError
 
 from eduid.common.config.base import EduidEnvironment
-from eduid.common.fastapi.context_request import ContextRequest
 from eduid.common.models.scim_base import Email, Meta, Name, PhoneNumber, SCIMResourceType, SCIMSchema, SearchRequest
 from eduid.common.models.scim_user import Group, LinkedAccount, NutidUserExtensionV1, Profile, UserResponse
 from eduid.common.utils import make_etag
-from eduid.scimapi.context_request import ScimApiContext
+from eduid.scimapi.context_request import ScimApiRequest
 from eduid.scimapi.exceptions import BadRequest
 from eduid.scimapi.routers.utils.events import add_api_event
 from eduid.scimapi.search import SearchFilter
@@ -20,7 +19,7 @@ from eduid.userdb.scimapi import EventLevel, EventStatus
 from eduid.userdb.scimapi.userdb import ScimApiUser
 
 
-def get_user_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> list[Group]:
+def get_user_groups(req: ScimApiRequest, db_user: ScimApiUser) -> list[Group]:
     """Return the groups for a user formatted as SCIM search sub-resources"""
     user_groups = req.context.require_groupdb().get_groups_for_user_identifer(db_user.scim_id)
     groups = []
@@ -31,7 +30,7 @@ def get_user_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -
 
 
 @retryable_db_write
-def remove_user_from_all_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> None:
+def remove_user_from_all_groups(req: ScimApiRequest, db_user: ScimApiUser) -> None:
     """Remove a user from all groups"""
     # Remove user from groups
     for member_group in req.context.require_groupdb().get_groups_for_user_identifer(db_user.scim_id):
@@ -77,7 +76,7 @@ def remove_user_from_all_groups(req: ContextRequest[ScimApiContext], db_user: Sc
                 break
 
 
-def db_user_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_user: ScimApiUser) -> UserResponse:
+def db_user_to_response(req: ScimApiRequest, resp: Response, db_user: ScimApiUser) -> UserResponse:
     location = req.app.context.url_for("Users", db_user.scim_id)
     meta = Meta(
         location=location,
@@ -120,7 +119,7 @@ def db_user_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_
     return user
 
 
-def save_user(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> None:
+def save_user(req: ScimApiRequest, db_user: ScimApiUser) -> None:
     try:
         req.context.require_userdb().save(db_user)
     except DuplicateKeyError as e:
@@ -171,7 +170,7 @@ def users_to_resources_dicts(query: SearchRequest, users: Sequence[ScimApiUser])
     return resources
 
 
-def filter_externalid(req: ContextRequest[ScimApiContext], search_filter: SearchFilter) -> list[ScimApiUser]:
+def filter_externalid(req: ScimApiRequest, search_filter: SearchFilter) -> list[ScimApiUser]:
     if search_filter.op != "eq":
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
     if not isinstance(search_filter.val, str):
@@ -185,7 +184,7 @@ def filter_externalid(req: ContextRequest[ScimApiContext], search_filter: Search
 
 
 def filter_lastmodified(
-    req: ContextRequest[ScimApiContext], search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
+    req: ScimApiRequest, search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
 ) -> tuple[list[ScimApiUser], int]:
     if search_filter.op not in ["gt", "ge"]:
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
@@ -197,7 +196,7 @@ def filter_lastmodified(
 
 
 def filter_profile_data(
-    req: ContextRequest[ScimApiContext],
+    req: ScimApiRequest,
     search_filter: SearchFilter,
     profile: str,
     key: str,

--- a/src/eduid/scimapi/routers/utils/users.py
+++ b/src/eduid/scimapi/routers/utils/users.py
@@ -20,9 +20,8 @@ from eduid.userdb.scimapi import EventLevel, EventStatus
 from eduid.userdb.scimapi.userdb import ScimApiUser
 
 
-def get_user_groups(req: ContextRequest, db_user: ScimApiUser) -> list[Group]:
+def get_user_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> list[Group]:
     """Return the groups for a user formatted as SCIM search sub-resources"""
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     user_groups = req.context.groupdb.get_groups_for_user_identifer(db_user.scim_id)
     groups = []
@@ -33,10 +32,9 @@ def get_user_groups(req: ContextRequest, db_user: ScimApiUser) -> list[Group]:
 
 
 @retryable_db_write
-def remove_user_from_all_groups(req: ContextRequest, db_user: ScimApiUser) -> None:
+def remove_user_from_all_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> None:
     """Remove a user from all groups"""
     # Remove user from groups
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.groupdb is not None  # please mypy
     assert req.context.data_owner is not None  # please mypy
     for member_group in req.context.groupdb.get_groups_for_user_identifer(db_user.scim_id):
@@ -81,7 +79,7 @@ def remove_user_from_all_groups(req: ContextRequest, db_user: ScimApiUser) -> No
                 break
 
 
-def db_user_to_response(req: ContextRequest, resp: Response, db_user: ScimApiUser) -> UserResponse:
+def db_user_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_user: ScimApiUser) -> UserResponse:
     location = req.app.context.url_for("Users", db_user.scim_id)
     meta = Meta(
         location=location,
@@ -124,9 +122,8 @@ def db_user_to_response(req: ContextRequest, resp: Response, db_user: ScimApiUse
     return user
 
 
-def save_user(req: ContextRequest, db_user: ScimApiUser) -> None:
+def save_user(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> None:
     try:
-        assert isinstance(req.context, ScimApiContext)  # please mypy
         assert req.context.userdb is not None  # please mypy
         req.context.userdb.save(db_user)
     except DuplicateKeyError as e:
@@ -177,13 +174,11 @@ def users_to_resources_dicts(query: SearchRequest, users: Sequence[ScimApiUser])
     return resources
 
 
-def filter_externalid(req: ContextRequest, search_filter: SearchFilter) -> list[ScimApiUser]:
+def filter_externalid(req: ContextRequest[ScimApiContext], search_filter: SearchFilter) -> list[ScimApiUser]:
     if search_filter.op != "eq":
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
     if not isinstance(search_filter.val, str):
         raise BadRequest(scim_type="invalidFilter", detail="Invalid externalId")
-
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.userdb is not None  # please mypy
     user = req.context.userdb.get_user_by_external_id(search_filter.val)
 
@@ -194,13 +189,12 @@ def filter_externalid(req: ContextRequest, search_filter: SearchFilter) -> list[
 
 
 def filter_lastmodified(
-    req: ContextRequest, search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
+    req: ContextRequest[ScimApiContext], search_filter: SearchFilter, skip: int | None = None, limit: int | None = None
 ) -> tuple[list[ScimApiUser], int]:
     if search_filter.op not in ["gt", "ge"]:
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
     if not isinstance(search_filter.val, str):
         raise BadRequest(scim_type="invalidFilter", detail="Invalid datetime")
-    assert isinstance(req.context, ScimApiContext)  # please mypy
     assert req.context.userdb is not None  # please mypy
     return req.context.userdb.get_users_by_last_modified(
         operator=search_filter.op, value=datetime.fromisoformat(search_filter.val), skip=skip, limit=limit
@@ -208,7 +202,7 @@ def filter_lastmodified(
 
 
 def filter_profile_data(
-    req: ContextRequest,
+    req: ContextRequest[ScimApiContext],
     search_filter: SearchFilter,
     profile: str,
     key: str,
@@ -221,7 +215,6 @@ def filter_profile_data(
     req.app.context.logger.debug(
         f"Searching for users with {search_filter.attr} {search_filter.op} {search_filter.val!r}"
     )
-    assert isinstance(req.context, ScimApiContext)
     assert req.context.userdb is not None
     users, count = req.context.userdb.get_user_by_profile_data(
         profile=profile, operator=search_filter.op, key=key, value=search_filter.val, skip=skip, limit=limit

--- a/src/eduid/scimapi/routers/utils/users.py
+++ b/src/eduid/scimapi/routers/utils/users.py
@@ -22,8 +22,7 @@ from eduid.userdb.scimapi.userdb import ScimApiUser
 
 def get_user_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> list[Group]:
     """Return the groups for a user formatted as SCIM search sub-resources"""
-    assert req.context.groupdb is not None  # please mypy
-    user_groups = req.context.groupdb.get_groups_for_user_identifer(db_user.scim_id)
+    user_groups = req.context.require_groupdb().get_groups_for_user_identifer(db_user.scim_id)
     groups = []
     for group in user_groups:
         ref = req.app.context.url_for("Groups", group.scim_id)
@@ -35,11 +34,9 @@ def get_user_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -
 def remove_user_from_all_groups(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> None:
     """Remove a user from all groups"""
     # Remove user from groups
-    assert req.context.groupdb is not None  # please mypy
-    assert req.context.data_owner is not None  # please mypy
-    for member_group in req.context.groupdb.get_groups_for_user_identifer(db_user.scim_id):
+    for member_group in req.context.require_groupdb().get_groups_for_user_identifer(db_user.scim_id):
         # we need to get the full group object to get all the members
-        group = req.context.groupdb.get_group_by_scim_id(str(member_group.scim_id))
+        group = req.context.require_groupdb().get_group_by_scim_id(str(member_group.scim_id))
         assert group is not None
         for member in group.graph.members.copy():
             if member.identifier == str(db_user.scim_id):
@@ -47,10 +44,10 @@ def remove_user_from_all_groups(req: ContextRequest[ScimApiContext], db_user: Sc
                     f"Removing member {db_user.scim_id} from group {group.scim_id} ({group.display_name}"
                 )
                 group.graph.members.remove(member)
-                req.context.groupdb.save(group)
+                req.context.require_groupdb().save(group)
                 add_api_event(
                     context=req.app.context,
-                    data_owner=req.context.data_owner,
+                    data_owner=req.context.require_data_owner(),
                     db_obj=group,
                     resource_type=SCIMResourceType.GROUP,
                     level=EventLevel.INFO,
@@ -59,17 +56,17 @@ def remove_user_from_all_groups(req: ContextRequest[ScimApiContext], db_user: Sc
                 )
                 break
 
-    for owner_group in req.context.groupdb.get_groups_owned_by_user_identifier(db_user.scim_id):
+    for owner_group in req.context.require_groupdb().get_groups_owned_by_user_identifier(db_user.scim_id):
         for owner in owner_group.graph.owners.copy():
             if owner.identifier == str(db_user.scim_id):
                 req.app.context.logger.debug(
                     f"Removing member {db_user.scim_id} from group {owner_group.scim_id} ({owner_group.display_name}"
                 )
                 owner_group.graph.owners.remove(owner)
-                req.context.groupdb.save(owner_group)
+                req.context.require_groupdb().save(owner_group)
                 add_api_event(
                     context=req.app.context,
-                    data_owner=req.context.data_owner,
+                    data_owner=req.context.require_data_owner(),
                     db_obj=owner_group,
                     resource_type=SCIMResourceType.GROUP,
                     level=EventLevel.INFO,
@@ -124,8 +121,7 @@ def db_user_to_response(req: ContextRequest[ScimApiContext], resp: Response, db_
 
 def save_user(req: ContextRequest[ScimApiContext], db_user: ScimApiUser) -> None:
     try:
-        assert req.context.userdb is not None  # please mypy
-        req.context.userdb.save(db_user)
+        req.context.require_userdb().save(db_user)
     except DuplicateKeyError as e:
         if e.details is None:
             raise
@@ -179,8 +175,7 @@ def filter_externalid(req: ContextRequest[ScimApiContext], search_filter: Search
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
     if not isinstance(search_filter.val, str):
         raise BadRequest(scim_type="invalidFilter", detail="Invalid externalId")
-    assert req.context.userdb is not None  # please mypy
-    user = req.context.userdb.get_user_by_external_id(search_filter.val)
+    user = req.context.require_userdb().get_user_by_external_id(search_filter.val)
 
     if not user:
         return []
@@ -195,8 +190,7 @@ def filter_lastmodified(
         raise BadRequest(scim_type="invalidFilter", detail="Unsupported operator")
     if not isinstance(search_filter.val, str):
         raise BadRequest(scim_type="invalidFilter", detail="Invalid datetime")
-    assert req.context.userdb is not None  # please mypy
-    return req.context.userdb.get_users_by_last_modified(
+    return req.context.require_userdb().get_users_by_last_modified(
         operator=search_filter.op, value=datetime.fromisoformat(search_filter.val), skip=skip, limit=limit
     )
 
@@ -215,8 +209,7 @@ def filter_profile_data(
     req.app.context.logger.debug(
         f"Searching for users with {search_filter.attr} {search_filter.op} {search_filter.val!r}"
     )
-    assert req.context.userdb is not None
-    users, count = req.context.userdb.get_user_by_profile_data(
+    users, count = req.context.require_userdb().get_user_by_profile_data(
         profile=profile, operator=search_filter.op, key=key, value=search_filter.val, skip=skip, limit=limit
     )
     return users, count

--- a/src/eduid/scimapi/routers/utils/users.py
+++ b/src/eduid/scimapi/routers/utils/users.py
@@ -37,7 +37,8 @@ def remove_user_from_all_groups(req: ContextRequest[ScimApiContext], db_user: Sc
     for member_group in req.context.require_groupdb().get_groups_for_user_identifer(db_user.scim_id):
         # we need to get the full group object to get all the members
         group = req.context.require_groupdb().get_group_by_scim_id(str(member_group.scim_id))
-        assert group is not None
+        if group is None:
+            raise RuntimeError(f"Group {member_group.scim_id} missing from db while member list iterated")
         for member in group.graph.members.copy():
             if member.identifier == str(db_user.scim_id):
                 req.app.context.logger.debug(


### PR DESCRIPTION
# Generic `ContextRequest`, drop `assert`s in scimapi / maccapi

## Why

Rule `S101` (`assert` outside tests) fires 203× across the repo. ~99% are mypy type-narrowing
scaffolding — `assert isinstance(req.context, ScimApiContext)` and `assert req.context.userdb is not None`
— not real invariants. Under `python -O` they vanish silently.

Strengthening types at the boundary eliminates the need for the scaffolding:

1. Make `ContextRequest` generic in its context type — static narrowing replaces `isinstance` asserts.
2. Introduce concrete `ScimApiRequest` / `MaccAPIRequest` subclasses — FastAPI's param inspector
   treats them as plain `Request` subclasses (it can't handle parameterized generic aliases).
3. Add `require_*` accessors on `ScimApiContext` / `MaccAPIContext` — real runtime checks replace
   `is not None` asserts, and the `None` case produces a typed error instead of `AssertionError`.

Result: scimapi + maccapi drop from 94 asserts to **0**. Global S101 count: **203 → 109**.
Mypy `--strict` passes across the touched packages.

## Changes by commit

### 1. `make ContextRequest generic over context type`

[src/eduid/common/fastapi/context_request.py](src/eduid/common/fastapi/context_request.py):

- `class ContextRequest[C: Context = Context](Request)` — PEP 695 syntax, PEP 696 default keeps
  unparameterized callers compiling.
- `context` property / setter / `contextClass` typed as `C`.
- `make_context_request[C: Context](...)` propagates the narrow type through.

### 2. `use generic ContextRequest in scimapi and maccapi`

Every scimapi/maccapi route handler: `req: ContextRequest` → `req: ContextRequest[ScimApiContext]`
(or `[MaccAPIContext]`). Every `assert isinstance(req.context, ...)` deleted (35 sites).

One bridging edit in [src/eduid/scimapi/context.py](src/eduid/scimapi/context.py) — `check_version`
param annotated with the parameterized type.

### 3. `add require_* helpers to context classes, drop asserts`

[scimapi/context_request.py](src/eduid/scimapi/context_request.py) and
[maccapi/context_request.py](src/eduid/maccapi/context_request.py) grow
`require_userdb()`, `require_groupdb()`, `require_invitedb()`, `require_eventdb()`,
`require_data_owner()`, `require_manager_eppn()` — raise `RuntimeError` when the underlying
field is `None`.

Router sweep: `req.context.groupdb.foo()` → `req.context.require_groupdb().foo()` (and similar).
48 `assert x is not None` lines deleted.

### 4. `drop remaining scimapi local-var asserts`

The tail — local-variable narrowing unrelated to context:

- `assert db_group` (after a re-fetch) → `if db_group is None: raise RuntimeError(...)`.
- `assert skip is not None` / `assert limit is not None` → narrow parameter signatures to `int`
  (legacy `Optional` from the falcon→fastapi switch; no caller ever passed `None`).
- `assert update_request.nutid_user_v1 is not None` → `if ... is None: raise BadRequest(...)` —
  maps to a proper 400 for missing schema extension.
- `assert create_request.nutid_invite_v1.inviter_name is not None` / `send_email` — same pattern.

### 5. `add concrete Request subclasses for FastAPI param inspector`

FastAPI's `lenient_issubclass(annotation, Request)` in the route-registration path can't handle
parameterized generic aliases — `ContextRequest[ScimApiContext]` is a `_GenericAlias` at runtime,
not a class, so `issubclass()` raises `TypeError`, FastAPI falls through to treating the param as
a Pydantic body field, and Pydantic can't build a field for a generic alias → 48 test errors at
`TestClient(self.api)` setup:

> `Invalid args for response field! Hint: check that ContextRequest[ScimApiContext] is a valid
>  Pydantic field type.`

Fix: add concrete subclasses that bake in the context type and therefore present as plain
`Request` subclasses:

```python
# scimapi/context_request.py
class ScimApiRequest(ContextRequest[ScimApiContext]):
    """Concrete subclass so FastAPI's param inspector sees a plain Request subclass."""

# maccapi/context_request.py
class MaccAPIRequest(ContextRequest[MaccAPIContext]):
    """Concrete subclass so FastAPI's param inspector sees a plain Request subclass."""
```

Sweep router annotations: `ContextRequest[ScimApiContext]` → `ScimApiRequest`
(and `ContextRequest[MaccAPIContext]` → `MaccAPIRequest`). Unused
`ScimApiContext` / `MaccAPIContext` imports removed by autofix.

Verified: `lenient_issubclass(ScimApiRequest, Request) == True`.
