### PR TITLE
Replace asserts in graphdb, vccs, and common/authn/utils with runtime checks

### DIFF
--- a/src/eduid/graphdb/groupdb/db.py
+++ b/src/eduid/graphdb/groupdb/db.py
@@ -97,9 +97,7 @@ class GroupDB(BaseGraphDB):
             version=version,
             display_name=group.display_name,
             new_version=new_version,
-        ).single()
-        if res is None:
-            raise RuntimeError("group update query returned no record")
+        ).single(strict=True)
         return self._load_group(res.data()["group"])
 
     def _add_or_update_users_and_groups(
@@ -374,9 +372,7 @@ class GroupDB(BaseGraphDB):
             RETURN count(*) as exists LIMIT 1
             """
         with self.db.driver.session(default_access_mode=READ_ACCESS) as session:
-            single_value = session.run(q, scope=self.scope, identifier=identifier).single()
-            if single_value is None:
-                raise RuntimeError("group_exists query returned no record")
+            single_value = session.run(q, scope=self.scope, identifier=identifier).single(strict=True)
             ret = single_value["exists"]
         return bool(ret)
 

--- a/src/eduid/graphdb/groupdb/db.py
+++ b/src/eduid/graphdb/groupdb/db.py
@@ -98,7 +98,8 @@ class GroupDB(BaseGraphDB):
             display_name=group.display_name,
             new_version=new_version,
         ).single()
-        assert res is not None  # please mypy
+        if res is None:
+            raise RuntimeError("group update query returned no record")
         return self._load_group(res.data()["group"])
 
     def _add_or_update_users_and_groups(
@@ -244,21 +245,20 @@ class GroupDB(BaseGraphDB):
             # group did not exist
             return None
 
-        group_data: Node | None  # please mypy
         if len(group_graph.relationships) == 0:
             # Just a group with no owners or members
-            group_data = next(iter(group_graph.nodes))
-            assert group_data is not None
-            return self._load_group(group_data)
+            return self._load_group(next(iter(group_graph.nodes)))
         else:
             # Grab the first relationships end node and create the group from that
-            group_data = next(iter(group_graph.relationships)).end_node
-            assert group_data is not None
-            group = self._load_group(group_data)
+            end_node = next(iter(group_graph.relationships)).end_node
+            if end_node is None:
+                raise RuntimeError("relationship end_node missing in non-empty graph result")
+            group = self._load_group(end_node)
 
             # Iterate over relationships and create owners and members
             for rel in group_graph.relationships:
-                assert rel.start_node is not None  # please mypy
+                if rel.start_node is None:
+                    raise RuntimeError("relationship start_node missing in graph result")
                 labels = rel.start_node.labels
                 # Merge node and relationship data
                 data = dict(rel.start_node.items())
@@ -375,7 +375,8 @@ class GroupDB(BaseGraphDB):
             """
         with self.db.driver.session(default_access_mode=READ_ACCESS) as session:
             single_value = session.run(q, scope=self.scope, identifier=identifier).single()
-            assert single_value is not None  # please mypy
+            if single_value is None:
+                raise RuntimeError("group_exists query returned no record")
             ret = single_value["exists"]
         return bool(ret)
 

--- a/src/eduid/vccs/server/config.py
+++ b/src/eduid/vccs/server/config.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from typing import Any
 
+from fastapi import Request
 from pydantic import BaseModel
 
 from eduid.common.config.base import RootConfig
@@ -45,6 +46,12 @@ class VCCSConfig(RootConfig):
 
 
 def init_config(ns: str, app_name: str, test_config: Mapping[str, Any] | None = None) -> VCCSConfig:
-    config = load_config(typ=VCCSConfig, app_name=app_name, ns=ns, test_config=test_config)
-    assert isinstance(config, VCCSConfig)  # convince mypy
+    return load_config(typ=VCCSConfig, app_name=app_name, ns=ns, test_config=test_config)
+
+
+def get_config(req: Request) -> VCCSConfig:
+    """Pull the VCCS config off the FastAPI app state with a runtime type check."""
+    config = req.app.state.config
+    if not isinstance(config, VCCSConfig):
+        raise RuntimeError(f"unexpected app.state.config type: {type(config).__name__}")
     return config

--- a/src/eduid/vccs/server/endpoints/add_creds.py
+++ b/src/eduid/vccs/server/endpoints/add_creds.py
@@ -4,7 +4,7 @@ from typing import Annotated, cast
 from fastapi import APIRouter, Form, Request
 from pydantic.main import BaseModel
 
-from eduid.vccs.server.config import VCCSConfig
+from eduid.vccs.server.config import VCCSConfig, get_config
 from eduid.vccs.server.db import KDF, CredType, PasswordCredential, Status, Version
 from eduid.vccs.server.factors import RequestFactor
 from eduid.vccs.server.password import calculate_cred_hash
@@ -51,8 +51,7 @@ async def add_creds_legacy(req: Request, request: Annotated[str, Form(...)]) -> 
 @add_creds_router.post("/v2/add_creds", response_model=AddCredsFormResponse)
 async def add_creds(req: Request, request: AddCredsRequestV1) -> AddCredsResponseV1:
     # convenience and typing
-    _config = req.app.state.config
-    assert isinstance(_config, VCCSConfig)
+    _config = get_config(req)
     results = []
     for factor in request.factors:
         this_result = False

--- a/src/eduid/vccs/server/endpoints/authenticate.py
+++ b/src/eduid/vccs/server/endpoints/authenticate.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import APIRouter, Form, Request
 from pydantic.main import BaseModel
 
-from eduid.vccs.server.config import VCCSConfig
+from eduid.vccs.server.config import get_config
 from eduid.vccs.server.db import CredType, Status
 from eduid.vccs.server.factors import RequestFactor
 from eduid.vccs.server.log import audit_log
@@ -70,8 +70,7 @@ async def authenticate(req: Request, request: AuthenticateRequestV1) -> Authenti
     :returns: True on successful authentication, False otherwise
     """
     # convenience and typing
-    _config = req.app.state.config
-    assert isinstance(_config, VCCSConfig)
+    _config = get_config(req)
 
     results: list[bool] = []
     # TODO: Make sure to respond False if request.factors is empty.

--- a/src/eduid/vccs/server/endpoints/revoke_creds.py
+++ b/src/eduid/vccs/server/endpoints/revoke_creds.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import APIRouter, Form, Request
 from pydantic.main import BaseModel
 
-from eduid.vccs.server.config import VCCSConfig
+from eduid.vccs.server.config import get_config
 from eduid.vccs.server.db import CredType, RevokedCredential, Status
 from eduid.vccs.server.factors import RevokeFactor
 from eduid.vccs.server.log import audit_log
@@ -51,8 +51,7 @@ async def revoke_creds_legacy(req: Request, request: Annotated[str, Form(...)]) 
 @revoke_creds_router.post("/v2/revoke_creds", response_model=RevokeCredsFormResponse)
 async def revoke_creds(req: Request, request: RevokeCredsRequestV1) -> RevokeCredsResponseV1:
     # convenience and typing
-    _config = req.app.state.config
-    assert isinstance(_config, VCCSConfig)
+    _config = get_config(req)
 
     results: list[bool] = []
     for factor in request.factors:

--- a/src/eduid/vccs/server/log.py
+++ b/src/eduid/vccs/server/log.py
@@ -41,7 +41,8 @@ def audit_log(msg: str) -> None:
     # Find calling function
     frame, depth = logging.currentframe(), 2
     while frame.f_code.co_filename == logging.__file__:
-        assert frame.f_back  # please mypy
+        if frame.f_back is None:
+            break
         frame = frame.f_back
         depth += 1
 

--- a/src/eduid/webapp/bankid/acs_actions.py
+++ b/src/eduid/webapp/bankid/acs_actions.py
@@ -23,7 +23,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     """
     Perform common checks for SAML ACS actions.
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=BankIDMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -50,8 +51,7 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
 
     if ret := common_saml_checks(args=args):
@@ -61,8 +61,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -92,10 +92,10 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     if ret := common_saml_checks(args=args):
         return ret
@@ -117,8 +117,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -176,8 +176,7 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=BankIDMsg.method_not_available)
 
     if ret := common_saml_checks(args=args):
