### PR TITLE
Final S101 cleanup, enable rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ select = [
   "PL",
   "PT",
   "RUF",
+  "S101",
   "SIM",
   "UP",
   "W",
@@ -160,7 +161,10 @@ eduid = ["ndnkdf"]
 
 [tool.ruff.lint.per-file-ignores]
 "**/test_*.py" = ["PLR2004"] # magic-value-comparison - allow magic numbers in tests
-"**/test*.py" = ["SIM117"] # multiple-with-statements - combined session_transaction() calls break tests
+"**/test*.py" = [
+  "SIM117", # multiple-with-statements - combined session_transaction() calls break tests
+  "S101" # assert - assert statements are used in tests
+  ] 
 # "src/eduid/scimapi/**" = ["A001", "A002"] # builtin shadowing - filter is core concept of scim and builtin is not used
 "src/eduid/webapp/common/authn/vccs.py" = ["PLR2004"] # magic-value-comparison - allow magic numbers for password version
 

--- a/src/eduid/webapp/authn/views.py
+++ b/src/eduid/webapp/authn/views.py
@@ -37,7 +37,7 @@ from eduid.webapp.common.session import session
 from eduid.webapp.common.session.eduid_session import EduidSession
 from eduid.webapp.common.session.namespaces import AuthnRequestRef, SP_AuthnRequest
 
-assert acs_actions  # make sure nothing optimises away the import of this, as it is needed to execute @acs_actions
+_ = acs_actions  # keep import side-effect: registers @acs_action handlers
 
 authn_views = Blueprint("authn", __name__, url_prefix="")
 
@@ -75,7 +75,8 @@ def support_authenticate() -> WerkzeugResponse:
         finish_url=authn_params.finish_url,
     )
     result = _authn(sp_authn=sp_authn, idp=_get_idp(), authn_params=authn_params)
-    assert result.url is not None  # please mypy
+    if result.url is None:
+        raise RuntimeError("_authn returned no url")
     return redirect(location=result.url, code=302)
 
 
@@ -140,7 +141,8 @@ def _get_idp() -> str:
         raise RuntimeError("Unknown SAML2 idp config")
     # For now, we will only ever use the single configured IdP
     idp = next(iter(_configured_idps.keys()))
-    assert isinstance(idp, str)
+    if not isinstance(idp, str):
+        raise RuntimeError(f"unexpected idp key type: {type(idp).__name__}")
     return idp
 
 
@@ -208,7 +210,8 @@ def assertion_consumer_service() -> WerkzeugResponse:
     result = action(args)
     current_app.logger.debug(f"ACS action result: {result}")
 
-    assert isinstance(args.authn_req, SP_AuthnRequest)  # please mypy
+    if not isinstance(args.authn_req, SP_AuthnRequest):
+        raise RuntimeError(f"unexpected authn_req type: {type(args.authn_req).__name__}")
     formatted_finish_url = args.authn_req.formatted_finish_url(app_name=current_app.conf.app_name)
 
     if not result.success:

--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -408,7 +408,8 @@ class SessionFactory(SessionInterface):
         # avoid circular import
         from eduid.webapp.common.api.app import EduIDBaseApp
 
-        assert isinstance(app, EduIDBaseApp), "app is not an EduIDBaseApp"
+        if not isinstance(app, EduIDBaseApp):
+            raise RuntimeError(f"app is not an EduIDBaseApp: {type(app).__name__}")
         # Load token from cookie
         _conf = get_from_current_app("conf", EduIDBaseAppConfig)
         cookie_name = _conf.flask.session_cookie_name
@@ -464,8 +465,10 @@ class SessionFactory(SessionInterface):
         # avoid circular import
         from eduid.webapp.common.api.app import EduIDBaseApp
 
-        assert isinstance(app, EduIDBaseApp), "app is not an EduIDBaseApp"
-        assert isinstance(session, EduidSession), "session is not an EduidSession"
+        if not isinstance(app, EduIDBaseApp):
+            raise RuntimeError(f"app is not an EduIDBaseApp: {type(app).__name__}")
+        if not isinstance(session, EduidSession):
+            raise RuntimeError(f"session is not an EduidSession: {type(session).__name__}")
         if session is None:
             # Do not try to save the session and set the cookie if the session is not initialized
             # We have seen this happen...

