### PR TITLE
Update Agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,17 +243,37 @@ user = self.app.userdb.lookup_user(self.test_user.eppn)
 
 ### Mocking Patterns
 
-When mocking complex objects, use `cast()` for proper typing:
+Use `pytest-mock` fixtures instead of direct `unittest.mock` imports in tests. Use `mocker: MockerFixture` in function-scoped
+tests and `class_mocker` for class-scoped setup in `EduidAPITestCase` subclasses. Reach for
+`mocker.patch`, `mocker.patch.object`, `mocker.MagicMock`, and `mocker.AsyncMock` instead of importing
+`patch`, `MagicMock`, or `AsyncMock` directly.
+
+```python
+from pytest_mock import MockerFixture
+
+def test_get_all_navet_data(self, mocker: MockerFixture) -> None:
+    mock_get_all_navet_data = mocker.patch("eduid.workers.msg.tasks.get_all_navet_data.apply_async")
+
+    self.msg_relay.get_all_navet_data("190000000000")
+
+    mock_get_all_navet_data.assert_called_once_with(kwargs={"nin": "190000000000"})
+```
+
+If you need a typed test double for a complex object, create it through `mocker` and use `cast()` only at the
+boundary:
 
 ```python
 from typing import cast
-from unittest.mock import MagicMock
 
-def _make_ticket(self, credentials_used: Mapping[ElementKey, AuthnData] | None = None) -> LoginContext:
+from pytest_mock import MockerFixture
+
+def _make_ticket(
+    mocker: MockerFixture, credentials_used: Mapping[ElementKey, AuthnData] | None = None
+) -> LoginContext:
     if credentials_used is None:
         credentials_used = {}
-    ticket = MagicMock(spec=LoginContext)
-    ticket.pending_request = MagicMock()
+    ticket = cast(LoginContext, mocker.MagicMock(spec=LoginContext))
+    ticket.pending_request = mocker.MagicMock()
     ticket.pending_request.credentials_used = credentials_used
     return cast(LoginContext, ticket)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This document provides guidelines for AI coding agents working in the eduID Backend repository.
 
+Rule language in this document:
+- **Must**: required for changes that are ready for review
+- **Should**: the default approach unless there is a clear reason to do otherwise
+- **May**: optional guidance
+
+Unless noted otherwise, code snippets in this document are illustrative and may omit surrounding imports or setup.
+
 ## Project Overview
 
 eduID Backend is a Python 3.13 monorepo for Swedish federated identity management:
@@ -44,7 +51,7 @@ make reformat   # Fix imports + format code + extended checks
 
 ### Type Checking
 
-**Run both type checkers before submitting changes:**
+**Must run both type checkers before submitting changes:**
 
 ```bash
 # mypy (required)
@@ -84,7 +91,7 @@ from eduid.webapp.common.api.messages import TranslatableMsg
 
 ### Type Annotations
 
-Use modern Python 3.10+ type syntax:
+Must use modern Python 3.10+ type syntax:
 
 ```python
 def get_user(identifier: str) -> User | None:            # Union with |
@@ -114,7 +121,7 @@ class UserConfig(BaseModel):
 
 ### Error Handling
 
-Use hierarchical custom exceptions:
+Should use hierarchical custom exceptions:
 ```python
 class EduIDDBError(Exception):
     def __init__(self, reason: object) -> None:
@@ -183,7 +190,7 @@ src/eduid/webapp/freja_eid/
 
 ### Base Test Classes
 
-Each webapp has a specific test base class. For the IdP, use `IdPAPITests`:
+Each webapp has a specific test base class. IdP tests should use `IdPAPITests`:
 
 ```python
 from eduid.webapp.idp.tests.test_api import IdPAPITests
@@ -197,7 +204,7 @@ class TestMyFeature(IdPAPITests):
         # ... test logic
 ```
 
-For other webapps, use `EduidAPITestCase[AppType]`:
+Other webapp tests should use `EduidAPITestCase[AppType]`:
 
 ```python
 class MyAppTests(EduidAPITestCase[MyApp]):
@@ -243,8 +250,8 @@ user = self.app.userdb.lookup_user(self.test_user.eppn)
 
 ### Mocking Patterns
 
-Use `pytest-mock` fixtures instead of direct `unittest.mock` imports in tests. Use `mocker: MockerFixture` in function-scoped
-tests and `class_mocker` for class-scoped setup in `EduidAPITestCase` subclasses. Reach for
+Tests must use `pytest-mock` fixtures instead of direct `unittest.mock` imports. Function-scoped tests should use `mocker: MockerFixture`,
+and class-scoped setup in `EduidAPITestCase` subclasses should use `class_mocker`. Tests should use
 `mocker.patch`, `mocker.patch.object`, `mocker.MagicMock`, and `mocker.AsyncMock` instead of importing
 `patch`, `MagicMock`, or `AsyncMock` directly.
 
@@ -278,10 +285,10 @@ def _make_ticket(
     return cast(LoginContext, ticket)
 ```
 
-Use real objects instead of mocks when feasible:
+Should use real objects instead of mocks when feasible.
 
 ```python
-# Prefer real AuthnData over MagicMock
+# Use real AuthnData rather than MagicMock when feasible
 from eduid.webapp.idp.idp_authn import AuthnData
 from eduid.common.misc.timeutil import utc_now
 
@@ -290,7 +297,7 @@ authn_data = AuthnData(cred_id=credential.key, timestamp=utc_now())
 
 ### Post-Edit Checklist
 
-After completing test changes, always run:
+Must run these commands after completing test changes:
 
 ```bash
 make reformat   # Fix imports and formatting
@@ -300,7 +307,7 @@ make typecheck  # Verify type correctness
 
 ## Commit Message Convention
 
-Use [Conventional Commits](https://www.conventionalcommits.org/):
+Should use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages:
 ```
 feat(webapp): add new identity verification flow
 fix(userdb): handle missing email gracefully

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ PYTHONPATH=src pytest -vvv -k "test_verify" src/eduid/webapp/freja_eid/tests/
 ```
 
 Tests require Docker services (MongoDB, Redis, Neo4j, SMTP). Tests auto-start containers as needed.
+If stale test containers need to be cleaned up before rerunning tests, use `make kill_tests`.
 
 ### Linting and Formatting
 


### PR DESCRIPTION
## Summary

This PR improves the guidance in [AGENTS.md](/workspaces/eduid-backend/AGENTS.md) for AI coding agents working in the eduID backend repository.

## Changes

- clarify the document's rule language by defining `Must`, `Should`, and `May`
- note that code snippets are illustrative unless stated otherwise
- update the mocking guidance to prefer `pytest-mock` fixtures and show a typed `mocker` example
- tighten several testing and style recommendations so the document reads more consistently
- document `make kill_tests` as the cleanup command for stale Docker test containers used by tests
