### PR TITLE
New signup fixes after frontend testing

### DIFF
--- a/src/eduid/maccapi/routers/users.py
+++ b/src/eduid/maccapi/routers/users.py
@@ -141,7 +141,9 @@ async def reset_password(
     new_password = generate_password()
     presentable_password = make_presentable_password(new_password)
     try:
-        managed_account = get_user(context=request.app.context, eppn=eppn, data_owner=request.context.require_data_owner())
+        managed_account = get_user(
+            context=request.app.context, eppn=eppn, data_owner=request.context.require_data_owner()
+        )
         replace_password(context=request.app.context, eppn=eppn, new_password=new_password)
 
         add_api_event(

--- a/src/eduid/scimapi/routers/events.py
+++ b/src/eduid/scimapi/routers/events.py
@@ -37,9 +37,7 @@ async def on_get(req: ScimApiRequest, resp: Response, scim_id: str | None = None
 
 
 @events_router.post("/", response_model_exclude_none=True)
-async def on_post(
-    req: ScimApiRequest, resp: Response, create_request: EventCreateRequest
-) -> EventResponse:
+async def on_post(req: ScimApiRequest, resp: Response, create_request: EventCreateRequest) -> EventResponse:
     """
     POST /Events  HTTP/1.1
     Host: example.com
@@ -114,8 +112,6 @@ async def on_post(
         version=1, data={"location": req.app.context.resource_url(SCIMResourceType.EVENT, event.scim_id)}
     )
 
-    req.app.context.notification_relay.notify(
-        data_owner=data_owner, message=message, context=req.app.context
-    )
+    req.app.context.notification_relay.notify(data_owner=data_owner, message=message, context=req.app.context)
 
     return db_event_to_response(req, resp, event)

--- a/src/eduid/scimapi/routers/groups.py
+++ b/src/eduid/scimapi/routers/groups.py
@@ -154,7 +154,9 @@ async def on_put(
                 req.app.context.logger.error(f"User {member.value} not found")
                 raise BadRequest(detail=f"User {member.value} not found")
 
-    updated_group, changed = req.context.require_groupdb().update_group(update_request=update_request, db_group=db_group)
+    updated_group, changed = req.context.require_groupdb().update_group(
+        update_request=update_request, db_group=db_group
+    )
     # Load the group from the database to ensure results are consistent with subsequent GETs.
     # For example, timestamps have higher resolution in updated_group than after a load.
     db_group = req.context.require_groupdb().get_group_by_scim_id(str(updated_group.scim_id))

--- a/src/eduid/webapp/common/authn/tests/test_webauthn.py
+++ b/src/eduid/webapp/common/authn/tests/test_webauthn.py
@@ -1,0 +1,197 @@
+"""Tests for shared WebAuthn registration (verify_webauthn_registration).
+
+Regression coverage for keyhandle format: must be base64url (registration.id),
+not hex of credential_id. Using hex breaks credential lookup by ElementKey since
+Webauthn.key = sha256(keyhandle + credential_data).
+"""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+from fido2.utils import websafe_decode, websafe_encode
+from fido2.webauthn import AttestedCredentialData, AuthenticatorAttachment
+
+from eduid.userdb.credentials import Webauthn
+from eduid.webapp.common.authn.webauthn import (
+    RegistrationError,
+    RegistrationResult,
+    verify_webauthn_registration,
+)
+
+# CTAP1 test data — same attestation fixtures as security/signup tests (Yubikey U2F)
+STATE = {"challenge": "u3zHzb7krB4c4wj0Uxuhsz2lCXqLnwV9ZxMhvL2lcfo", "user_verification": "discouraged"}
+
+ATTESTATION_OBJECT = (
+    b"o2NmbXRoZmlkby11MmZnYXR0U3RtdKJjc2lnWEcwRQIgPCNiKlxIO0iR5Wo9BidnNhX2lAFcAB3VwuRH"
+    b"QZbL3dwCIQDFKuPjwLTvjaDw9TbfoJeww7DMsZSlteW4ClwRivpUqWN4NWOBWQIzMIICLzCCARmgAwIB"
+    b"AgIEQvUaTTALBgkqhkiG9w0BAQswLjEsMCoGA1UEAxMjWXViaWNvIFUyRiBSb290IENBIFNlcmlhbCA0"
+    b"NTcyMDA2MzEwIBcNMTQwODAxMDAwMDAwWhgPMjA1MDA5MDQwMDAwMDBaMCoxKDAmBgNVBAMMH1l1Ymlj"
+    b"byBVMkYgRUUgU2VyaWFsIDExMjMzNTkzMDkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQphQ-PJYiZ"
+    b"jZEVHtrx5QGE3_LE1-OytZPTwzrpWBKywji_3qmg22mwmVFl32PO269TxY-yVN4jbfVf5uX0EWJWoyYw"
+    b"JDAiBgkrBgEEAYLECgIEFTEuMy42LjEuNC4xLjQxNDgyLjEuNDALBgkqhkiG9w0BAQsDggEBALSc3YwT"
+    b"RbLwXhePj_imdBOhWiqh6ssS2ONgp5tphJCHR5Agjg2VstLBRsJzyJnLgy7bGZ0QbPOyh_J0hsvgBfvj"
+    b"ByXOu1AwCW-tcoJ-pfxESojDLDn8hrFph6eWZoCtBsWMDh6vMqPENeP6grEAECWx4fTpBL9Bm7F-0Rp_"
+    b"d1_l66g4IhF_ZvuRFhY-BUK94BfivuBHpEkMwxKENTas7VkxvlVstUvPqhPHGYOq7RdF1D_THsbNY8-t"
+    b"gCTgvTziEG-bfDeY6zIz5h7bxb1rpajNVTpUDWtVYL7_w44e1KCoErqdS-kEbmmkmm7KvDE8kuyg42Fm"
+    b"b5DTMsbY2jxMlMVoYXV0aERhdGFYxNz3BHEmKmoM4iTRAmMUgSjEdNSeKZskhyDzwzPuNmHTQQAAAAAA"
+    b"AAAAAAAAAAAAAAAAAAAAAEC8lMNeMgJDZOvOHus-78SI8YvR3HVUwv2NR3PcfvBndpabw-UiQQjx4N-T"
+    b"lJZcGJFfhzzQ9oAnkvZhcwGGTdtLpQECAyYgASFYIOHIO6vueJNYEgtQUy_wdwVka6DrKYSXnsIM6nfx"
+    b"-mtgIlggkCpDejidmogF4SZ_n01JlE8dY43tFEIwAPy2qCGinzQ"
+)
+
+CLIENT_DATA_JSON = (
+    b"eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoidTN6SHpiN2tyQjRjNHdqMFV4dWhz"
+    b"ejJsQ1hxTG53VjlaeE1odkwybGNmbyIsIm9yaWdpbiI6Imh0dHBzOi8vZGFzaGJvYXJkLmVkdWlkLmRv"
+    b"Y2tlciIsImNyb3NzT3JpZ2luIjpmYWxzZX0"
+)
+
+# Correct base64url credential ID (matches what's embedded in the attestation object above)
+CREDENTIAL_ID_B64URL = "vJTDXjICQ2Trzh7rPu_EiPGL0dx1VML9jUdz3H7wZ3aWm8PlIkEI8eDfk5SWXBiRX4c80PaAJ5L2YXMBhk3bSw"
+
+# Same credential ID as hex — the OLD broken format used before the shared registration refactor
+CREDENTIAL_ID_HEX = (
+    "bc94c35e32024364ebce1eeb3eefc488f18bd1dc7554c2fd8d4773dc7ef06776"
+    "969bc3e5224108f1e0df9394965c18915f873cd0f6802792f6617301864ddb4b"
+)
+
+
+def _make_response(credential_id: str = CREDENTIAL_ID_B64URL) -> dict:
+    return {
+        "credentialId": credential_id,
+        "rawId": credential_id,
+        "response": {
+            "attestationObject": ATTESTATION_OBJECT.decode("ascii").strip("="),
+            "clientDataJSON": CLIENT_DATA_JSON.decode("ascii").strip("="),
+        },
+    }
+
+
+def _register(**kwargs) -> RegistrationResult:
+    defaults = dict(
+        response=_make_response(),
+        webauthn_state=STATE,
+        authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
+        rp_id="eduid.docker",
+        rp_name="eduID",
+        fido_mds=MagicMock(),
+        fido_metadata_log=MagicMock(),
+        app_name="testing",
+        is_backdoor=True,
+    )
+    defaults.update(kwargs)
+    return verify_webauthn_registration(**defaults)
+
+
+class TestVerifyWebauthnRegistration:
+    def test_keyhandle_is_base64url_not_hex(self) -> None:
+        """Regression: keyhandle must be base64url, not hex of credential_id."""
+        result = _register()
+
+        assert result.keyhandle == CREDENTIAL_ID_B64URL
+        assert result.keyhandle != CREDENTIAL_ID_HEX
+
+    def test_keyhandle_round_trips_to_credential_id_bytes(self) -> None:
+        result = _register()
+
+        decoded = websafe_decode(result.keyhandle)
+        assert decoded == bytes.fromhex(CREDENTIAL_ID_HEX)
+        assert websafe_encode(decoded) == result.keyhandle
+
+    def test_credential_key_differs_from_hex_keyhandle(self) -> None:
+        """Webauthn.key depends on keyhandle — hex vs base64url produces different keys."""
+        result = _register()
+
+        correct_credential = Webauthn(
+            keyhandle=result.keyhandle,
+            credential_data=result.credential_data,
+            app_id="eduid.docker",
+            created_by="testing",
+            authenticator=result.authenticator,
+        )
+        broken_credential = Webauthn(
+            keyhandle=CREDENTIAL_ID_HEX,
+            credential_data=result.credential_data,
+            app_id="eduid.docker",
+            created_by="testing",
+            authenticator=result.authenticator,
+        )
+
+        assert correct_credential.key != broken_credential.key
+
+    def test_credential_data_unpacks_to_matching_credential_id(self) -> None:
+        """Stored credential_data contains the same credential_id as the keyhandle."""
+        result = _register()
+
+        decoded = base64.urlsafe_b64decode(result.credential_data.encode("ascii"))
+        cred_data, rest = AttestedCredentialData.unpack_from(decoded)
+        assert not rest
+        assert websafe_encode(cred_data.credential_id) == result.keyhandle
+
+    def test_registration_result_fields(self) -> None:
+        result = _register()
+
+        assert isinstance(result, RegistrationResult)
+        assert result.authenticator == AuthenticatorAttachment.CROSS_PLATFORM
+        assert result.authenticator_info is not None
+        assert result.authenticator_info.user_present is True
+        assert result.mfa_approved is False
+        assert result.is_discoverable is False
+
+    def test_discoverable_credential_from_credprops(self) -> None:
+        result = _register(
+            authenticator=AuthenticatorAttachment.PLATFORM,
+            client_extension_results={"credProps": {"rk": True}},
+        )
+
+        assert result.is_discoverable is True
+
+    def test_non_discoverable_without_credprops(self) -> None:
+        result = _register()
+        assert result.is_discoverable is False
+
+    def test_credprops_without_rk(self) -> None:
+        result = _register(client_extension_results={"credProps": {}})
+        assert result.is_discoverable is False
+
+    def test_credprops_rk_false(self) -> None:
+        result = _register(client_extension_results={"credProps": {"rk": False}})
+        assert result.is_discoverable is False
+
+    def test_invalid_attestation_raises(self) -> None:
+        bad_response = _make_response()
+        bad_response["response"]["attestationObject"] = "aW52YWxpZA"
+
+        with pytest.raises((RegistrationError, ValueError)):
+            _register(response=bad_response)
+
+    def test_wrong_challenge_raises_registration_error(self) -> None:
+        wrong_state = {
+            "challenge": "WRONG_CHALLENGE_aaaaaaaaaaaaaaaaaaaaaaaaa",
+            "user_verification": "discouraged",
+        }
+
+        with pytest.raises(RegistrationError, match="registration completion failed"):
+            _register(webauthn_state=wrong_state)
+
+    def test_wrong_rp_id_raises_registration_error(self) -> None:
+        with pytest.raises(RegistrationError, match="registration completion failed"):
+            _register(rp_id="wrong.rp.id")
+
+    def test_credential_lookup_matches_raw_id(self) -> None:
+        """Credential stored via registration can be found by raw credential_id bytes (as fido_tokens.py does)."""
+        result = _register()
+
+        credential = Webauthn(
+            keyhandle=result.keyhandle,
+            credential_data=result.credential_data,
+            app_id="eduid.docker",
+            created_by="testing",
+            authenticator=result.authenticator,
+        )
+
+        cred_data_bytes = base64.urlsafe_b64decode(credential.credential_data.encode("ascii"))
+        unpacked, _ = AttestedCredentialData.unpack_from(cred_data_bytes)
+
+        raw_id = websafe_decode(result.keyhandle)
+        assert unpacked.credential_id == raw_id

--- a/src/eduid/webapp/common/authn/tests/test_webauthn.py
+++ b/src/eduid/webapp/common/authn/tests/test_webauthn.py
@@ -6,6 +6,7 @@ Webauthn.key = sha256(keyhandle + credential_data).
 """
 
 import base64
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -56,7 +57,7 @@ CREDENTIAL_ID_HEX = (
 )
 
 
-def _make_response(credential_id: str = CREDENTIAL_ID_B64URL) -> dict:
+def _make_response(credential_id: str = CREDENTIAL_ID_B64URL) -> dict[str, Any]:
     return {
         "credentialId": credential_id,
         "rawId": credential_id,
@@ -67,18 +68,18 @@ def _make_response(credential_id: str = CREDENTIAL_ID_B64URL) -> dict:
     }
 
 
-def _register(**kwargs) -> RegistrationResult:
-    defaults = dict(
-        response=_make_response(),
-        webauthn_state=STATE,
-        authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
-        rp_id="eduid.docker",
-        rp_name="eduID",
-        fido_mds=MagicMock(),
-        fido_metadata_log=MagicMock(),
-        app_name="testing",
-        is_backdoor=True,
-    )
+def _register(**kwargs: Any) -> RegistrationResult:
+    defaults: dict[str, Any] = {
+        "response": _make_response(),
+        "webauthn_state": STATE,
+        "authenticator": AuthenticatorAttachment.CROSS_PLATFORM,
+        "rp_id": "eduid.docker",
+        "rp_name": "eduID",
+        "fido_mds": MagicMock(),
+        "fido_metadata_log": MagicMock(),
+        "app_name": "testing",
+        "is_backdoor": True,
+    }
     defaults.update(kwargs)
     return verify_webauthn_registration(**defaults)
 

--- a/src/eduid/webapp/common/authn/webauthn.py
+++ b/src/eduid/webapp/common/authn/webauthn.py
@@ -328,7 +328,7 @@ def verify_webauthn_registration(
 
     return RegistrationResult(
         credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
-        keyhandle=auth_data.credential_data.credential_id.hex(),
+        keyhandle=registration.id,
         authenticator=authenticator,
         authenticator_info=authenticator_info,
         mfa_approved=mfa_approved,

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -193,6 +193,7 @@ class Signup(TimestampedNS):
     captcha: Captcha = Field(default_factory=Captcha)
     credentials: Credentials = Field(default_factory=Credentials)
     idp_request_ref: RequestRef | None = None
+    idp_service_info: dict[str, dict[str, str]] | None = None
 
 
 class Phone(SessionNSBase):

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from datetime import datetime
 from enum import StrEnum, unique
 from typing import Any, NewType, Self, cast
+from uuid import UUID
 
 from fido2.webauthn import AuthenticatorAttachment
 from fido_mds.models.webauthn import AttestationFormat
@@ -160,9 +161,9 @@ class WebauthnCredential(BaseModel):
     credential_data: str  # base64 AttestedCredentialData
     keyhandle: str
     authenticator: AuthenticatorAttachment
-    authenticator_id: str | None = None
+    authenticator_id: UUID | str
     mfa_approved: bool = False
-    attestation_format: AttestationFormat | None = None
+    attestation_format: AttestationFormat
     description: str = ""
     # attestation flags for proofing log
     user_present: bool = True

--- a/src/eduid/webapp/idp/views/signup_auth.py
+++ b/src/eduid/webapp/idp/views/signup_auth.py
@@ -105,7 +105,8 @@ def signup_auth(ticket: LoginContext, sso_session: SSOSession | None) -> FluxDat
 def _register_signup_credentials(ticket: LoginContext, user: IdPUser) -> list[AuthnData]:
     """Register the user's signup credentials on the pending request and return AuthnData for the SSO session."""
     authn_credentials: list[AuthnData] = []
-    assert session.signup.user_created_at is not None  # checked by caller
+    if session.signup.user_created_at is None:  # checked by caller
+        raise RuntimeError(f"No user_created_at in signup session")
 
     for cred in user.credentials.to_list():
         fido_data = None

--- a/src/eduid/webapp/idp/views/signup_auth.py
+++ b/src/eduid/webapp/idp/views/signup_auth.py
@@ -106,7 +106,7 @@ def _register_signup_credentials(ticket: LoginContext, user: IdPUser) -> list[Au
     """Register the user's signup credentials on the pending request and return AuthnData for the SSO session."""
     authn_credentials: list[AuthnData] = []
     if session.signup.user_created_at is None:  # checked by caller
-        raise RuntimeError(f"No user_created_at in signup session")
+        raise RuntimeError("No user_created_at in signup session")
 
     for cred in user.credentials.to_list():
         fido_data = None

--- a/src/eduid/webapp/security/tests/test_webauthn.py
+++ b/src/eduid/webapp/security/tests/test_webauthn.py
@@ -80,10 +80,7 @@ CLIENT_DATA_JSON = (
     b"Y2tlciIsImNyb3NzT3JpZ2luIjpmYWxzZX0"
 )
 
-CREDENTIAL_ID = (
-    "31f8974379e65869f9b7caaf28f0e44eead0fdd883e9c545404e351824a6c4cea738613e4ef5b9"
-    "d699fbc4d6bab05117a13cc81875b732e00058027155ced047"
-)
+CREDENTIAL_ID = "vJTDXjICQ2Trzh7rPu_EiPGL0dx1VML9jUdz3H7wZ3aWm8PlIkEI8eDfk5SWXBiRX4c80PaAJ5L2YXMBhk3bSw"
 
 # CTAP2 security key
 STATE_2 = {"challenge": "yxHWG+ouoa8MLGSxOJJhM0NtiH5ubK3BPfx+6uE3QkU=", "user_verification": "required"}
@@ -108,10 +105,7 @@ eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoieXhIV0ctb3VvYThNTEdTeE9KSmhN
 biI6Imh0dHBzOi8vaHRtbC5lZHVpZC5kb2NrZXIiLCJjcm9zc09yaWdpbiI6ZmFsc2V9
 """
 
-CREDENTIAL_ID_2 = (
-    "7bad3b59fa16e9e8840e2fd15c026a3c9a7d2877fd7d97c25a3b3158d1a9cba1e14b7c9913915"
-    "f912366c18bd06bc9e903bc779409a8a7c749511e2b44e54c88"
-)
+CREDENTIAL_ID_2 = "5daF3O2VpnZWJkYXKHuYbY8eg_pgUcRpMp96P8QkH6tBawr3hJhB5BvWJnzsYDO-0kK0XxvaN4x7mX6RAS2cKA"
 
 
 class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
@@ -164,10 +158,9 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
         auth_data = server.register_complete(state=state, response=registration)
         cred_data = auth_data.credential_data
         assert cred_data is not None  # please mypy
-        cred_id = cred_data.credential_id
 
         credential = Webauthn(
-            keyhandle=cred_id.hex(),
+            keyhandle=registration.id,
             credential_data=base64.urlsafe_b64encode(cred_data).decode("ascii"),
             app_id=self.app.conf.fido2_rp_id,
             description="ctap1 token",
@@ -336,8 +329,8 @@ class SecurityWebauthnTests(EduidAPITestCase[SecurityApp]):
                     data = {
                         "csrf_token": csrf_token,
                         "response": {
-                            "credentialId": CREDENTIAL_ID,
-                            "rawId": CREDENTIAL_ID,
+                            "credentialId": cred_id,
+                            "rawId": cred_id,
                             "response": {
                                 "attestationObject": attestation.decode(),
                                 "clientDataJSON": client_data.decode(),

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -8,6 +8,7 @@ from eduid.webapp.common.api.schemas.email import LowercaseEmail
 from eduid.webapp.common.api.schemas.validators import validate_email
 from eduid.webapp.common.api.utils import time_left
 from eduid.webapp.common.session import session
+from eduid.webapp.common.session.namespaces import EmailVerification
 from eduid.webapp.signup.app import current_signup_app as current_app
 
 __author__ = "lundberg"
@@ -52,6 +53,13 @@ class SignupStatusResponse(FluxStandardAction):
                 webauthn_is_discoverable = fields.Boolean(required=True, dump_default=False)
                 webauthn_description = fields.String(required=True, dump_default=None)
 
+            class ServiceInfo(EduidSchema):
+                class DisplayName(EduidSchema):
+                    en = fields.String(required=False)
+                    sv = fields.String(required=False)
+
+                display_name = fields.Nested(DisplayName, required=False)
+
             already_signed_up = fields.Boolean(required=True)
             name = fields.Nested(Name, required=True)
             email = fields.Nested(EmailVerification, required=True)
@@ -61,7 +69,7 @@ class SignupStatusResponse(FluxStandardAction):
             credentials = fields.Nested(Credentials, required=True)
             user_created = fields.Boolean(required=True)
             idp_request_ref = fields.String(required=False, load_default=None)
-            idp_service_info = fields.String(required=False, load_default=None)
+            idp_service_info = fields.Nested(nested=ServiceInfo, required=False, load_default=None)
 
         state = fields.Nested(State, required=True)
 

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -61,6 +61,7 @@ class SignupStatusResponse(FluxStandardAction):
             credentials = fields.Nested(Credentials, required=True)
             user_created = fields.Boolean(required=True)
             idp_request_ref = fields.String(required=False, load_default=None)
+            idp_service_info = fields.String(required=False, load_default=None)
 
         state = fields.Nested(State, required=True)
 
@@ -186,3 +187,4 @@ class WebauthnRegisterCompleteRequest(EduidSchema, CSRFRequestMixin):
 
 class ReturnToAuthRequest(EduidSchema, CSRFRequestMixin):
     ref = fields.String(required=True)
+    service_info = fields.Dict(required=True)

--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -8,7 +8,6 @@ from eduid.webapp.common.api.schemas.email import LowercaseEmail
 from eduid.webapp.common.api.schemas.validators import validate_email
 from eduid.webapp.common.api.utils import time_left
 from eduid.webapp.common.session import session
-from eduid.webapp.common.session.namespaces import EmailVerification
 from eduid.webapp.signup.app import current_signup_app as current_app
 
 __author__ = "lundberg"

--- a/src/eduid/webapp/signup/tests/test_app.py
+++ b/src/eduid/webapp/signup/tests/test_app.py
@@ -874,6 +874,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
             "tou": {"completed": False, "version": "2016-v1"},
             "user_created": False,
             "idp_request_ref": None,
+            "idp_service_info": None,
         }, f"actual state is {state}"
 
     def test_get_state_initial_logged_in(self) -> None:
@@ -897,6 +898,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
             "tou": {"completed": False, "version": "2016-v1"},
             "user_created": False,
             "idp_request_ref": None,
+            "idp_service_info": None,
         }, f"actual state is {state}"
 
     def test_accept_tou(self) -> None:
@@ -1480,6 +1482,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
             "tou": {"completed": False, "version": "2016-v1"},
             "user_created": False,
             "idp_request_ref": None,
+            "idp_service_info": None,
         }, f"Actual state {normalised_data(state, exclude_keys=['expires_time_left', 'throttle_time_left', 'sent_at'])}"
 
     def test_complete_invite_new_user(self) -> None:
@@ -1619,6 +1622,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
                     )
                     data = {
                         "ref": "test-ref",
+                        "service_info": {"display_name": {"sv": "eduID Sverige"}},
                         "csrf_token": sess.get_csrf_token(),
                     }
 
@@ -1631,6 +1635,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
         )
         payload = self.get_response_payload(response)
         assert payload["state"]["idp_request_ref"] == "test-ref"
+        assert payload["state"]["idp_service_info"] == {"display_name": {"sv": "eduID Sverige"}}
 
     def test_return_to_auth_invalid_ref(self) -> None:
         """Call with a ref that doesn't exist in pending_requests."""
@@ -1640,6 +1645,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
                 with client.session_transaction() as sess:
                     data = {
                         "ref": "nonexistent-ref",
+                        "service_info": {"display_name": {"sv": "eduID Sverige"}},
                         "csrf_token": sess.get_csrf_token(),
                     }
 
@@ -1668,6 +1674,7 @@ class SignupTests(EduidAPITestCase[SignupApp], MockedScimAPIMixin):
                     )
                     data = {
                         "ref": "test-ref",
+                        "service_info": {"display_name": {"sv": "eduID Sverige"}},
                         "csrf_token": sess.get_csrf_token(),
                     }
 

--- a/src/eduid/webapp/signup/tests/test_webauthn.py
+++ b/src/eduid/webapp/signup/tests/test_webauthn.py
@@ -50,10 +50,7 @@ CLIENT_DATA_JSON = (
     b"Y2tlciIsImNyb3NzT3JpZ2luIjpmYWxzZX0"
 )
 
-CREDENTIAL_ID = (
-    "31f8974379e65869f9b7caaf28f0e44eead0fdd883e9c545404e351824a6c4cea738613e4ef5b9"
-    "d699fbc4d6bab05117a13cc81875b732e00058027155ced047"
-)
+CREDENTIAL_ID = "vJTDXjICQ2Trzh7rPu_EiPGL0dx1VML9jUdz3H7wZ3aWm8PlIkEI8eDfk5SWXBiRX4c80PaAJ5L2YXMBhk3bSw"
 
 
 class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
@@ -201,7 +198,7 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
             with client.session_transaction() as sess:
                 sess.signup.credentials.webauthn = WebauthnCredential(
                     credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
-                    keyhandle=auth_data.credential_data.credential_id.hex(),
+                    keyhandle=registration.id,
                     attestation_format=AttestationFormat.NONE,
                     authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
                     authenticator_id="test-authenticator-id",
@@ -498,7 +495,7 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
             with client.session_transaction() as sess:
                 sess.signup.credentials.webauthn = WebauthnCredential(
                     credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
-                    keyhandle=auth_data.credential_data.credential_id.hex(),
+                    keyhandle=registration.id,
                     attestation_format=AttestationFormat.PACKED,
                     authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
                     authenticator_id="test-authenticator-id",

--- a/src/eduid/webapp/signup/tests/test_webauthn.py
+++ b/src/eduid/webapp/signup/tests/test_webauthn.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 from fido2.webauthn import AuthenticatorAttachment, RegistrationResponse
+from fido_mds.models.webauthn import AttestationFormat
 from jwcrypto.jwk import JWK
 from pytest_mock import MockerFixture
 from werkzeug.test import TestResponse
@@ -201,6 +202,7 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
                 sess.signup.credentials.webauthn = WebauthnCredential(
                     credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
                     keyhandle=auth_data.credential_data.credential_id.hex(),
+                    attestation_format=AttestationFormat.NONE,
                     authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
                     authenticator_id="test-authenticator-id",
                     description="test security key",
@@ -497,6 +499,7 @@ class SignupWebauthnTests(EduidAPITestCase[SignupApp]):
                 sess.signup.credentials.webauthn = WebauthnCredential(
                     credential_data=base64.urlsafe_b64encode(auth_data.credential_data).decode("ascii"),
                     keyhandle=auth_data.credential_data.credential_id.hex(),
+                    attestation_format=AttestationFormat.PACKED,
                     authenticator=AuthenticatorAttachment.CROSS_PLATFORM,
                     authenticator_id="test-authenticator-id",
                     mfa_approved=True,

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -312,7 +312,7 @@ def webauthn_register_begin(authenticator: str) -> FluxData:
         return error_response(message=SignupMsg.name_not_set)
     user_entity = PublicKeyCredentialUserEntity(
         id=bytes(eppn, "utf-8"),
-        name=eppn,
+        name=f"{session.signup.name.given_name} {session.signup.name.surname}",
         display_name=f"{session.signup.name.given_name} {session.signup.name.surname}",
     )
     registration_data, state = server.register_begin(

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -401,7 +401,7 @@ def webauthn_register_complete(
 @UnmarshalWith(ReturnToAuthRequest)
 @MarshalWith(SignupStatusResponse)
 @require_not_logged_in
-def return_to_auth(ref: str) -> FluxData:
+def return_to_auth(ref: str, service_info: dict[str, dict[str, str]]) -> FluxData:
     """Store a reference to a pending IdP SAML request for resumption after signup."""
     current_app.logger.info("Setting IdP request ref for post-signup auth resumption")
 
@@ -415,6 +415,7 @@ def return_to_auth(ref: str) -> FluxData:
         return error_response(message=SignupMsg.idp_request_ref_not_found)
 
     session.signup.idp_request_ref = request_ref
+    session.signup.idp_service_info = service_info
     current_app.logger.info(f"Stored idp_request_ref: {request_ref}")
     return success_response(payload={"state": session.signup.to_dict()})
 

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -2,7 +2,6 @@ from typing import Any
 from uuid import uuid4
 
 from fido2.webauthn import AuthenticatorAttachment, PublicKeyCredentialUserEntity
-from fido_mds.models.webauthn import AttestationFormat
 from flask import Blueprint, abort, request
 
 from eduid.common.misc.timeutil import utc_now
@@ -384,6 +383,7 @@ def webauthn_register_complete(
         key_protection=result.authenticator_info.key_protection,
         is_discoverable=result.is_discoverable,
     )
+    current_app.logger.debug(f"stored webauthn credential: {session.signup.credentials.webauthn}")
     session.signup.credentials.completed = True
 
     current_app.logger.info("WebAuthn registration completed")
@@ -514,6 +514,8 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
             webauthn_proofing_version=current_app.conf.webauthn_proofing_version,
             attestation_format=wn.attestation_format,
         )
+        current_app.logger.debug(f"Created webauthn credential: {webauthn_credential}")
+
         webauthn_authenticator_info = AuthenticatorInformation(
             authenticator_id=wn.authenticator_id,
             attestation_format=wn.attestation_format,

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -328,7 +328,8 @@ def webauthn_register_begin(authenticator: str) -> FluxData:
     )
 
     current_app.logger.info("WebAuthn registration begun")
-    current_app.stats.count(name="webauthn_register_begin")
+    if not check_magic_cookie(current_app.conf):  # no stats for automatic tests
+        current_app.stats.count(name="webauthn_register_begin")
 
     return success_response(
         payload={"csrf_token": session.new_csrf_token(), "registration_data": dict(registration_data)}
@@ -386,11 +387,12 @@ def webauthn_register_complete(
     session.signup.credentials.completed = True
 
     current_app.logger.info("WebAuthn registration completed")
-    current_app.stats.count(name="webauthn_register_complete")
-    if result.mfa_approved:
-        current_app.stats.count(name="webauthn_mfa_approved")
-    if result.is_discoverable:
-        current_app.stats.count(name="webauthn_is_discoverable")
+    if not check_magic_cookie(current_app.conf):
+        current_app.stats.count(name="webauthn_register_complete")
+        if result.mfa_approved:
+            current_app.stats.count(name="webauthn_mfa_approved")
+        if result.is_discoverable:
+            current_app.stats.count(name="webauthn_is_discoverable")
 
     return success_response(payload={"state": session.signup.to_dict()})
 

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -513,8 +513,8 @@ def create_user(use_suggested_password: bool, use_webauthn: bool, custom_passwor
             attestation_format=wn.attestation_format,
         )
         webauthn_authenticator_info = AuthenticatorInformation(
-            authenticator_id=wn.authenticator_id or "",
-            attestation_format=wn.attestation_format or AttestationFormat.NONE,
+            authenticator_id=wn.authenticator_id,
+            attestation_format=wn.attestation_format,
             user_present=wn.user_present,
             user_verified=wn.user_verified,
             user_verification_methods=wn.user_verification_methods,

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -374,7 +374,7 @@ def webauthn_register_complete(
         credential_data=result.credential_data,
         keyhandle=result.keyhandle,
         authenticator=result.authenticator,
-        authenticator_id=str(result.authenticator_info.authenticator_id),
+        authenticator_id=result.authenticator_info.authenticator_id,
         mfa_approved=result.mfa_approved,
         attestation_format=result.authenticator_info.attestation_format,
         description=description,

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -351,6 +351,7 @@ def webauthn_register_complete(
     reg_state = session.signup.credentials.webauthn_registration
     session.signup.credentials.webauthn_registration = None
 
+    is_backdoor = check_magic_cookie(current_app.conf)
     try:
         result = verify_webauthn_registration(
             response=response,
@@ -361,7 +362,7 @@ def webauthn_register_complete(
             fido_mds=current_app.fido_mds,
             fido_metadata_log=current_app.fido_metadata_log,
             app_name=current_app.conf.app_name,
-            is_backdoor=check_magic_cookie(current_app.conf),
+            is_backdoor=is_backdoor,
             disallowed_status=current_app.conf.webauthn_disallowed_status,
             client_extension_results=client_extension_results,
         )
@@ -387,7 +388,7 @@ def webauthn_register_complete(
     session.signup.credentials.completed = True
 
     current_app.logger.info("WebAuthn registration completed")
-    if not check_magic_cookie(current_app.conf):
+    if not is_backdoor:
         current_app.stats.count(name="webauthn_register_complete")
         if result.mfa_approved:
             current_app.stats.count(name="webauthn_mfa_approved")


### PR DESCRIPTION
  ## Summary                                  
                                                                                                                                              
  - Fix WebAuthn credential registration in signup to match the security webapp: correct `PublicKeyCredentialUserEntity` creation, use        
  `registration.id` as keyhandle (base64url, not hex), and make `authenticator_id`/`attestation_format` non-optional in session namespace
  - Add `service_info` when signup hands off to the auth/IdP flow, fixing missing context on login continuation                               
  - Add shared regression tests for `verify_webauthn_registration` covering keyhandle format correctness                                      
                                                                                                                                              
  ## Changes                                                                                                                                  
                                                                                                                                              
  **Signup webapp**                           
  - `views.py` — align WebAuthn registration with security webapp (PublicKeyCredentialUserEntity, authenticator_id, backdoor reuse)
  - `schemas.py` — add `ServiceInfo` schema for auth handoff                                                                                  
  - `namespaces.py` — `authenticator_id` and `attestation_format` no longer optional                                                          
                                                                                                                                              
  **IdP**                                                                                                                                     
  - `signup_auth.py` — pass `service_info` when continuing signup to auth                                                                     
                                              
  **Tests**                                                                                                                                   
  - New shared `test_webauthn.py` — regression tests for keyhandle format (base64url vs hex)
  - Fix existing security and signup test helpers to use base64url credential IDs matching production                                         
                                                                                                                                              
  **Other**                                                                                                                                   
  - Minor reformats in `maccapi`, `scimapi` routers (no functional changes)       