### PR TITLE
Replace proofing.py isinstance asserts with RuntimeError checks

### DIFF
--- a/src/eduid/webapp/bankid/acs_actions.py
+++ b/src/eduid/webapp/bankid/acs_actions.py
@@ -23,7 +23,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     """
     Perform common checks for SAML ACS actions.
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=BankIDMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -50,8 +51,7 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
 
     if ret := common_saml_checks(args=args):
@@ -61,8 +61,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -92,10 +92,10 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     if ret := common_saml_checks(args=args):
         return ret
@@ -117,8 +117,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -176,8 +176,7 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
 
     if ret := common_saml_checks(args=args):
@@ -190,8 +189,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/bankid/proofing.py
+++ b/src/eduid/webapp/bankid/proofing.py
@@ -55,7 +55,8 @@ class BankIDProofingFunctions(ProofingFunctions[BankIDSessionInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         nin_element = NinProofingElement(
@@ -103,8 +104,8 @@ class BankIDProofingFunctions(ProofingFunctions[BankIDSessionInfo]):
         else:
             proofing_version = self.config.security_key_proofing_version
 
-        # please type checking
-        assert user.identities.nin
+        if user.identities.nin is None:
+            raise RuntimeError("user.identities.nin not set when expected")
 
         data = MFATokenBankIDProofing(
             created_by=self.app_name,

--- a/src/eduid/webapp/common/proofing/base.py
+++ b/src/eduid/webapp/common/proofing/base.py
@@ -91,7 +91,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
         mark_result = self.mark_credential_as_verified(credential, loa)
         if mark_result.error:
             return mark_result
-        assert mark_result.credential  # please type checking
+        if mark_result.credential is None:
+            raise RuntimeError("mark_credential_as_verified returned no error and no credential")
         credential = mark_result.credential
 
         # Create a proofing log
@@ -101,8 +102,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
 
         # get a reference to the credential on the proofing_user, since that is the one we'll save below
         _credential = proofing_user.credentials.find(credential.key)
-        # please type checking
-        assert _credential
+        if _credential is None:
+            raise RuntimeError(f"credential {credential.key} not found on proofing_user")
         credential = _credential
 
         # Set token as verified
@@ -111,7 +112,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
         credential.proofing_version = self.config.security_key_proofing_version
 
         # Save proofing log entry and save user
-        assert proofing_log_entry.data  # please type checking
+        if proofing_log_entry.data is None:
+            raise RuntimeError("credential_proofing_element returned no error and no data")
         if not current_app.proofing_log.save(proofing_log_entry.data):
             current_app.logger.exception("Saving proofing log for user failed")
             return VerifyCredentialResult(error=CommonMsg.temp_problem)
@@ -173,7 +175,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
                 mfa_data = self.get_mfa_data()
                 if mfa_data.error is not None:
                     return MatchResult(error=mfa_data.error)
-                assert mfa_data.result is not None  # please mypy
+                if mfa_data.result is None:
+                    raise RuntimeError("get_mfa_data returned no error and no result")
 
                 if mfa_success:
                     credential_used = self._find_or_add_credential(

--- a/src/eduid/webapp/common/proofing/methods.py
+++ b/src/eduid/webapp/common/proofing/methods.py
@@ -171,7 +171,8 @@ def get_proofing_method(
     | None
 ):
     authn_params = config.frontend_action_authn_parameters.get(frontend_action)
-    assert authn_params is not None  # please mypy
+    if authn_params is None:
+        raise RuntimeError(f"no authn parameters configured for frontend_action {frontend_action}")
 
     if method == "freja":
         if not config.freja_idp:

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -22,7 +22,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     """
     Check that the user is authenticated and that the session info is valid.
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=EidasMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -51,8 +52,7 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
@@ -63,8 +63,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -94,15 +94,15 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
     if ret := common_saml_checks(args=args):
         return ret
 
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -121,8 +121,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -180,8 +180,7 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
@@ -196,8 +195,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/eidas/proofing.py
+++ b/src/eduid/webapp/eidas/proofing.py
@@ -82,7 +82,8 @@ class FrejaProofingFunctions(SwedenConnectProofingFunctions[NinSessionInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         date_of_birth = self.session_info.attributes.date_of_birth
@@ -151,8 +152,8 @@ class FrejaProofingFunctions(SwedenConnectProofingFunctions[NinSessionInfo]):
             issuer = self.session_info.issuer
             authn_context = self.session_info.authn_context
 
-        # please type checking
-        assert user.identities.nin
+        if user.identities.nin is None:
+            raise RuntimeError("user.identities.nin not set when expected")
 
         data = MFATokenProofing(
             authn_context_class=authn_context,
@@ -240,7 +241,8 @@ class EidasProofingFunctions(SwedenConnectProofingFunctions[ForeignEidSessionInf
         proofing_log_entry = self.identity_proofing_element(user=proofing_user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, ForeignIdProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, ForeignIdProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # update the users names from the verified identity
         proofing_user = set_user_names_from_foreign_id(proofing_user, proofing_log_entry.data)

--- a/src/eduid/webapp/freja_eid/callback_actions.py
+++ b/src/eduid/webapp/freja_eid/callback_actions.py
@@ -29,8 +29,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -64,7 +64,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if not args.proofing_method:
         return ACSResult(message=FrejaEIDMsg.method_not_available)
 
-    assert isinstance(args.authn_req, RP_AuthnRequest)
+    if not isinstance(args.authn_req, RP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -83,8 +84,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -151,8 +152,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/freja_eid/proofing.py
+++ b/src/eduid/webapp/freja_eid/proofing.py
@@ -95,7 +95,8 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         date_of_birth = self.session_info.date_of_birth
@@ -172,7 +173,8 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=proofing_user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, FrejaEIDForeignProofing)  # please type checking
+        if not isinstance(proofing_log_entry.data, FrejaEIDForeignProofing):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # update the users names from the verified identity
         proofing_user = set_user_names_from_foreign_id(proofing_user, proofing_log_entry.data)
@@ -273,13 +275,15 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
 
     def _nin_credential_proofing_element(self, user: User, credential: Credential) -> ProofingElementResult:
         proofing_element_result = self._nin_identity_proofing_element(user)
-        assert proofing_element_result.data is not None  # please mypy
+        if proofing_element_result.data is None:
+            raise RuntimeError("proofing_element_result.data not set when expected")
         data = MFATokenFrejaEIDProofing(**proofing_element_result.data.to_dict(), key_id=credential.key)
         return ProofingElementResult(data=data)
 
     def _foreign_credential_proofing_element(self, user: User, credential: Credential) -> ProofingElementResult:
         proofing_element_result = self._foreign_identity_proofing_element(user)
-        assert proofing_element_result.data is not None  # please mypy
+        if proofing_element_result.data is None:
+            raise RuntimeError("proofing_element_result.data not set when expected")
         data = MFATokenFrejaEIDForeignProofing(**proofing_element_result.data.to_dict(), key_id=credential.key)
         return ProofingElementResult(data=data)
 
@@ -287,7 +291,8 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
         if self.is_swedish_document():
             identity_type = IdentityType.NIN
             asserted_unique_value = self.session_info.personal_identity_number
-            assert asserted_unique_value is not None  # please mypy
+            if asserted_unique_value is None:
+                raise RuntimeError("asserted_unique_value not set when expected")
         else:
             identity_type = IdentityType.FREJA
             asserted_unique_value = self.session_info.user_id

--- a/src/eduid/webapp/samleid/acs_actions.py
+++ b/src/eduid/webapp/samleid/acs_actions.py
@@ -28,7 +28,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     :param args: ACS action arguments containing session info and proofing method
     :returns: ACSResult with error message if validation fails, None if all checks pass
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=SamlEidMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -65,8 +66,7 @@ def samleid_verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
@@ -77,8 +77,8 @@ def samleid_verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -116,15 +116,15 @@ def samleid_verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
     if ret := common_saml_checks(args=args):
         return ret
 
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -143,8 +143,8 @@ def samleid_verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -207,8 +207,7 @@ def samleid_mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
@@ -223,8 +222,8 @@ def samleid_mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/svipe_id/callback_actions.py
+++ b/src/eduid/webapp/svipe_id/callback_actions.py
@@ -24,8 +24,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, SvipeDocumentUserInfo)
+    if not isinstance(parsed.info, SvipeDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/svipe_id/proofing.py
+++ b/src/eduid/webapp/svipe_id/proofing.py
@@ -60,7 +60,8 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         date_of_birth = self.session_info.birthdate
@@ -130,7 +131,8 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=proofing_user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, SvipeIDForeignProofing)  # please type checking
+        if not isinstance(proofing_log_entry.data, SvipeIDForeignProofing):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # update the users names from the verified identity
         proofing_user = set_user_names_from_foreign_id(proofing_user, proofing_log_entry.data)


### PR DESCRIPTION
# Replace proofing.py isinstance asserts with RuntimeError checks

## Why

17 mypy-narrowing `assert isinstance(...)` / `assert X is not None` calls in
proofing-related modules were silent under `python -O`. Replace each with an
explicit `if … : raise RuntimeError(...)` so the invariant survives optimised
builds.

Part of an ongoing effort to clear S101 (`assert` outside tests) violations
across the repo. Drops global S101 count: **89 → 72**.

## Pattern

The asserts encode "if `result.error` is None, the `result.data` field is set"
invariants on result-pair dataclasses (`GenericResult`, `MatchResult`,
`ProofingElementResult`, `VerifyCredentialResult`). Each call site narrows the
Optional payload after checking `error`. Replacement:

```python
# before
result = some_op()
if result.error:
    return ...
assert result.data is not None  # please mypy
# use result.data

# after
result = some_op()
if result.error:
    return ...
if result.data is None:
    raise RuntimeError("some_op returned no error and no data")
# use result.data
```

Same shape for `assert isinstance(proofing_log_entry.data, NinProofingLogElement)`
→ `if not isinstance(...): raise RuntimeError(f"unexpected type: {type(...).__name__}")`.

For `assert user.identities.nin` (caller-invariant) and
`assert authn_params is not None` (config-invariant), same `if … is None: raise`
treatment.

## Files touched

| File | Asserts removed |
|---|---:|
| [src/eduid/webapp/common/proofing/base.py](src/eduid/webapp/common/proofing/base.py) | 4 |
| [src/eduid/webapp/common/proofing/methods.py](src/eduid/webapp/common/proofing/methods.py) | 1 |
| [src/eduid/webapp/bankid/proofing.py](src/eduid/webapp/bankid/proofing.py) | 2 |
| [src/eduid/webapp/eidas/proofing.py](src/eduid/webapp/eidas/proofing.py) | 3 |
| [src/eduid/webapp/freja_eid/proofing.py](src/eduid/webapp/freja_eid/proofing.py) | 5 |
| [src/eduid/webapp/svipe_id/proofing.py](src/eduid/webapp/svipe_id/proofing.py) | 2 |

Diff: `+36/-21`.

## Known residual: result-class anti-pattern

`GenericResult[T]`, `ProofingElementResult`, `MatchResult`, `VerifyUserResult`,
`VerifyCredentialResult` all encode "exactly one of (data, error) is set" via
two Optional fields. The `RuntimeError` checks added here are duct tape — the
proper fix is a tagged union (`Ok[T] | Err`) so mypy narrows from the match arm
without runtime help.

Deferred deliberately: structural refactor across ~30 call sites, including
SAML/OIDC `acs_actions.py` files. Better done after the bankid + eidas deprecation
trims the call-site count.

Other small follow-ups in the same vein:

- Pass `nin: NinIdentity` directly to `credential_proofing_element` instead of
  relying on `user.identities.nin` being set.
- Tighten `frontend_action_authn_parameters.get(...)` to raise on missing key
  (or return a non-Optional via a typed wrapper).

## Scope not in this PR

- webapp/signup, authn/views, etc. (~70 remaining S101) — separate PRs.
- vccs / graphdb / workers — separate PRs.
- Enabling `S101` enforcement in `ruff.toml` — wait until count hits zero or
  carve-outs are decided.
