### PR TITLE
Replace acs_actions isinstance asserts with typed exits

### DIFF
--- a/src/eduid/webapp/bankid/acs_actions.py
+++ b/src/eduid/webapp/bankid/acs_actions.py
@@ -23,7 +23,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     """
     Perform common checks for SAML ACS actions.
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=BankIDMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -50,8 +51,7 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
 
     if ret := common_saml_checks(args=args):
@@ -61,8 +61,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -92,10 +92,10 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     if ret := common_saml_checks(args=args):
         return ret
@@ -117,8 +117,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -176,8 +176,7 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
 
     if ret := common_saml_checks(args=args):
@@ -190,8 +189,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -22,7 +22,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     """
     Check that the user is authenticated and that the session info is valid.
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=EidasMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -51,8 +52,7 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
@@ -63,8 +63,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -94,15 +94,15 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
     if ret := common_saml_checks(args=args):
         return ret
 
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -121,8 +121,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -180,8 +180,7 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
@@ -196,8 +195,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/freja_eid/callback_actions.py
+++ b/src/eduid/webapp/freja_eid/callback_actions.py
@@ -29,8 +29,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -64,7 +64,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if not args.proofing_method:
         return ACSResult(message=FrejaEIDMsg.method_not_available)
 
-    assert isinstance(args.authn_req, RP_AuthnRequest)
+    if not isinstance(args.authn_req, RP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -83,8 +84,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -151,8 +152,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/samleid/acs_actions.py
+++ b/src/eduid/webapp/samleid/acs_actions.py
@@ -28,7 +28,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     :param args: ACS action arguments containing session info and proofing method
     :returns: ACSResult with error message if validation fails, None if all checks pass
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=SamlEidMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -65,8 +66,7 @@ def samleid_verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
@@ -77,8 +77,8 @@ def samleid_verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -116,15 +116,15 @@ def samleid_verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
     if ret := common_saml_checks(args=args):
         return ret
 
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -143,8 +143,8 @@ def samleid_verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -207,8 +207,7 @@ def samleid_mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
@@ -223,8 +222,8 @@ def samleid_mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/svipe_id/callback_actions.py
+++ b/src/eduid/webapp/svipe_id/callback_actions.py
@@ -24,8 +24,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, SvipeDocumentUserInfo)
+    if not isinstance(parsed.info, SvipeDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor


### PR DESCRIPTION
# Replace acs_actions isinstance asserts with typed exits

## Why

Follow-up to #954 (`ContextRequest` generic + scimapi/maccapi sweep).

20 mypy-narrowing `assert isinstance(...)` calls across SAML/OIDC ACS handlers.
Same pattern as before: type-checker scaffolding masquerading as runtime invariants,
silently stripped under `python -O`.

Drops global S101 count: **109 → 89**.

## Changes

Single commit, 5 files. Each `assert isinstance(...)` swapped for a typed exit
based on the failure mode:

### `args.proofing_method` not the expected `ProofingMethod` subtype

→ `return ACSResult(message=XMsg.method_not_available)`

Strictly extends the pre-existing `if not args.proofing_method: return method_not_available`
to also catch wrong-type. Same semantic ("can't process this proofing method"),
same response shape.

### `args.authn_req` / `parsed.info` not the expected type

→ `raise RuntimeError(f"unexpected ... type: {type(...).__name__}")`

These are upstream invariants — `args.authn_req` is constructed by view code with
a fixed type per protocol; `parsed.info` is set when `parse_session_info` returns
no error. Wrong type means a programming error, not a user-facing failure. Matches
the "shouldn't happen, blow up cleanly" semantics the original `assert` had,
preserved as a runtime check that survives `-O`.

## Files touched

| File | Asserts removed |
|---|---:|
| [src/eduid/webapp/bankid/acs_actions.py](src/eduid/webapp/bankid/acs_actions.py) | 5 |
| [src/eduid/webapp/eidas/acs_actions.py](src/eduid/webapp/eidas/acs_actions.py) | 5 |
| [src/eduid/webapp/samleid/acs_actions.py](src/eduid/webapp/samleid/acs_actions.py) | 5 |
| [src/eduid/webapp/freja_eid/callback_actions.py](src/eduid/webapp/freja_eid/callback_actions.py) | 4 |
| [src/eduid/webapp/svipe_id/callback_actions.py](src/eduid/webapp/svipe_id/callback_actions.py) | 1 |

Diff is roughly balanced (~`+51/-52`) — each `assert isinstance(...)` becomes a
2-line `if not isinstance(...): return/raise`, but the `# please mypy` /
`# please type checking` comments that prefixed them go away, and a few
now-redundant `if not args.proofing_method:` guards are subsumed by the new
isinstance-or-None check.

## Known residual: duplicate isinstance narrowing

`common_saml_checks` in bankid/eidas/samleid still does its own isinstance check
on `args.proofing_method`, duplicating the caller's gate (mypy can't propagate
narrowing across function boundaries).

Deferred deliberately: bankid + eidas are being deprecated in favour of samleid.
Refactoring three copies of the same helper is wasted work when two of them
will be removed soon. After that cleanup, the duplication problem reduces to one
helper in samleid alone — a much smaller, focused refactor.

## Scope not in this PR

- webapp/proofing/*.py asserts (~17) — separate PR.
- webapp/signup, authn/views, etc. (~70 remaining) — separate PRs.
- Enabling `S101` in `ruff.toml` — wait until count hits zero or carve-outs are decided.