--- a/src/eduid/webapp/idp/login.py
+++ b/src/eduid/webapp/idp/login.py
@@ -296,7 +296,8 @@ class SSO(Service):
         except AttributeError:
             current_app.logger.debug(f"Asserting AuthnContext {authn_info} (none requested)")
 
-        assert self.sso_session  # please mypy
+        if self.sso_session is None:
+            raise RuntimeError("sso_session not set when expected during login response")
         attributes = self.gather_attributes(response_authn=authn_info, resp_args=resp_args, user=user, ticket=ticket)
         missing_attributes = self.get_missing_attributes(ticket=ticket, attributes=attributes)
         saml_response = self._make_saml_response(

--- a/src/eduid/webapp/idp/logout.py
+++ b/src/eduid/webapp/idp/logout.py
@@ -136,7 +136,8 @@ class SLO(Service):
 
         try:
             req_info = current_app.IDP.parse_logout_request(request, binding)
-            assert isinstance(req_info, LogoutRequest)
+            if not isinstance(req_info, LogoutRequest):
+                raise RuntimeError(f"unexpected parse_logout_request type: {type(req_info).__name__}")
             current_app.logger.debug(f"Parsed Logout request ({binding}):\n{req_info.message}")
         except Exception as e:
             current_app.logger.exception("Failed parsing logout request")

--- a/src/eduid/webapp/idp/views/misc.py
+++ b/src/eduid/webapp/idp/views/misc.py
@@ -75,9 +75,7 @@ def logout(ref: str | None, sso_session: SSOSession | None) -> WerkzeugResponse:
         else:
             current_app.logger.debug(f"Will retain SAML request in session for entity ID {_entity_id}")
             if not isinstance(ticket.pending_request, IdP_SAMLPendingRequest):
-                raise RuntimeError(
-                    f"unexpected ticket.pending_request type: {type(ticket.pending_request).__name__}"
-                )
+                raise RuntimeError(f"unexpected ticket.pending_request type: {type(ticket.pending_request).__name__}")
             old_saml_req = ticket.pending_request
             _ref = ticket.request_ref
 

--- a/src/eduid/webapp/idp/views/misc.py
+++ b/src/eduid/webapp/idp/views/misc.py
@@ -74,7 +74,10 @@ def logout(ref: str | None, sso_session: SSOSession | None) -> WerkzeugResponse:
             current_app.logger.debug(f"Will ask frontend to redirect user to {location} for entity ID {_entity_id}")
         else:
             current_app.logger.debug(f"Will retain SAML request in session for entity ID {_entity_id}")
-            assert isinstance(ticket.pending_request, IdP_SAMLPendingRequest)  # please type checking
+            if not isinstance(ticket.pending_request, IdP_SAMLPendingRequest):
+                raise RuntimeError(
+                    f"unexpected ticket.pending_request type: {type(ticket.pending_request).__name__}"
+                )
             old_saml_req = ticket.pending_request
             _ref = ticket.request_ref
 


### PR DESCRIPTION
# Final S101 cleanup, enable rule

10 remaining mypy-narrowing `assert` calls replaced with explicit runtime
checks, plus `S101` enabled in `pyproject.toml`. Brings repo to **zero** S101
violations.

Stacked on `ylle-fix-security-views-asserts`.

## Commits

1. **authn/views (4)** —
   - `assert acs_actions` import-side-effect guard → `_ = acs_actions` sentinel.
   - `result.url is not None` → `RuntimeError`.
   - `isinstance(idp, str)` → `RuntimeError` (pysaml2 untyped boundary).
   - `isinstance(args.authn_req, SP_AuthnRequest)` → `RuntimeError`.
2. **session/eduid_session (3)** — flask `SessionInterface` overrides narrow
   `app: Flask` → `EduIDBaseApp` and `session: SessionMixin` → `EduidSession`.
   Liskov-required runtime `isinstance` checks; converted to `RuntimeError`.
3. **idp (3)** — `LoginContext.sso_session` truthiness, `parse_logout_request`
   union narrow, `ticket.pending_request` SAML-variant narrow.
4. **enable `S101` rule** —
   - Add `"S101"` to `select` in `pyproject.toml`.
   - Add `"S101"` to per-file-ignores for `**/test*.py` (asserts fine in tests).