@@ -190,8 +189,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/bankid/proofing.py
+++ b/src/eduid/webapp/bankid/proofing.py
@@ -55,7 +55,8 @@ class BankIDProofingFunctions(ProofingFunctions[BankIDSessionInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         nin_element = NinProofingElement(
@@ -103,8 +104,8 @@ class BankIDProofingFunctions(ProofingFunctions[BankIDSessionInfo]):
         else:
             proofing_version = self.config.security_key_proofing_version
 
-        # please type checking
-        assert user.identities.nin
+        if user.identities.nin is None:
+            raise RuntimeError("user.identities.nin not set when expected")
 
         data = MFATokenBankIDProofing(
             created_by=self.app_name,

--- a/src/eduid/webapp/common/authn/utils.py
+++ b/src/eduid/webapp/common/authn/utils.py
@@ -48,12 +48,15 @@ def get_saml2_config(module_path: str, name: str = "SAML_CONFIG") -> SPConfig:
 
 def get_location(http_info: SAMLHttpArgs) -> str:
     """Extract the redirect URL from a pysaml2 http_info object"""
-    assert "headers" in http_info
+    if "headers" not in http_info:
+        raise ValueError("http_info missing 'headers' key")
     headers = http_info["headers"]
 
-    assert len(headers) == 1
+    if len(headers) != 1:
+        raise ValueError(f"expected exactly one header, got {len(headers)}")
     header_name, header_value = headers[0]
-    assert header_name == "Location"
+    if header_name != "Location":
+        raise ValueError(f"expected 'Location' header, got {header_name!r}")
     return cast(str, header_value)
 
 

--- a/src/eduid/webapp/common/proofing/base.py
+++ b/src/eduid/webapp/common/proofing/base.py
@@ -91,7 +91,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
         mark_result = self.mark_credential_as_verified(credential, loa)
         if mark_result.error:
             return mark_result
-        assert mark_result.credential  # please type checking
+        if mark_result.credential is None:
+            raise RuntimeError("mark_credential_as_verified returned no error and no credential")
         credential = mark_result.credential
 
         # Create a proofing log
@@ -101,8 +102,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
 
         # get a reference to the credential on the proofing_user, since that is the one we'll save below
         _credential = proofing_user.credentials.find(credential.key)
-        # please type checking
-        assert _credential
+        if _credential is None:
+            raise RuntimeError(f"credential {credential.key} not found on proofing_user")
         credential = _credential
 
         # Set token as verified
@@ -111,7 +112,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
         credential.proofing_version = self.config.security_key_proofing_version
 
         # Save proofing log entry and save user
-        assert proofing_log_entry.data  # please type checking
+        if proofing_log_entry.data is None:
+            raise RuntimeError("credential_proofing_element returned no error and no data")
         if not current_app.proofing_log.save(proofing_log_entry.data):
             current_app.logger.exception("Saving proofing log for user failed")
             return VerifyCredentialResult(error=CommonMsg.temp_problem)
@@ -173,7 +175,8 @@ class ProofingFunctions[SessionInfoVar](ABC):
                 mfa_data = self.get_mfa_data()
                 if mfa_data.error is not None:
                     return MatchResult(error=mfa_data.error)
-                assert mfa_data.result is not None  # please mypy
+                if mfa_data.result is None:
+                    raise RuntimeError("get_mfa_data returned no error and no result")
 
                 if mfa_success:
                     credential_used = self._find_or_add_credential(

--- a/src/eduid/webapp/common/proofing/methods.py
+++ b/src/eduid/webapp/common/proofing/methods.py
@@ -171,7 +171,8 @@ def get_proofing_method(
     | None
 ):
     authn_params = config.frontend_action_authn_parameters.get(frontend_action)
-    assert authn_params is not None  # please mypy
+    if authn_params is None:
+        raise RuntimeError(f"no authn parameters configured for frontend_action {frontend_action}")
 
     if method == "freja":
         if not config.freja_idp:

--- a/src/eduid/webapp/eidas/acs_actions.py
+++ b/src/eduid/webapp/eidas/acs_actions.py
@@ -22,7 +22,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     """
     Check that the user is authenticated and that the session info is valid.
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=EidasMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -51,8 +52,7 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
@@ -63,8 +63,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -94,15 +94,15 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
     if ret := common_saml_checks(args=args):
         return ret
 
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -121,8 +121,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -180,8 +180,7 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :return: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=EidasMsg.method_not_available)
 
     # validate the assertion data
@@ -196,8 +195,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/eidas/proofing.py
+++ b/src/eduid/webapp/eidas/proofing.py
@@ -82,7 +82,8 @@ class FrejaProofingFunctions(SwedenConnectProofingFunctions[NinSessionInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         date_of_birth = self.session_info.attributes.date_of_birth
@@ -151,8 +152,8 @@ class FrejaProofingFunctions(SwedenConnectProofingFunctions[NinSessionInfo]):
             issuer = self.session_info.issuer
             authn_context = self.session_info.authn_context
 
-        # please type checking
-        assert user.identities.nin
+        if user.identities.nin is None:
+            raise RuntimeError("user.identities.nin not set when expected")
 
         data = MFATokenProofing(
             authn_context_class=authn_context,
@@ -240,7 +241,8 @@ class EidasProofingFunctions(SwedenConnectProofingFunctions[ForeignEidSessionInf
         proofing_log_entry = self.identity_proofing_element(user=proofing_user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, ForeignIdProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, ForeignIdProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # update the users names from the verified identity
         proofing_user = set_user_names_from_foreign_id(proofing_user, proofing_log_entry.data)

--- a/src/eduid/webapp/freja_eid/callback_actions.py
+++ b/src/eduid/webapp/freja_eid/callback_actions.py
@@ -29,8 +29,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -64,7 +64,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if not args.proofing_method:
         return ACSResult(message=FrejaEIDMsg.method_not_available)
 
-    assert isinstance(args.authn_req, RP_AuthnRequest)
+    if not isinstance(args.authn_req, RP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -83,8 +84,8 @@ def verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -151,8 +152,8 @@ def mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, FrejaEIDDocumentUserInfo)
+    if not isinstance(parsed.info, FrejaEIDDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/freja_eid/proofing.py
+++ b/src/eduid/webapp/freja_eid/proofing.py
@@ -95,7 +95,8 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         date_of_birth = self.session_info.date_of_birth
@@ -172,7 +173,8 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=proofing_user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, FrejaEIDForeignProofing)  # please type checking
+        if not isinstance(proofing_log_entry.data, FrejaEIDForeignProofing):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # update the users names from the verified identity
         proofing_user = set_user_names_from_foreign_id(proofing_user, proofing_log_entry.data)
@@ -273,13 +275,15 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
 
     def _nin_credential_proofing_element(self, user: User, credential: Credential) -> ProofingElementResult:
         proofing_element_result = self._nin_identity_proofing_element(user)
-        assert proofing_element_result.data is not None  # please mypy
+        if proofing_element_result.data is None:
+            raise RuntimeError("proofing_element_result.data not set when expected")
         data = MFATokenFrejaEIDProofing(**proofing_element_result.data.to_dict(), key_id=credential.key)
         return ProofingElementResult(data=data)
 
     def _foreign_credential_proofing_element(self, user: User, credential: Credential) -> ProofingElementResult:
         proofing_element_result = self._foreign_identity_proofing_element(user)
-        assert proofing_element_result.data is not None  # please mypy
+        if proofing_element_result.data is None:
+            raise RuntimeError("proofing_element_result.data not set when expected")
         data = MFATokenFrejaEIDForeignProofing(**proofing_element_result.data.to_dict(), key_id=credential.key)
         return ProofingElementResult(data=data)
 
@@ -287,7 +291,8 @@ class FrejaEIDProofingFunctions(ProofingFunctions[FrejaEIDDocumentUserInfo]):
         if self.is_swedish_document():
             identity_type = IdentityType.NIN
             asserted_unique_value = self.session_info.personal_identity_number
-            assert asserted_unique_value is not None  # please mypy
+            if asserted_unique_value is None:
+                raise RuntimeError("asserted_unique_value not set when expected")
         else:
             identity_type = IdentityType.FREJA
             asserted_unique_value = self.session_info.user_id

--- a/src/eduid/webapp/samleid/acs_actions.py
+++ b/src/eduid/webapp/samleid/acs_actions.py
@@ -28,7 +28,8 @@ def common_saml_checks(args: ACSArgs) -> ACSResult | None:
     :param args: ACS action arguments containing session info and proofing method
     :returns: ACSResult with error message if validation fails, None if all checks pass
     """
-    assert isinstance(args.proofing_method, ProofingMethodSAML)  # please mypy
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
+        return ACSResult(message=SamlEidMsg.method_not_available)
     if not is_required_loa(
         args.session_info, args.proofing_method.required_loa, current_app.conf.loa_authn_context_map
     ):
@@ -65,8 +66,7 @@ def samleid_verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
@@ -77,8 +77,8 @@ def samleid_verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -116,15 +116,15 @@ def samleid_verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
     if ret := common_saml_checks(args=args):
         return ret
 
-    assert isinstance(args.authn_req, SP_AuthnRequest)
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
 
     credential = user.credentials.find(args.authn_req.proofing_credential_id)
     if not isinstance(credential, FidoCredential):
@@ -143,8 +143,8 @@ def samleid_verify_credential_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor
@@ -207,8 +207,7 @@ def samleid_mfa_authenticate_action(args: ACSArgs) -> ACSResult:
 
     :returns: ACS action result
     """
-    # please type checking
-    if not args.proofing_method:
+    if not isinstance(args.proofing_method, ProofingMethodSAML):
         return ACSResult(message=SamlEidMsg.method_not_available)
 
     # validate the assertion data
@@ -223,8 +222,8 @@ def samleid_mfa_authenticate_action(args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, BaseSessionInfo)
+    if not isinstance(parsed.info, BaseSessionInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -160,7 +160,8 @@ def check_email_status(email: str) -> EmailStatus:
         return EmailStatus.NEW
 
     # check if mail sending is throttled
-    assert session.signup.email.sent_at is not None
+    if session.signup.email.sent_at is None:
+        raise RuntimeError("session.signup.email.sent_at not set")
     if is_throttled(session.signup.email.sent_at, current_app.conf.throttle_resend):
         seconds_left = time_left(session.signup.email.sent_at, current_app.conf.throttle_resend)
         current_app.logger.info(f"User has been sent a verification code too recently: {seconds_left} seconds left")
@@ -242,7 +243,8 @@ def create_and_sync_user(
     if generated_password is not None or custom_password is not None:
         is_generated = custom_password is None
         password = custom_password or generated_password
-        assert password is not None  # please mypy
+        if password is None:
+            raise RuntimeError("password not set after generated/custom password check")
 
         if not add_password(
             signup_user,
@@ -441,7 +443,8 @@ def update_or_create_scim_user(invite: Invite, signup_user: SignupUser) -> UserR
             value=f"{signup_user.eppn}@{current_app.conf.eduid_scope}",
             parameters=parameters,
         )
-        assert update_user.nutid_user_v1 is not None  # please mypy
+        if update_user.nutid_user_v1 is None:
+            raise RuntimeError("update_user.nutid_user_v1 not set")
         linked_accounts = update_user.nutid_user_v1.model_dump().get("linked_accounts", [])
         linked_accounts.append(eduid_linked_account)
         update_user = update_user.model_copy(

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -121,9 +121,12 @@ def register_email(given_name: str, surname: str, email: str) -> FluxData:
     # send email to the user
     if email_status in [EmailStatus.NEW, EmailStatus.RESEND_CODE]:
         current_app.logger.info("Sending verification email")
-        assert session.signup.email.address is not None  # please mypy
-        assert session.signup.email.verification_code is not None  # please mypy
-        assert session.signup.email.reference is not None  # please mypy
+        if session.signup.email.address is None:
+            raise RuntimeError("session.signup.email.address not set")
+        if session.signup.email.verification_code is None:
+            raise RuntimeError("session.signup.email.verification_code not set")
+        if session.signup.email.reference is None:
+            raise RuntimeError("session.signup.email.reference not set")
         send_signup_mail(
             email=session.signup.email.address,
             verification_code=session.signup.email.verification_code,
@@ -482,16 +485,21 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
     if error is not None:
         return error
 
-    assert session.signup.name.given_name is not None  # please mypy
-    assert session.signup.name.surname is not None  # please mypy
-    assert session.signup.email.address is not None  # please mypy
-    assert session.signup.tou.version is not None  # please mypy
+    if session.signup.name.given_name is None:
+        raise RuntimeError("session.signup.name.given_name not set")
+    if session.signup.name.surname is None:
+        raise RuntimeError("session.signup.name.surname not set")
+    if session.signup.email.address is None:
+        raise RuntimeError("session.signup.email.address not set")
+    if session.signup.tou.version is None:
+        raise RuntimeError("session.signup.tou.version not set")
 
     webauthn_credential = None
     webauthn_authenticator_info = None
     if use_webauthn:
         wn = session.signup.credentials.webauthn
-        assert wn is not None  # checked above
+        if wn is None:
+            raise RuntimeError("session.signup.credentials.webauthn not set after _check_credentials_selected")
         webauthn_credential = Webauthn(
             keyhandle=wn.keyhandle,
             credential_data=wn.credential_data,
@@ -578,7 +586,8 @@ def get_invite(invite_code: str) -> FluxData:
 
     if session.common.is_logged_in:
         user = current_app.central_userdb.get_user_by_eppn(eppn=session.common.eppn)
-        assert user.mail_addresses.primary is not None  # please mypy
+        if user.mail_addresses.primary is None:
+            raise RuntimeError("logged-in user has no primary email")
         invite_data["user"] = {
             "given_name": user.given_name,
             "surname": user.surname,
@@ -633,7 +642,8 @@ def complete_invite() -> FluxData:
 
     user = current_app.central_userdb.get_user_by_eppn(eppn=session.common.eppn)
 
-    assert session.signup.invite.invite_code is not None  # please mypy
+    if session.signup.invite.invite_code is None:
+        raise RuntimeError("session.signup.invite.invite_code not set")
     try:
         complete_and_update_invite(user=user, invite_code=session.signup.invite.invite_code)
     except InviteNotFound:
@@ -658,7 +668,8 @@ def complete_invite_existing_user(user: User) -> FluxData:
     if session.signup.invite.initiated_signup is False:
         return success_response(payload={"state": session.signup.to_dict()})
 
-    assert session.signup.invite.invite_code is not None  # please mypy
+    if session.signup.invite.invite_code is None:
+        raise RuntimeError("session.signup.invite.invite_code not set")
     try:
         complete_and_update_invite(user=user, invite_code=session.signup.invite.invite_code)
     except InviteNotFound:

--- a/src/eduid/webapp/svipe_id/callback_actions.py
+++ b/src/eduid/webapp/svipe_id/callback_actions.py
@@ -24,8 +24,8 @@ def verify_identity_action(user: User, args: ACSArgs) -> ACSResult:
     if parsed.error:
         return ACSResult(message=parsed.error)
 
-    # please type checking
-    assert isinstance(parsed.info, SvipeDocumentUserInfo)
+    if not isinstance(parsed.info, SvipeDocumentUserInfo):
+        raise RuntimeError(f"unexpected parsed.info type: {type(parsed.info).__name__}")
 
     proofing = get_proofing_functions(
         session_info=parsed.info, app_name=current_app.conf.app_name, config=current_app.conf, backdoor=args.backdoor

--- a/src/eduid/webapp/svipe_id/proofing.py
+++ b/src/eduid/webapp/svipe_id/proofing.py
@@ -60,7 +60,8 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, NinProofingLogElement)  # please type checking
+        if not isinstance(proofing_log_entry.data, NinProofingLogElement):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # Verify NIN for user
         date_of_birth = self.session_info.birthdate
@@ -130,7 +131,8 @@ class SvipeIDProofingFunctions(ProofingFunctions[SvipeDocumentUserInfo]):
         proofing_log_entry = self.identity_proofing_element(user=proofing_user)
         if proofing_log_entry.error:
             return VerifyUserResult(error=proofing_log_entry.error)
-        assert isinstance(proofing_log_entry.data, SvipeIDForeignProofing)  # please type checking
+        if not isinstance(proofing_log_entry.data, SvipeIDForeignProofing):
+            raise RuntimeError(f"unexpected proofing_log_entry.data type: {type(proofing_log_entry.data).__name__}")
 
         # update the users names from the verified identity
         proofing_user = set_user_names_from_foreign_id(proofing_user, proofing_log_entry.data)


### PR DESCRIPTION
# Replace asserts in graphdb, vccs, and common/authn/utils with runtime checks

## Why

13 mypy-narrowing / runtime-invariant `assert` calls outside the webapp dense
clusters were silent under `python -O`. Replace each with an explicit runtime
check (or eliminate via better-typed boundaries).

Part of an ongoing effort to clear S101 (`assert` outside tests) violations
across the repo. Drops global S101 count: **58 → 45**.

Combines three contained backends in one PR — each is small enough on its own
that a single review pass covers all three.

## Changes by area

### graphdb (5 → 0)

[src/eduid/graphdb/groupdb/db.py](src/eduid/graphdb/groupdb/db.py):

- Two `Result.single()` + `assert ... is not None` patterns → `Result.single(strict=True)`.
  The neo4j driver raises `ResultNotSingleError` when the result isn't exactly
  one row, and the `strict=True` overload returns non-Optional. Idiomatic, no
  follow-up narrowing.
- The `_get_group` helper had an explicit `group_data: Node | None` annotation
  that widened `next(iter(graph.nodes))`'s actually-non-Optional return for the
  sake of a single shared variable. Split into separate locals (`end_node` for
  the relationship branch) so the simple-group branch returns directly without
  a None check at all.
- Remaining `rel.start_node is None` check in the relationship loop becomes a
  proper `if … : raise RuntimeError(...)` — `start_node` really is `Node | None`
  in the neo4j stubs, so the check is reachable.

### vccs (5 → 0)

[src/eduid/vccs/server/config.py](src/eduid/vccs/server/config.py):

- `init_config` no longer needs `assert isinstance(config, VCCSConfig)` — the
  generic `load_config[T: RootConfig](typ: type[T]) -> T` already returns the
  exact type, the assert was redundant.
- New `get_config(req: Request) -> VCCSConfig` helper centralises the
  `app.state.config` runtime type check (FastAPI's `app.state` is `Any`).

[src/eduid/vccs/server/endpoints/{add_creds,authenticate,revoke_creds}.py](src/eduid/vccs/server/endpoints/):

- `_config = req.app.state.config; assert isinstance(_config, VCCSConfig)` →
  `_config = get_config(req)`. Three identical asserts collapse to one helper.

[src/eduid/vccs/server/log.py](src/eduid/vccs/server/log.py):

- `assert frame.f_back` (mid-loop) → `if frame.f_back is None: break`. The
  loop terminates cleanly if `currentframe()` walks off the stack rather than
  exploding with `AssertionError`.

### common/authn/utils.get_location (3 → 0)

[src/eduid/webapp/common/authn/utils.py](src/eduid/webapp/common/authn/utils.py):

`get_location(http_info)` extracts the redirect URL from a pysaml2 `http_info`
dict. Three asserts encoded real invariants on the pysaml2 response shape:

```python
# before
assert "headers" in http_info
headers = http_info["headers"]
assert len(headers) == 1
header_name, header_value = headers[0]
assert header_name == "Location"

# after
if "headers" not in http_info:
    raise ValueError("http_info missing 'headers' key")
headers = http_info["headers"]
if len(headers) != 1:
    raise ValueError(f"expected exactly one header, got {len(headers)}")
header_name, header_value = headers[0]
if header_name != "Location":
    raise ValueError(f"expected 'Location' header, got {header_name!r}")
```

`ValueError` rather than `RuntimeError` — these are checks on data shape, not
internal-state invariants, so a value-error class fits better.

## Files touched

| File | Asserts removed |
|---|---:|
| [src/eduid/graphdb/groupdb/db.py](src/eduid/graphdb/groupdb/db.py) | 5 |
| [src/eduid/vccs/server/config.py](src/eduid/vccs/server/config.py) | 1 (+ helper added) |
| [src/eduid/vccs/server/endpoints/add_creds.py](src/eduid/vccs/server/endpoints/add_creds.py) | 1 |
| [src/eduid/vccs/server/endpoints/authenticate.py](src/eduid/vccs/server/endpoints/authenticate.py) | 1 |
| [src/eduid/vccs/server/endpoints/revoke_creds.py](src/eduid/vccs/server/endpoints/revoke_creds.py) | 1 |
| [src/eduid/vccs/server/log.py](src/eduid/vccs/server/log.py) | 1 |
| [src/eduid/webapp/common/authn/utils.py](src/eduid/webapp/common/authn/utils.py) | 3 |

Diff: `+25/-21`.

## Scope not in this PR

- webapp/views, webapp/idp, workers/job_runner — separate PRs.
- webapp/common (api/{helpers,checks,translation,sanitation}, session) —
  separate PR; wider blast radius.
- Enabling `S101` enforcement in `ruff.toml` — wait until count hits zero or
  carve-outs are decided.
