### PR TITLE
Drop trivial mypy-narrowing asserts across small webapp clusters

### DIFF
--- a/src/eduid/satosa/scimapi/stepup.py
+++ b/src/eduid/satosa/scimapi/stepup.py
@@ -536,7 +536,8 @@ class AuthnContext(RequestMicroService):  # type: ignore[misc]
         context: satosa.context.Context,
         data: satosa.internal.InternalData,
     ) -> ProcessReturnType:
-        assert context.state is not None  # please type checking
+        if context.state is None:
+            raise RuntimeError("satosa context.state not set")
         loa_settings = get_loa_settings_for_entity_id(
             EntityId(data.requester), [context.internal_data.get(Context.KEY_METADATA_STORE)], self.mfa
         )

--- a/src/eduid/userdb/db/base.py
+++ b/src/eduid/userdb/db/base.py
@@ -49,7 +49,8 @@ class BaseMongoDB:
             del kwargs["replicaSet"]
 
         _options = self._parsed_uri.get("options")
-        assert _options is not None  # please mypy
+        if _options is None:
+            raise RuntimeError("parsed mongo URI has no options dict")
 
         if "replicaSet" in _options and _options["replicaSet"] is not None:
             kwargs["replicaSet"] = _options["replicaSet"]

--- a/src/eduid/webapp/bankid/views.py
+++ b/src/eduid/webapp/bankid/views.py
@@ -176,9 +176,8 @@ def _authn(
 
     proofing_method = get_proofing_method(method, _frontend_action, current_app.conf)
     current_app.logger.debug(f"Proofing method: {proofing_method}")
-    if not proofing_method:
+    if not isinstance(proofing_method, ProofingMethodSAML):
         return AuthnResult(error=BankIDMsg.method_not_available)
-    assert isinstance(proofing_method, ProofingMethodSAML)  # please mypy
 
     idp = proofing_method.idp
 
@@ -282,7 +281,8 @@ def assertion_consumer_service() -> WerkzeugResponse:
     formatted_finish_url = proofing_method.formatted_finish_url(
         app_name=current_app.conf.app_name, authn_id=assertion.authn_req_ref
     )
-    assert formatted_finish_url  # please type checking
+    if formatted_finish_url is None:
+        raise RuntimeError("formatted_finish_url is None — finish_url config likely empty")
 
     # assertion checks out try to do the action
     action = get_action(default_action=None, authndata=assertion.authn_data)

--- a/src/eduid/webapp/common/api/checks.py
+++ b/src/eduid/webapp/common/api/checks.py
@@ -113,7 +113,8 @@ def check_mongo() -> bool:
 def check_redis() -> bool:
     current_app = get_current_app()
     _conf = current_app.conf
-    assert isinstance(_conf, RedisConfigMixin)
+    if not isinstance(_conf, RedisConfigMixin):
+        raise RuntimeError(f"app.conf does not implement RedisConfigMixin: {type(_conf).__name__}")
     pool = get_redis_pool(_conf.redis_config)
     client = redis.StrictRedis(connection_pool=pool)
     try:

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -128,8 +128,8 @@ def verify_nin_for_user(
     if proofing_user.identities.nin is None:
         proofing_user = add_nin_to_user(user=proofing_user, proofing_state=proofing_state)
 
-    # please mypy
-    assert proofing_user.identities.nin is not None
+    if proofing_user.identities.nin is None:
+        raise RuntimeError("proofing_user.identities.nin not set after add_nin_to_user")
 
     # Check if the NIN is already verified
     if proofing_user.identities.nin.is_verified:
@@ -241,8 +241,8 @@ def get_proofing_log_navet_data(nin: str) -> ProofingNavetData:
         navet_data.person.is_deregistered()
         and navet_data.person.deregistration_information.cause_code is not DeregisteredCauseCode.EMIGRATED
     ):
-        # please type checking
-        assert navet_data.person.deregistration_information.cause_code is not None
+        if navet_data.person.deregistration_information.cause_code is None:
+            raise RuntimeError("deregistration cause_code missing for deregistered person")
         raise NoNavetData(
             f"Person deregistered with code {navet_data.person.deregistration_information.cause_code.value}"
         )

--- a/src/eduid/webapp/common/api/translation.py
+++ b/src/eduid/webapp/common/api/translation.py
@@ -11,7 +11,8 @@ __author__ = "lundberg"
 
 def get_user_locale() -> str | None:
     app = current_app
-    assert isinstance(app, EduIDBaseApp)
+    if not isinstance(app, EduIDBaseApp):
+        raise RuntimeError(f"unexpected current_app type: {type(app).__name__}")
     lang: str | None  # mypy 0.910 needs this
     # if a user is logged in, use the locale from the user settings
     if session.common.preferred_language is not None:

--- a/src/eduid/webapp/eidas/views.py
+++ b/src/eduid/webapp/eidas/views.py
@@ -180,9 +180,8 @@ def _authn(
 
     proofing_method = get_proofing_method(method, _frontend_action, current_app.conf)
     current_app.logger.debug(f"Proofing method: {proofing_method}")
-    if not proofing_method:
+    if not isinstance(proofing_method, ProofingMethodSAML):
         return AuthnResult(error=EidasMsg.method_not_available)
-    assert isinstance(proofing_method, ProofingMethodSAML)  # please mypy
 
     idp = proofing_method.idp
     if check_magic_cookie(current_app.conf):
@@ -313,7 +312,8 @@ def assertion_consumer_service() -> WerkzeugResponse:
     formatted_finish_url = proofing_method.formatted_finish_url(
         app_name=current_app.conf.app_name, authn_id=assertion.authn_req_ref
     )
-    assert formatted_finish_url  # please type checking
+    if formatted_finish_url is None:
+        raise RuntimeError("formatted_finish_url is None — finish_url config likely empty")
 
     if not result.success:
         current_app.logger.info(f"SAML ACS action failed: {result.message}")

--- a/src/eduid/webapp/email/verifications.py
+++ b/src/eduid/webapp/email/verifications.py
@@ -40,7 +40,8 @@ def send_verification_code(email: str, user: User) -> bool:
     if state is None:
         return False
 
-    assert state.verification.verification_code  # please mypy
+    if state.verification.verification_code is None:
+        raise RuntimeError("verification_code not set on freshly created proofing state")
     payload = EduidVerificationEmail(
         email=email,
         verification_code=state.verification.verification_code,
@@ -83,8 +84,8 @@ def verify_mail_address(state: EmailProofingState, proofing_user: ProofingUser) 
         # Adding the phone to the list creates a copy of the element, so we have to 'find' it again
         email = proofing_user.mail_addresses.find(state.verification.email)
 
-    # please mypy, email should be set now
-    assert email
+    if email is None:
+        raise RuntimeError("mail address not found after add")
 
     email.is_verified = True
     if not proofing_user.mail_addresses.primary:

--- a/src/eduid/webapp/ladok/client.py
+++ b/src/eduid/webapp/ladok/client.py
@@ -114,7 +114,8 @@ class LadokClient:
         if universities_response.error is not None:
             logger.error(f"endpoint {endpoint} returned error: {universities_response.error}")
             raise LadokClientException("could not load universities")
-        assert universities_response.data is not None  # please mypy
+        if universities_response.data is None:
+            raise LadokClientException("universities response had no data and no error")
         return universities_response.data
 
     def get_user_info(self, ladok_name: str, nin: str) -> LadokUserInfo | None:

--- a/src/eduid/webapp/ladok/helpers.py
+++ b/src/eduid/webapp/ladok/helpers.py
@@ -45,7 +45,8 @@ def link_user_backdoor(user: User, ladok_name: str) -> FluxData:
     )
 
     proofing_user.ladok = ladok_data
-    assert proofing_user.identities.nin is not None  # please mypy
+    if proofing_user.identities.nin is None:
+        raise RuntimeError("proofing_user.identities.nin not set when expected for ladok proofing")
     proofing_log_entry = LadokProofing(
         eppn=proofing_user.eppn,
         nin=proofing_user.identities.nin.number,

--- a/src/eduid/webapp/ladok/views.py
+++ b/src/eduid/webapp/ladok/views.py
@@ -69,7 +69,8 @@ def link_user(user: User, ladok_name: str) -> FluxData:
         verified_by="eduid-ladok",
     )
     proofing_user.ladok = ladok_data
-    assert proofing_user.identities.nin is not None  # please mypy
+    if proofing_user.identities.nin is None:
+        raise RuntimeError("proofing_user.identities.nin not set when expected for ladok view")
     proofing_log_entry = LadokProofing(
         eppn=proofing_user.eppn,
         nin=proofing_user.identities.nin.number,

--- a/src/eduid/webapp/phone/verifications.py
+++ b/src/eduid/webapp/phone/verifications.py
@@ -72,7 +72,8 @@ def verify_phone_number(state: PhoneProofingState, proofing_user: ProofingUser) 
         proofing_user.phone_numbers.add(phone)
         # Adding the phone to the list creates a copy of the element, so we have to 'find' it again
         phone = proofing_user.phone_numbers.find(phone.key)
-        assert phone is not None  # ensure mypy
+        if phone is None:
+            raise RuntimeError("phone number not found after add")
 
     phone.is_verified = True
     if not proofing_user.phone_numbers.primary:

--- a/src/eduid/webapp/samleid/views.py
+++ b/src/eduid/webapp/samleid/views.py
@@ -182,9 +182,8 @@ def _authn(
 
     proofing_method = get_proofing_method(method, _frontend_action, current_app.conf)
     current_app.logger.debug(f"Proofing method: {proofing_method}")
-    if not proofing_method:
+    if not isinstance(proofing_method, ProofingMethodSAML):
         return AuthnResult(error=SamlEidMsg.method_not_available)
-    assert isinstance(proofing_method, ProofingMethodSAML)  # please mypy
 
     idp = proofing_method.idp
     if check_magic_cookie(current_app.conf):
@@ -330,7 +329,8 @@ def assertion_consumer_service() -> WerkzeugResponse:
     formatted_finish_url = proofing_method.formatted_finish_url(
         app_name=current_app.conf.app_name, authn_id=assertion.authn_req_ref
     )
-    assert formatted_finish_url  # please type checking
+    if formatted_finish_url is None:
+        raise RuntimeError("formatted_finish_url is None — finish_url config likely empty")
 
     if not result.success:
         current_app.logger.info(f"SAML ACS action failed: {result.message}")

--- a/src/eduid/webapp/security/views/change_password.py
+++ b/src/eduid/webapp/security/views/change_password.py
@@ -60,7 +60,8 @@ def change_password_view(user: User, new_password: str, old_password: str | None
         return _need_reauthn
 
     authn, _ = get_authn_for_action(config=current_app.conf, frontend_action=frontend_action)
-    assert authn is not None  # please mypy (if authn was None we would have returned with _need_reauthn above)
+    if authn is None:
+        raise RuntimeError("expected authn after _need_reauthn check for change-password")
     current_app.logger.debug(f"change_password called with authn {authn}")
 
     if not new_password or (current_app.conf.chpass_old_password_needed and not old_password):

--- a/src/eduid/webapp/security/views/security.py
+++ b/src/eduid/webapp/security/views/security.py
@@ -78,7 +78,8 @@ def terminate_account(user: User) -> FluxData:
         return _need_reauthn
 
     authn, _ = get_authn_for_action(config=current_app.conf, frontend_action=frontend_action)
-    assert authn is not None  # please mypy (if authn was None we would have returned with _need_reauthn above)
+    if authn is None:
+        raise RuntimeError("expected authn after _need_reauthn check for terminate-account")
     current_app.logger.debug(f"terminate_account called with authn {authn}")
 
     security_user = SecurityUser.from_user(user, current_app.private_userdb)
@@ -189,7 +190,8 @@ def remove_identities(user: User, identity_type: str) -> FluxData:
         return _need_reauthn
 
     authn, _ = get_authn_for_action(config=current_app.conf, frontend_action=frontend_action)
-    assert authn is not None  # please mypy (if authn was None we would have returned with _need_reauthn above)
+    if authn is None:
+        raise RuntimeError("expected authn after _need_reauthn check for remove-identity")
 
     try:
         _type = IdentityType(identity_type)

--- a/src/eduid/webapp/security/views/webauthn.py
+++ b/src/eduid/webapp/security/views/webauthn.py
@@ -195,7 +195,8 @@ def remove(user: User, credential_key: str) -> FluxData:
         return _need_reauthn
 
     authn, _ = get_authn_for_action(config=current_app.conf, frontend_action=frontend_action)
-    assert authn is not None  # please mypy (if authn was None we would have returned with _need_reauthn above)
+    if authn is None:
+        raise RuntimeError("expected authn after _need_reauthn check for remove-security-key")
     current_app.logger.debug(f"remove security key called with authn {authn}")
 
     security_user = SecurityUser.from_user(user, current_app.private_userdb)

--- a/src/eduid/workers/job_runner/config.py
+++ b/src/eduid/workers/job_runner/config.py
@@ -37,7 +37,8 @@ class JobCronConfig(BaseModel):
     def at_least_one_datetime_value(cls, data: dict[str, Any]) -> dict[str, Any]:
         if isinstance(data, dict):
             need_one_of = ["year", "month", "day", "week", "day_of_week", "hour", "minute", "second"]
-            assert len(data.keys() & need_one_of), f"At least one of {need_one_of} must be set"
+            if not data.keys() & need_one_of:
+                raise ValueError(f"At least one of {need_one_of} must be set")
         return data
 
 

--- a/src/eduid/workers/job_runner/jobs/skv.py
+++ b/src/eduid/workers/job_runner/jobs/skv.py
@@ -45,7 +45,8 @@ def check_skv_users(context: Context) -> None:
 
     context.stats.count("skv_users_checked")
     context.logger.debug(f"Checking if user with eppn {user.eppn} should be terminated")
-    assert user.identities.nin is not None  # Please mypy
+    if user.identities.nin is None:
+        raise RuntimeError("user.identities.nin not set when expected for skv check")
     try:
         navet_data: NavetData = context.msg_relay.get_all_navet_data(
             nin=user.identities.nin.number, allow_deregistered=True
@@ -70,7 +71,8 @@ def check_user_deregistered(context: Context, user: CleanerQueueUser, navet_data
         return False
 
     cause = navet_data.person.deregistration_information.cause_code
-    assert cause is not None  # Please mypy
+    if cause is None:
+        raise RuntimeError("deregistration cause_code missing for deregistered person")
 
     if cause in context.config.skv.termination_cause_codes:
         context.logger.info(f"User with eppn {user.eppn} should be terminated, cause: {cause.value} ({cause.name})")
@@ -118,7 +120,8 @@ def check_user_official_name(context: Context, queue_user: CleanerQueueUser, nav
         official_address=navet_data.person.postal_addresses.official_address,
     )
 
-    assert user.identities.nin is not None  #  please mypy
+    if user.identities.nin is None:
+        raise RuntimeError("user.identities.nin not set when expected for skv check")
     # Create a proofing log entry
     proofing_log_entry = NameUpdateProofing(
         created_by="job_runner_skv",


### PR DESCRIPTION
# Drop trivial mypy-narrowing asserts across small webapp clusters

## Why

26 mypy-narrowing `assert` calls across small files were silent under
`python -O`. Replace each with an explicit runtime check.

Part of the ongoing S101 (`assert` outside tests) cleanup.
Drops global S101 count: **36 → 10**.

## Commits

1. **security/views (4)** — `authn is not None` after `check_reauthn`.
2. **ladok (3)** — `nin is not None`, `universities_response.data is not None`.
3. **email + phone verifications (3)** — `verification_code`, `email`/`phone` after add+find.
4. **trivial sweep (9)** — skv (3), api/helpers (2), api/translation, api/checks, userdb/db/base, satosa/stepup.
5. **pydantic validator (1)** — `assert ..., "msg"` → `raise ValueError(msg)` in `job_runner/config.py`.
6. **SAML views (6)** — bankid/eidas/samleid: `isinstance(proofing_method, ProofingMethodSAML)` (subsumes prior `if not proofing_method:` gate) and `formatted_finish_url` truthiness.

