### PR TITLE
modernize orcid app

### DIFF
--- a/src/eduid/common/config/base.py
+++ b/src/eduid/common/config/base.py
@@ -419,8 +419,6 @@ class FrontendActionMixin(BaseModel):
                 finish_url="https://eduid.se/profile/ext-return/{app_name}/{authn_id}",
             ),
             FrontendAction.CONNECT_ORCID: AuthnParameters(
-                force_authn=False,
-                allow_login_auth=True,
                 finish_url="https://eduid.se/profile/ext-return/{app_name}/{authn_id}",
             ),
             FrontendAction.LOGIN: AuthnParameters(

--- a/src/eduid/common/config/base.py
+++ b/src/eduid/common/config/base.py
@@ -370,6 +370,7 @@ class FrontendAction(Enum):
     ADD_SECURITY_KEY_AUTHN = "addSecurityKeyAuthn"
     CHANGE_PW_AUTHN = "changepwAuthn"
     CHANGE_SECURITY_PREFERENCES_AUTHN = "changeSecurityPreferencesAuthn"
+    CONNECT_ORCID = "connectOrcid"
     LOGIN = "login"
     LOGIN_MFA_AUTHN = "loginMfaAuthn"
     REMOVE_IDENTITY = "removeIdentity"
@@ -414,6 +415,11 @@ class FrontendActionMixin(BaseModel):
             FrontendAction.CHANGE_SECURITY_PREFERENCES_AUTHN: AuthnParameters(
                 force_authn=True,
                 high_security=True,
+                allow_login_auth=True,
+                finish_url="https://eduid.se/profile/ext-return/{app_name}/{authn_id}",
+            ),
+            FrontendAction.CONNECT_ORCID: AuthnParameters(
+                force_authn=False,
                 allow_login_auth=True,
                 finish_url="https://eduid.se/profile/ext-return/{app_name}/{authn_id}",
             ),

--- a/src/eduid/userdb/proofing/db.py
+++ b/src/eduid/userdb/proofing/db.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from operator import itemgetter
 from typing import Any
 
+from eduid.common.decorators import deprecated
 from eduid.userdb.db import BaseDB, SaveResult, TUserDbDocument
 from eduid.userdb.proofing.state import (
     EmailProofingState,
@@ -198,6 +199,7 @@ class OidcStateDB[ProofingStateVar: ProofingState](ProofingStateDB[ProofingState
         return self.state_from_dict(state)
 
 
+@deprecated("Orcid app now saves state in session")
 class OrcidProofingStateDB(OidcStateDB[OrcidProofingState]):
     ProofingStateClass = OrcidProofingState
 

--- a/src/eduid/userdb/proofing/state.py
+++ b/src/eduid/userdb/proofing/state.py
@@ -9,6 +9,7 @@ from typing import Any, Self
 
 import bson
 
+from eduid.common.decorators import deprecated
 from eduid.common.misc.timeutil import utc_now
 from eduid.userdb.db import TUserDbDocument
 from eduid.userdb.exceptions import UserDBValueError
@@ -142,6 +143,7 @@ class LetterProofingState(NinProofingState):
         return res
 
 
+@deprecated("Orcid app now saves state in session")
 @dataclass()
 class OrcidProofingState(ProofingState):
     state: str

--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -27,6 +27,7 @@ from eduid.webapp.common.session.namespaces import (
     FrejaEIDNamespace,
     IdP_Namespace,
     MfaAction,
+    OrcidNamespace,
     Phone,
     ResetPasswordNS,
     SamlEidNamespace,
@@ -60,6 +61,7 @@ class EduidNamespaces(BaseModel):
     svipe_id: SvipeIDNamespace | None = None
     bankid: BankIDNamespace | None = None
     freja_eid: FrejaEIDNamespace | None = None
+    orcid: OrcidNamespace | None = None
     samleid: SamlEidNamespace | None = None
 
 
@@ -254,6 +256,12 @@ class EduidSession(SessionMixin):
         if not self._namespaces.freja_eid:
             self._namespaces.freja_eid = FrejaEIDNamespace.from_dict(self._session.get("freja_eid", {}))
         return self._namespaces.freja_eid
+
+    @property
+    def orcid(self) -> OrcidNamespace:
+        if not self._namespaces.orcid:
+            self._namespaces.orcid = OrcidNamespace.from_dict(self._session.get("orcid", {}))
+        return self._namespaces.orcid
 
     @property
     def samleid(self) -> SamlEidNamespace:

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -325,6 +325,13 @@ class RPAuthnData(BaseModel):
     authlib_cache: dict[str, Any] = Field(default_factory=dict)
     authns: dict[OIDCState, RP_AuthnRequest] = Field(default_factory=dict)
 
+    @field_serializer("authns")
+    def authns_cleanup(self, authns: dict[OIDCState, RP_AuthnRequest]) -> dict[OIDCState, Any]:
+        if len(authns) > MAX_AUTHNS_TO_KEEP:
+            items = sorted(authns.items(), reverse=True, key=lambda item: item[1].created_ts)
+            authns = dict(items[:MAX_AUTHNS_TO_KEEP])
+        return {k: v.model_dump() for k, v in authns.items()}
+
 
 class SvipeIDNamespace(SessionNSBase):
     rp: RPAuthnData = Field(default=RPAuthnData())
@@ -341,6 +348,10 @@ class FrejaEIDNamespace(SessionNSBase):
 class OrcidNamespace(SessionNSBase):
     rp: RPAuthnData = Field(default=RPAuthnData())
     nonces: dict[OIDCState, str] = Field(default_factory=dict)
+
+    @field_serializer("nonces")
+    def nonces_cleanup(self, nonces: dict[OIDCState, str]) -> dict[OIDCState, str]:
+        return {k: v for k, v in nonces.items() if k in self.rp.authns}
 
 
 class SamlEidNamespace(SessionNSBase):

--- a/src/eduid/webapp/common/session/namespaces.py
+++ b/src/eduid/webapp/common/session/namespaces.py
@@ -24,6 +24,7 @@ from eduid.webapp.common.authn.acs_enums import AuthnAcsAction, BankIDAcsAction,
 from eduid.webapp.freja_eid.callback_enums import FrejaEIDAction
 from eduid.webapp.idp.idp_authn import AuthnData
 from eduid.webapp.idp.other_device.data import OtherDeviceId
+from eduid.webapp.orcid.callback_enums import OrcidAction
 from eduid.webapp.svipe_id.callback_enums import SvipeIDAction
 
 __author__ = "ft"
@@ -240,7 +241,9 @@ class BaseAuthnRequest(BaseModel, ABC):
     frontend_action: FrontendAction  # what action frontend is performing
     frontend_state: str | None = None  # opaque data from frontend, returned in /status
     method: str | None = None  # proofing method that frontend is invoking
-    post_authn_action: AuthnAcsAction | EidasAcsAction | SvipeIDAction | BankIDAcsAction | FrejaEIDAction | None = None
+    post_authn_action: (
+        AuthnAcsAction | EidasAcsAction | SvipeIDAction | BankIDAcsAction | FrejaEIDAction | OrcidAction | None
+    ) = None
     # proofing_credential_id is the credential being person-proofed, when doing that
     proofing_credential_id: ElementKey | None = None
     created_ts: datetime = Field(default_factory=utc_now)
@@ -333,6 +336,11 @@ class BankIDNamespace(SessionNSBase):
 
 class FrejaEIDNamespace(SessionNSBase):
     rp: RPAuthnData = Field(default=RPAuthnData())
+
+
+class OrcidNamespace(SessionNSBase):
+    rp: RPAuthnData = Field(default=RPAuthnData())
+    nonces: dict[OIDCState, str] = Field(default_factory=dict)
 
 
 class SamlEidNamespace(SessionNSBase):

--- a/src/eduid/webapp/orcid/app.py
+++ b/src/eduid/webapp/orcid/app.py
@@ -6,12 +6,10 @@ from flask import current_app
 from eduid.common.config.parsers import load_config
 from eduid.common.rpc.am_relay import AmRelay
 from eduid.userdb.logs import ProofingLog
-from eduid.userdb.proofing import OrcidProofingStateDB, OrcidProofingUserDB
+from eduid.userdb.proofing import OrcidProofingUserDB
 from eduid.webapp.common.api.oidc import init_lazy_client
 from eduid.webapp.common.authn.middleware import AuthnBaseApp
 from eduid.webapp.orcid.settings.common import OrcidConfig
-
-__author__ = "lundberg"
 
 
 class OrcidApp(AuthnBaseApp):
@@ -22,7 +20,6 @@ class OrcidApp(AuthnBaseApp):
 
         # Init dbs
         self.private_userdb = OrcidProofingUserDB(config.mongo_uri, auto_expire=config.private_userdb_auto_expire)
-        self.proofing_statedb = OrcidProofingStateDB(config.mongo_uri, auto_expire=config.state_db_auto_expire)
         self.proofing_log = ProofingLog(config.mongo_uri)
 
         # Init celery
@@ -41,11 +38,10 @@ current_orcid_app: OrcidApp = cast(OrcidApp, current_app)
 
 
 def init_orcid_app(name: str = "orcid", test_config: Mapping[str, Any] | None = None) -> OrcidApp:
-    """
-    :param name: The name of the instance, it will affect the configuration loaded.
-    :param test_config: Override config, used in test cases.
-    """
     config = load_config(typ=OrcidConfig, app_name=name, ns="webapp", test_config=test_config)
+
+    # Load acs actions on app init
+    from . import callback_actions  # noqa: F401
 
     app = OrcidApp(config)
 
@@ -56,4 +52,5 @@ def init_orcid_app(name: str = "orcid", test_config: Mapping[str, Any] | None = 
 
     app.register_blueprint(orcid_views)
 
+    app.logger.info(f"{name!s} initialized")
     return app

--- a/src/eduid/webapp/orcid/callback_actions.py
+++ b/src/eduid/webapp/orcid/callback_actions.py
@@ -1,0 +1,80 @@
+from pydantic import ValidationError
+
+from eduid.userdb.logs import OrcidProofing
+from eduid.userdb.orcid import OidcAuthorization, OidcIdToken, Orcid
+from eduid.userdb.proofing import ProofingUser
+from eduid.userdb.user import User
+from eduid.webapp.common.api.decorators import require_user
+from eduid.webapp.common.api.messages import CommonMsg
+from eduid.webapp.common.api.utils import save_and_sync_user
+from eduid.webapp.common.authn.acs_registry import ACSArgs, ACSResult, acs_action
+from eduid.webapp.orcid.app import current_orcid_app as current_app
+from eduid.webapp.orcid.callback_enums import OrcidAction
+from eduid.webapp.orcid.helpers import OrcidMsg, OrcidUserinfo
+
+
+@acs_action(OrcidAction.connect_orcid)
+@require_user
+def connect_orcid_action(user: User, args: ACSArgs) -> ACSResult:
+    session_info = args.session_info
+
+    id_token = session_info["id_token"]
+
+    try:
+        userinfo = OrcidUserinfo(**session_info["userinfo"])
+    except (ValidationError, KeyError) as e:
+        current_app.logger.error(f"Failed to parse userinfo: {e}")
+        return ACSResult(message=OrcidMsg.authz_error)
+
+    if userinfo.sub != id_token["sub"]:
+        current_app.logger.error(f"The 'sub' of userinfo does not match 'sub' of ID Token for user {user.eppn}.")
+        return ACSResult(message=OrcidMsg.sub_mismatch)
+
+    proofing_user = ProofingUser.from_user(user, current_app.private_userdb)
+    oidc_id_token = OidcIdToken(
+        iss=id_token["iss"],
+        sub=id_token["sub"],
+        aud=id_token["aud"],
+        exp=id_token["exp"],
+        iat=id_token["iat"],
+        nonce=id_token["nonce"],
+        auth_time=id_token["auth_time"],
+        created_by="orcid",
+    )
+    oidc_authz = OidcAuthorization(
+        access_token=session_info["access_token"],
+        token_type=session_info["token_type"],
+        id_token=oidc_id_token,
+        expires_in=session_info["expires_in"],
+        refresh_token=session_info["refresh_token"],
+        created_by="orcid",
+    )
+    orcid_element = Orcid(
+        id=userinfo.orcid,
+        name=userinfo.name,
+        given_name=userinfo.given_name,
+        family_name=userinfo.family_name,
+        is_verified=True,
+        oidc_authz=oidc_authz,
+        created_by="orcid",
+    )
+    orcid_proofing = OrcidProofing(
+        eppn=proofing_user.eppn,
+        created_by="orcid",
+        orcid=orcid_element.id,
+        issuer=orcid_element.oidc_authz.id_token.iss,
+        audience=orcid_element.oidc_authz.id_token.aud,
+        proofing_method="oidc",
+        proofing_version="2018v1",
+    )
+
+    if not current_app.proofing_log.save(orcid_proofing):
+        current_app.logger.error("ORCID proofing data NOT saved, failed to save proofing log")
+        return ACSResult(message=CommonMsg.temp_problem)
+
+    current_app.logger.info("ORCID proofing data saved to log")
+    proofing_user.orcid = orcid_element
+    save_and_sync_user(proofing_user)
+    current_app.logger.info("ORCID proofing data saved to user")
+
+    return ACSResult(success=True, message=OrcidMsg.authz_success)

--- a/src/eduid/webapp/orcid/callback_actions.py
+++ b/src/eduid/webapp/orcid/callback_actions.py
@@ -16,6 +16,10 @@ from eduid.webapp.orcid.helpers import OrcidMsg, OrcidUserinfo
 @acs_action(OrcidAction.connect_orcid)
 @require_user
 def connect_orcid_action(user: User, args: ACSArgs) -> ACSResult:
+    if user.orcid is not None:
+        current_app.logger.info(f"User {user.eppn} already has ORCID linked, ignoring callback")
+        return ACSResult(message=OrcidMsg.already_connected)
+
     session_info = args.session_info
 
     id_token = session_info["id_token"]

--- a/src/eduid/webapp/orcid/callback_enums.py
+++ b/src/eduid/webapp/orcid/callback_enums.py
@@ -1,0 +1,6 @@
+from enum import StrEnum, unique
+
+
+@unique
+class OrcidAction(StrEnum):
+    connect_orcid = "connect-orcid-action"

--- a/src/eduid/webapp/orcid/helpers.py
+++ b/src/eduid/webapp/orcid/helpers.py
@@ -17,8 +17,6 @@ class OrcidMsg(TranslatableMsg):
     already_connected = "orc.already_connected"
     # Authorization error at ORCID
     authz_error = "orc.authorization_fail"
-    # proofing state corresponding to ORCID response not found
-    no_state = "orc.unknown_state"
     # nonce received from ORCID not known
     unknown_nonce = "orc.unknown_nonce"
     # The 'sub' of userinfo does not match 'sub' of ID Token for user

--- a/src/eduid/webapp/orcid/helpers.py
+++ b/src/eduid/webapp/orcid/helpers.py
@@ -25,6 +25,8 @@ class OrcidMsg(TranslatableMsg):
     sub_mismatch = "orc.sub_mismatch"
     # ORCID proofing data saved for user
     authz_success = "orc.authorization_success"
+    # frontend action not supported
+    frontend_action_not_supported = "orc.frontend_action_not_supported"
 
 
 class OrcidUserinfo(BaseModel):

--- a/src/eduid/webapp/orcid/schemas.py
+++ b/src/eduid/webapp/orcid/schemas.py
@@ -1,10 +1,20 @@
 from marshmallow import fields
 
 from eduid.webapp.common.api.schemas.base import EduidSchema, FluxStandardAction
-from eduid.webapp.common.api.schemas.csrf import CSRFResponseMixin
+from eduid.webapp.common.api.schemas.csrf import CSRFRequestMixin, CSRFResponseMixin
 from eduid.webapp.common.api.schemas.orcid import OrcidSchema
 
-__author__ = "lundberg"
+
+class OrcidConnectRequestSchema(EduidSchema, CSRFRequestMixin):
+    frontend_action = fields.String(required=True)
+    frontend_state = fields.String(required=False, load_default=None)
+
+
+class OrcidConnectResponseSchema(FluxStandardAction):
+    class OrcidConnectResponsePayload(EduidSchema, CSRFResponseMixin):
+        location = fields.String(required=False)
+
+    payload = fields.Nested(OrcidConnectResponsePayload)
 
 
 class OrcidResponseSchema(FluxStandardAction):

--- a/src/eduid/webapp/orcid/settings/common.py
+++ b/src/eduid/webapp/orcid/settings/common.py
@@ -1,15 +1,9 @@
-from datetime import timedelta
-
 from pydantic import Field
 
-from eduid.common.config.base import AmConfigMixin, EduIDBaseAppConfig, ErrorsConfigMixin
+from eduid.common.config.base import AmConfigMixin, EduIDBaseAppConfig, ErrorsConfigMixin, FrontendActionMixin
 
 
-class OrcidConfig(EduIDBaseAppConfig, AmConfigMixin, ErrorsConfigMixin):
-    """
-    Configuration for the orcid app
-    """
-
+class OrcidConfig(EduIDBaseAppConfig, AmConfigMixin, ErrorsConfigMixin, FrontendActionMixin):
     app_name: str = "orcid"
 
     # OIDC
@@ -21,4 +15,3 @@ class OrcidConfig(EduIDBaseAppConfig, AmConfigMixin, ErrorsConfigMixin):
     )
     userinfo_endpoint_method: str = "GET"
     orcid_verify_redirect_url: str = "/profile/accountlinking"
-    state_db_auto_expire: timedelta | None = timedelta(days=7)

--- a/src/eduid/webapp/orcid/settings/common.py
+++ b/src/eduid/webapp/orcid/settings/common.py
@@ -14,4 +14,3 @@ class OrcidConfig(EduIDBaseAppConfig, AmConfigMixin, ErrorsConfigMixin, Frontend
         }
     )
     userinfo_endpoint_method: str = "GET"
-    orcid_verify_redirect_url: str = "/profile/accountlinking"

--- a/src/eduid/webapp/orcid/tests/test_app.py
+++ b/src/eduid/webapp/orcid/tests/test_app.py
@@ -6,13 +6,14 @@ import pytest
 from pytest_mock import MockerFixture
 from werkzeug.test import TestResponse
 
+from eduid.common.config.base import FrontendAction
 from eduid.userdb.orcid import OidcAuthorization, OidcIdToken, Orcid
 from eduid.userdb.proofing import ProofingUser
-from eduid.userdb.proofing.state import OrcidProofingState
+from eduid.webapp.common.api.messages import AuthnStatusMsg
 from eduid.webapp.common.api.testing import EduidAPITestCase
+from eduid.webapp.common.session.namespaces import OIDCState
 from eduid.webapp.orcid.app import OrcidApp, init_orcid_app
-
-__author__ = "lundberg"
+from eduid.webapp.orcid.helpers import OrcidMsg
 
 
 class MockResponse:
@@ -63,7 +64,7 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
         oidc_provider_config = {
             "token_endpoint_auth_signing_alg_values_supported": ["RS256"],
             "id_token_signing_alg_values_supported": ["RS256"],
-            "userinfo_endpoint": "https://https://example.com/op/oauth/userinfo",
+            "userinfo_endpoint": "https://example.com/op/oauth/userinfo",
             "authorization_endpoint": "https://example.com/op/oauth/authorize",
             "token_endpoint": "https://example.com/op/oauth/token",
             "jwks_uri": "https://example.com/op/oauth/jwks",
@@ -86,13 +87,41 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
                 "client_registration_info": {"client_id": "test_client", "client_secret": "secret"},
                 "userinfo_endpoint_method": "GET",
                 "orcid_verify_redirect_url": "https://dashboard.example.com/",
+                "frontend_action_authn_parameters": {
+                    FrontendAction.CONNECT_ORCID.value: {
+                        "finish_url": "https://dashboard.example.com/profile/ext-return/{app_name}/{authn_id}",
+                    },
+                },
             }
         )
         return config
 
-    def mock_authorization_response(
+    def _start_connect(self, eppn: str) -> TestResponse:
+        with self.session_cookie(self.browser, eppn) as client:
+            with client.session_transaction() as sess:
+                csrf_token = sess.get_csrf_token()
+            return client.post(
+                "/connect-orcid",
+                json={
+                    "csrf_token": csrf_token,
+                    "frontend_action": FrontendAction.CONNECT_ORCID.value,
+                    "frontend_state": "test_state",
+                },
+            )
+
+    def _get_authn_id_from_session(self) -> OIDCState:
+        with self.browser.session_transaction() as sess:
+            authn_ids = list(sess.orcid.rp.authns.keys())
+            return authn_ids[-1]
+
+    def _get_nonce_from_session(self, oidc_state: OIDCState) -> str:
+        with self.browser.session_transaction() as sess:
+            return sess.orcid.nonces[oidc_state]
+
+    def mock_authorization_callback(
         self,
-        proofing_state: OrcidProofingState,
+        state: str,
+        nonce: str,
         userinfo: dict[str, Any],
     ) -> TestResponse:
         mock_auth_response = self.mocker.patch("oic.oic.Client.parse_response")
@@ -101,7 +130,7 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
         mock_auth_response.return_value = {
             "id_token": "id_token",
             "code": "code",
-            "state": proofing_state.state,
+            "state": state,
         }
 
         mock_token_request.return_value = {
@@ -110,7 +139,7 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
             "expires_in": 0,
             "refresh_token": "refresh_token",
             "id_token": {
-                "nonce": proofing_state.nonce,
+                "nonce": nonce,
                 "sub": "sub",
                 "iss": "iss",
                 "aud": ["aud"],
@@ -124,34 +153,38 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
         }
         userinfo["sub"] = "sub"
         mock_userinfo_request.return_value = userinfo
-        return self.browser.get(f"/authorization-response?id_token=id_token&state={proofing_state.state}")
+        return self.browser.get(f"/authn-callback?id_token=id_token&state={state}")
 
     def test_authenticate(self) -> None:
-        response = self.browser.get("/authorize")
-        assert response.status_code == 401
-        with self.session_cookie(self.browser, self.test_user_eppn) as browser:
-            response = browser.get("/authorize")
-        assert response.status_code == 302  # Authenticated request redirected to OP
-        assert response.location.startswith(self.app.conf.provider_configuration_info["issuer"])
+        response = self._start_connect(self.test_user_eppn)
+        assert response.status_code == 200
+        payload = self.get_response_payload(response)
+        assert "location" in payload
+        assert payload["location"].startswith(self.app.conf.provider_configuration_info["issuer"])
 
     def test_oidc_flow(self, mocker: MockerFixture) -> None:
         mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
         mock_request_user_sync.side_effect = self.request_user_sync
 
-        with self.session_cookie(self.browser, self.test_user_eppn) as browser:
-            response = browser.get("/authorize")
-        assert response.status_code == 302  # Authenticated request redirected to OP
+        response = self._start_connect(self.test_user_eppn)
+        assert response.status_code == 200
+        payload = self.get_response_payload(response)
+        assert "location" in payload
+
+        # Get state and nonce from session
+        authn_id = self._get_authn_id_from_session()
+        nonce = self._get_nonce_from_session(authn_id)
 
         # Fake callback from OP
-        proofing_state = self.app.proofing_statedb.get_state_by_eppn(self.test_user_eppn)
-        assert proofing_state is not None
         userinfo = {
             "id": "https://sandbox.orcid.org/0000-0000-0000-0000",
             "name": None,
             "given_name": "Test",
             "family_name": "Testsson",
         }
-        self.mock_authorization_response(proofing_state, userinfo)
+        callback_response = self.mock_authorization_callback(state=str(authn_id), nonce=nonce, userinfo=userinfo)
+        assert callback_response.status_code == 302
+        assert "/ext-return/" in callback_response.location
 
         user = self.app.private_userdb.get_user_by_eppn(self.test_user_eppn)
         assert user.orcid is not None
@@ -160,6 +193,16 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
         assert user.orcid.given_name == userinfo["given_name"]
         assert user.orcid.family_name == userinfo["family_name"]
         assert self.app.proofing_log.db_count() == 1
+
+    def test_get_status_not_found(self) -> None:
+        with self.session_cookie(self.browser, self.test_user_eppn) as client:
+            with client.session_transaction() as sess:
+                csrf_token = sess.get_csrf_token()
+            response = client.post(
+                "/get-status",
+                json={"csrf_token": csrf_token, "authn_id": "nonexistent"},
+            )
+        self._check_error_response(response, type_="POST_ORCID_GET_STATUS_FAIL", msg=AuthnStatusMsg.not_found)
 
     def test_get_orcid(self) -> None:
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
@@ -200,3 +243,15 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
 
         user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
         assert user.orcid is None
+
+    def test_already_connected(self, mocker: MockerFixture) -> None:
+        mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
+        mock_request_user_sync.side_effect = self.request_user_sync
+
+        user = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
+        proofing_user = ProofingUser.from_user(user, self.app.private_userdb)
+        proofing_user.orcid = self.orcid_element
+        self.request_user_sync(proofing_user)
+
+        response = self._start_connect(self.test_user_eppn)
+        self._check_error_response(response, type_="POST_ORCID_CONNECT_ORCID_FAIL", msg=OrcidMsg.already_connected)

--- a/src/eduid/webapp/orcid/tests/test_app.py
+++ b/src/eduid/webapp/orcid/tests/test_app.py
@@ -153,7 +153,7 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
         }
         userinfo["sub"] = "sub"
         mock_userinfo_request.return_value = userinfo
-        return self.browser.get(f"/authn-callback?id_token=id_token&state={state}")
+        return self.browser.get(f"/authorization-response?id_token=id_token&state={state}")
 
     def test_authenticate(self) -> None:
         response = self._start_connect(self.test_user_eppn)

--- a/src/eduid/webapp/orcid/tests/test_app.py
+++ b/src/eduid/webapp/orcid/tests/test_app.py
@@ -194,6 +194,40 @@ class OrcidTests(EduidAPITestCase[OrcidApp]):
         assert user.orcid.family_name == userinfo["family_name"]
         assert self.app.proofing_log.db_count() == 1
 
+    def test_get_status_after_callback(self, mocker: MockerFixture) -> None:
+        mock_request_user_sync = mocker.patch("eduid.common.rpc.am_relay.AmRelay.request_user_sync")
+        mock_request_user_sync.side_effect = self.request_user_sync
+
+        response = self._start_connect(self.test_user_eppn)
+        assert response.status_code == 200
+
+        authn_id = self._get_authn_id_from_session()
+        nonce = self._get_nonce_from_session(authn_id)
+
+        userinfo = {
+            "id": "https://sandbox.orcid.org/0000-0000-0000-0000",
+            "name": None,
+            "given_name": "Test",
+            "family_name": "Testsson",
+        }
+        callback_response = self.mock_authorization_callback(state=str(authn_id), nonce=nonce, userinfo=userinfo)
+        assert callback_response.status_code == 302
+
+        # Poll get-status with the authn_id from the callback
+        with self.browser.session_transaction() as sess:
+            csrf_token = sess.get_csrf_token()
+        status_response = self.browser.post(
+            "/get-status",
+            json={"csrf_token": csrf_token, "authn_id": str(authn_id)},
+        )
+        self._check_success_response(status_response, type_="POST_ORCID_GET_STATUS_SUCCESS")
+        status_payload = self.get_response_payload(status_response)
+        assert status_payload["frontend_action"] == FrontendAction.CONNECT_ORCID.value
+        assert status_payload["frontend_state"] == "test_state"
+        assert status_payload["method"] == "orcid"
+        assert status_payload["error"] is False
+        assert status_payload["status"] == OrcidMsg.authz_success.value
+
     def test_get_status_not_found(self) -> None:
         with self.session_cookie(self.browser, self.test_user_eppn) as client:
             with client.session_transaction() as sess:

--- a/src/eduid/webapp/orcid/tests/test_msgs.py
+++ b/src/eduid/webapp/orcid/tests/test_msgs.py
@@ -6,7 +6,6 @@ class MessagesTests:
         """"""
         assert OrcidMsg.already_connected.value == "orc.already_connected"
         assert OrcidMsg.authz_error.value == "orc.authorization_fail"
-        assert OrcidMsg.no_state.value == "orc.unknown_state"
         assert OrcidMsg.unknown_nonce.value == "orc.unknown_nonce"
         assert OrcidMsg.sub_mismatch.value == "orc.sub_mismatch"
         assert OrcidMsg.authz_success.value == "orc.authorization_success"

--- a/src/eduid/webapp/orcid/views.py
+++ b/src/eduid/webapp/orcid/views.py
@@ -104,7 +104,7 @@ def connect_orcid(user: User, frontend_action: str, frontend_state: str | None =
     return success_response(payload={"location": authorization_url})
 
 
-@orcid_views.route("/authn-callback", methods=["GET"])
+@orcid_views.route("/authorization-response", methods=["GET"])
 @require_user
 def authn_callback(user: User) -> WerkzeugResponse:
     current_app.logger.debug(f"authn_callback called with args: {request.args}")

--- a/src/eduid/webapp/orcid/views.py
+++ b/src/eduid/webapp/orcid/views.py
@@ -42,7 +42,6 @@ def get_status(user: User, authn_id: OIDCState) -> FluxData:
         return error_response(message=AuthnStatusMsg.not_found)
 
     payload = {
-        "authn_id": str(authn_id),
         "frontend_action": authn.frontend_action.value,
         "frontend_state": authn.frontend_state,
         "method": authn.method,

--- a/src/eduid/webapp/orcid/views.py
+++ b/src/eduid/webapp/orcid/views.py
@@ -172,6 +172,9 @@ def authn_callback(user: User) -> WerkzeugResponse:
             authn_req.status = OrcidMsg.unknown_nonce.value
             return redirect(formatted_finish_url)
 
+        # Nonce validated, remove it
+        del session.orcid.nonces[oidc_state]
+
         current_app.logger.info("ORCID authorized for user")
 
         # Userinfo request

--- a/src/eduid/webapp/orcid/views.py
+++ b/src/eduid/webapp/orcid/views.py
@@ -1,205 +1,223 @@
 from urllib.parse import urlencode
 
-from flask import Blueprint, redirect, request, url_for
+from flask import Blueprint, make_response, redirect, request, url_for
 from oic.oic.message import AuthorizationResponse, Claims, ClaimsRequest
-from pydantic import ValidationError
 from werkzeug.wrappers import Response as WerkzeugResponse
 
-from eduid.userdb.logs import OrcidProofing
-from eduid.userdb.orcid import OidcAuthorization, OidcIdToken, Orcid
-from eduid.userdb.proofing import OrcidProofingState, ProofingUser
+from eduid.common.config.base import FrontendAction
+from eduid.userdb.proofing import ProofingUser
 from eduid.userdb.user import User
 from eduid.webapp.common.api.decorators import MarshalWith, UnmarshalWith, require_user
+from eduid.webapp.common.api.errors import EduidErrorsContext, goto_errors_response
 from eduid.webapp.common.api.messages import (
+    AuthnStatusMsg,
     CommonMsg,
     FluxData,
-    TranslatableMsg,
-    redirect_with_msg,
+    error_response,
     success_response,
 )
 from eduid.webapp.common.api.oidc import OidcServiceUnavailableError
+from eduid.webapp.common.api.schemas.authn_status import StatusRequestSchema, StatusResponseSchema
 from eduid.webapp.common.api.schemas.csrf import EmptyRequest
 from eduid.webapp.common.api.utils import get_unique_hash, save_and_sync_user
+from eduid.webapp.common.authn.acs_registry import ACSArgs, get_action
+from eduid.webapp.common.authn.session_info import SessionInfo
+from eduid.webapp.common.session import session
+from eduid.webapp.common.session.namespaces import OIDCState, RP_AuthnRequest
 from eduid.webapp.orcid.app import current_orcid_app as current_app
-from eduid.webapp.orcid.helpers import OrcidMsg, OrcidUserinfo
-from eduid.webapp.orcid.schemas import OrcidResponseSchema
-
-__author__ = "lundberg"
+from eduid.webapp.orcid.callback_enums import OrcidAction
+from eduid.webapp.orcid.helpers import OrcidMsg
+from eduid.webapp.orcid.schemas import OrcidConnectRequestSchema, OrcidConnectResponseSchema, OrcidResponseSchema
 
 orcid_views = Blueprint("orcid", __name__, url_prefix="", template_folder="templates")
 
 
-@orcid_views.route("/authorize", methods=["GET"])
+@orcid_views.route("/get-status", methods=["POST"])
+@UnmarshalWith(StatusRequestSchema)
+@MarshalWith(StatusResponseSchema)
 @require_user
-def authorize(user: User) -> WerkzeugResponse:
-    if user.orcid is None:
-        try:
-            proofing_state = current_app.proofing_statedb.get_state_by_eppn(user.eppn)
-            if not proofing_state:
-                current_app.logger.debug(f"No proofing state found for user {user!s}. Initializing new proofing state.")
-                proofing_state = OrcidProofingState(
-                    id=None, modified_ts=None, eppn=user.eppn, state=get_unique_hash(), nonce=get_unique_hash()
-                )
-                current_app.proofing_statedb.save(proofing_state, is_in_database=False)
+def get_status(user: User, authn_id: OIDCState) -> FluxData:
+    authn = session.orcid.rp.authns.get(authn_id)
+    if not authn:
+        return error_response(message=AuthnStatusMsg.not_found)
 
-            claims_request = ClaimsRequest(userinfo=Claims(id=None))  # type: ignore[no-untyped-call]
-            oidc_args = {
-                "client_id": current_app.oidc_client.client_id,
-                "response_type": "code",
-                "scope": "openid",
-                "claims": claims_request.to_json(),  # type: ignore[no-untyped-call]
-                "redirect_uri": url_for("orcid.authorization_response", _external=True),
-                "state": proofing_state.state,
-                "nonce": proofing_state.nonce,
-            }
-            authorization_url = f"{current_app.oidc_client.authorization_endpoint}?{urlencode(oidc_args)}"
-            current_app.logger.debug(f"Authorization url: {authorization_url!s}")
-            current_app.stats.count(name="authn_request")
-            return redirect(authorization_url)
-        except OidcServiceUnavailableError as e:
-            current_app.logger.warning(f"ORCID service unavailable during authorization: {e}")
-            redirect_url = current_app.conf.orcid_verify_redirect_url
-            return redirect_with_msg(redirect_url, CommonMsg.temp_problem, error=True)
-    # Orcid already connected to user
-    redirect_url = current_app.conf.orcid_verify_redirect_url
-    return redirect_with_msg(redirect_url, OrcidMsg.already_connected)
+    payload = {
+        "authn_id": str(authn_id),
+        "frontend_action": authn.frontend_action.value,
+        "frontend_state": authn.frontend_state,
+        "method": authn.method,
+        "error": bool(authn.error),
+    }
+    if authn.status is not None:
+        payload["status"] = authn.status
+
+    return success_response(payload=payload)
 
 
-@orcid_views.route("/authorization-response", methods=["GET"])
+@orcid_views.route("/connect-orcid", methods=["POST"])
+@UnmarshalWith(OrcidConnectRequestSchema)
+@MarshalWith(OrcidConnectResponseSchema)
 @require_user
-def authorization_response(user: User) -> WerkzeugResponse:
-    # Redirect url for user feedback
-    redirect_url = current_app.conf.orcid_verify_redirect_url
+def connect_orcid(user: User, frontend_action: str, frontend_state: str | None = None) -> FluxData:
+    if user.orcid is not None:
+        return error_response(message=OrcidMsg.already_connected)
+
+    try:
+        _frontend_action = FrontendAction(frontend_action)
+        authn_params = current_app.conf.frontend_action_authn_parameters[_frontend_action]
+    except (ValueError, KeyError):
+        current_app.logger.error(f"Frontend action {frontend_action} not supported")
+        return error_response(message=OrcidMsg.frontend_action_not_supported)
+
+    state = get_unique_hash()
+    nonce = get_unique_hash()
+
+    try:
+        claims_request = ClaimsRequest(userinfo=Claims(id=None))  # type: ignore[no-untyped-call]
+        oidc_args = {
+            "client_id": current_app.oidc_client.client_id,
+            "response_type": "code",
+            "scope": "openid",
+            "claims": claims_request.to_json(),  # type: ignore[no-untyped-call]
+            "redirect_uri": url_for("orcid.authn_callback", _external=True),
+            "state": state,
+            "nonce": nonce,
+        }
+        authorization_url = f"{current_app.oidc_client.authorization_endpoint}?{urlencode(oidc_args)}"
+    except OidcServiceUnavailableError as e:
+        current_app.logger.warning(f"ORCID service unavailable during authorization: {e}")
+        return error_response(message=CommonMsg.temp_problem)
+
+    oidc_state = OIDCState(state)
+    authn_req = RP_AuthnRequest(
+        authn_id=oidc_state,
+        frontend_action=_frontend_action,
+        frontend_state=frontend_state,
+        post_authn_action=OrcidAction.connect_orcid,
+        method="orcid",
+        finish_url=authn_params.finish_url,
+    )
+    session.orcid.rp.authns[oidc_state] = authn_req
+    session.orcid.nonces[oidc_state] = nonce
+
+    current_app.logger.debug(f"Stored RP_AuthnRequest[{oidc_state}]: {authn_req}")
+    current_app.stats.count(name="authn_request")
+    return success_response(payload={"location": authorization_url})
+
+
+@orcid_views.route("/authn-callback", methods=["GET"])
+@require_user
+def authn_callback(user: User) -> WerkzeugResponse:
+    current_app.logger.debug(f"authn_callback called with args: {request.args}")
+
+    oidc_state: OIDCState | None = None
+    authn_req: RP_AuthnRequest | None = None
+    if "state" in request.args:
+        oidc_state = OIDCState(request.args["state"])
+    if oidc_state is not None:
+        authn_req = session.orcid.rp.authns.get(oidc_state)
+
+    if not oidc_state or not authn_req:
+        current_app.logger.info(
+            f"Response {oidc_state} does not match one in session, redirecting user to eduID Errors page"
+        )
+        if not current_app.conf.errors_url_template:
+            return make_response("Unknown authn response", 400)
+        return goto_errors_response(
+            errors_url=current_app.conf.errors_url_template,
+            ctx=EduidErrorsContext.OIDC_RESPONSE_UNSOLICITED,
+            rp=url_for("orcid.authn_callback", _external=True),
+        )
 
     current_app.stats.count(name="authn_response")
+    formatted_finish_url = authn_req.formatted_finish_url(app_name=current_app.conf.app_name)
 
-    # parse authentication response
+    # Parse authorization response
     query_string = request.query_string.decode("utf-8")
-    current_app.logger.debug(f"query_string: {query_string!s}")
-
     try:
         authn_resp = current_app.oidc_client.parse_response(
             AuthorizationResponse, info=query_string, sformat="urlencoded"
         )
-        current_app.logger.debug(f"Authorization response received: {authn_resp!s}")
     except OidcServiceUnavailableError as e:
         current_app.logger.warning(f"ORCID service unavailable during authorization response: {e}")
-        return redirect_with_msg(redirect_url, CommonMsg.temp_problem, error=True)
+        authn_req.error = True
+        authn_req.status = CommonMsg.temp_problem.value
+        return redirect(formatted_finish_url)
 
     if authn_resp.get("error"):  # type: ignore[no-untyped-call]
         current_app.logger.error(
-            "AuthorizationError from {}: {} - {} ({})".format(
-                request.host,
-                authn_resp["error"],
-                authn_resp.get("error_message"),  # type: ignore[no-untyped-call]
-                authn_resp.get("error_description"),  # type: ignore[no-untyped-call]
-            )
+            f"AuthorizationError: {authn_resp['error']} - {authn_resp.get('error_message')}"  # type: ignore[no-untyped-call]
+            f" ({authn_resp.get('error_description')})"  # type: ignore[no-untyped-call]
         )
-        return redirect_with_msg(redirect_url, OrcidMsg.authz_error)
+        authn_req.error = True
+        authn_req.status = OrcidMsg.authz_error.value
+        return redirect(formatted_finish_url)
 
-    user_oidc_state = authn_resp["state"]
-    proofing_state = current_app.proofing_statedb.get_state_by_oidc_state(user_oidc_state)
-    if not proofing_state:
-        current_app.logger.error(f"The 'state' parameter ({user_oidc_state!s}) does not match a user state.")
-        return redirect_with_msg(redirect_url, OrcidMsg.no_state)
-
-    # do token request
+    # Token request
     args = {
         "code": authn_resp["code"],
-        "redirect_uri": url_for("orcid.authorization_response", _external=True),
+        "redirect_uri": url_for("orcid.authn_callback", _external=True),
     }
-    current_app.logger.debug(f"Trying to do token request: {args!s}")
     try:
         token_resp = current_app.oidc_client.do_access_token_request(  # type: ignore[no-untyped-call]
             scope="openid", state=authn_resp["state"], request_args=args, authn_method="client_secret_basic"
         )
-        current_app.logger.debug(f"token response received: {token_resp!s}")
         id_token = token_resp["id_token"]
-        if id_token["nonce"] != proofing_state.nonce:
+
+        # Validate nonce
+        expected_nonce = session.orcid.nonces.get(oidc_state)
+        if not expected_nonce or id_token["nonce"] != expected_nonce:
             current_app.logger.error("The 'nonce' parameter does not match for user")
-            return redirect_with_msg(redirect_url, OrcidMsg.unknown_nonce)
+            authn_req.error = True
+            authn_req.status = OrcidMsg.unknown_nonce.value
+            return redirect(formatted_finish_url)
 
         current_app.logger.info("ORCID authorized for user")
 
-        # do userinfo request
-        current_app.logger.debug("Trying to do userinfo request:")
+        # Userinfo request
         userinfo_result = current_app.oidc_client.do_user_info_request(  # type: ignore[no-untyped-call]
             method=current_app.conf.userinfo_endpoint_method, state=authn_resp["state"]
         )
-        current_app.logger.debug(f"userinfo received: {userinfo_result}")
     except OidcServiceUnavailableError as e:
         current_app.logger.warning(f"ORCID service unavailable during token/userinfo request: {e}")
-        return redirect_with_msg(redirect_url, CommonMsg.temp_problem, error=True)
+        authn_req.error = True
+        authn_req.status = CommonMsg.temp_problem.value
+        return redirect(formatted_finish_url)
 
-    try:
-        userinfo = OrcidUserinfo(**userinfo_result)
-    except ValidationError as e:
-        current_app.logger.error(f"Failed to parse userinfo: {e}")
-        return redirect_with_msg(redirect_url, OrcidMsg.authz_error)
-
-    if userinfo.sub != id_token["sub"]:
-        current_app.logger.error(
-            f"The 'sub' of userinfo does not match 'sub' of ID Token for user {proofing_state.eppn}."
-        )
-        return redirect_with_msg(redirect_url, OrcidMsg.sub_mismatch)
-
-    # Save orcid and oidc data to user
-    current_app.logger.info("Saving ORCID data for user")
-    proofing_user = ProofingUser.from_user(user, current_app.private_userdb)
-    oidc_id_token = OidcIdToken(
-        iss=id_token["iss"],
-        sub=id_token["sub"],
-        aud=id_token["aud"],
-        exp=id_token["exp"],
-        iat=id_token["iat"],
-        nonce=id_token["nonce"],
-        auth_time=id_token["auth_time"],
-        created_by="orcid",
-    )
-    oidc_authz = OidcAuthorization(
-        access_token=token_resp["access_token"],
-        token_type=token_resp["token_type"],
-        id_token=oidc_id_token,
-        expires_in=token_resp["expires_in"],
-        refresh_token=token_resp["refresh_token"],
-        created_by="orcid",
-    )
-    orcid_element = Orcid(
-        id=userinfo.orcid,
-        name=userinfo.name,
-        given_name=userinfo.given_name,
-        family_name=userinfo.family_name,
-        is_verified=True,
-        oidc_authz=oidc_authz,
-        created_by="orcid",
-    )
-    orcid_proofing = OrcidProofing(
-        eppn=proofing_user.eppn,
-        created_by="orcid",
-        orcid=orcid_element.id,
-        issuer=orcid_element.oidc_authz.id_token.iss,
-        audience=orcid_element.oidc_authz.id_token.aud,
-        proofing_method="oidc",
-        proofing_version="2018v1",
+    # Build session_info for callback action
+    session_info = SessionInfo(
+        {
+            "id_token": dict(id_token),
+            "userinfo": dict(userinfo_result),
+            "access_token": token_resp["access_token"],
+            "token_type": token_resp["token_type"],
+            "expires_in": token_resp["expires_in"],
+            "refresh_token": token_resp["refresh_token"],
+        }
     )
 
-    _error = True
-    _msg: TranslatableMsg = CommonMsg.temp_problem
+    action = get_action(default_action=None, authndata=authn_req)
+    acs_args = ACSArgs(
+        session_info=session_info,
+        authn_req=authn_req,
+    )
+    result = action(args=acs_args)
+    current_app.logger.debug(f"Callback action result: {result}")
 
-    if current_app.proofing_log.save(orcid_proofing):
-        current_app.logger.info("ORCID proofing data saved to log")
-        proofing_user.orcid = orcid_element
-        save_and_sync_user(proofing_user)
-        current_app.logger.info("ORCID proofing data saved to user")
-        _error = False
-        _msg = OrcidMsg.authz_success
-    else:
-        current_app.logger.info("ORCID proofing data NOT saved, failed to save proofing log")
+    if not result.success:
+        current_app.logger.info(f"OIDC callback action failed: {result.message}")
+        current_app.stats.count(name="authn_action_failed")
+        authn_req.error = True
+        if result.message:
+            authn_req.status = result.message.value
+        authn_req.consumed = True
+        return redirect(formatted_finish_url)
 
-    # Clean up
-    current_app.logger.info("Removing proofing state")
-    current_app.proofing_statedb.remove_state(proofing_state)
-    return redirect_with_msg(redirect_url, msg=_msg, error=_error)
+    current_app.logger.debug(f"OIDC callback action successful (frontend_action {authn_req.frontend_action})")
+    if result.message:
+        authn_req.status = result.message.value
+    authn_req.consumed = True
+    return redirect(formatted_finish_url)
 
 
 @orcid_views.route("/", methods=["GET"])

--- a/src/eduid/webapp/orcid/views.py
+++ b/src/eduid/webapp/orcid/views.py
@@ -194,8 +194,8 @@ def authn_callback(user: User) -> WerkzeugResponse:
             "userinfo": dict(userinfo_result),
             "access_token": token_resp["access_token"],
             "token_type": token_resp["token_type"],
-            "expires_in": token_resp["expires_in"],
-            "refresh_token": token_resp["refresh_token"],
+            "expires_in": token_resp.get("expires_in"),
+            "refresh_token": token_resp.get("refresh_token"),
         }
     )
 


### PR DESCRIPTION
 ## Summary

  The ORCID webapp now follows the same OIDC pattern as freja_eid and svipe_id. State is stored in the Redis session instead of MongoDB, and the callback redirects to an ext-return URL that the frontend polls for status.

  ## Breaking API Changes

  ### Removed endpoints
  - **`GET /authorize`** — No longer exists. Was a server-side redirect to ORCID.

  ### New endpoints

  #### `POST /connect-orcid`
  Initiates ORCID account linking. Returns the authorization URL for the frontend to redirect to.

  **Request:**
  ```json
  {
    "csrf_token": "...",
    "frontend_action": "connectOrcid",
    "frontend_state": "optional-opaque-string"
  }
  ```

  **Response:**
  ```json
  {
    "type": "POST_ORCID_CONNECT_ORCID_SUCCESS",
    "payload": {
      "csrf_token": "...",
      "location": "https://orcid.org/oauth/authorize?client_id=...&state=..."
    }
  } 
  ```
  
  The frontend should redirect the user to payload.location.

  #### `POST /get-status`

  Poll this endpoint after the OIDC callback redirect lands on the ext-return URL.

**Request:**
```json
  {
    "csrf_token": "...",
    "authn_id": "<the authn_id from the ext-return URL path>"
  }
```

**Response:**
```json
  {
    "type": "POST_ORCID_GET_STATUS_SUCCESS",
    "payload": {
      "csrf_token": "...",
      "authn_id": "...",
      "frontend_action": "connectOrcid",
      "frontend_state": "optional-opaque-string",
      "method": "orcid",
      "error": false,
      "status": "orc.authorization_success"
    }
  }
```

#### Unchanged endpoints

  - GET / — Returns current ORCID data (no changes)
  - POST /remove — Removes ORCID link (no changes)

####Frontend Flow (before → after)

  Before

  1. Frontend navigates user to GET /authorize
  2. Server redirects to ORCID
  3. ORCID redirects back to server at /authorization-response
  4. Server redirects to static orcid_verify_redirect_url with a flash message

  After

  1. Frontend calls POST /connect-orcid with frontend_action: "connectOrcid"
  2. Frontend redirects user to payload.location (ORCID authorization URL)
  3. ORCID redirects back to server at /authn-callback
  4. Server redirects to https://eduid.se/profile/ext-return/orcid/{authn_id}
  5. Frontend extracts authn_id from the URL path and polls POST /get-status
  6. Frontend reads status and error fields to determine outcome

  This is the same flow used by freja_eid and svipe_id — the ext-return/{app_name}/{authn_id} pattern.

#### Status Values
```
  │       status value        │ error │               Meaning                │
  │ orc.authorization_success │ false │ ORCID linked successfully            │  
  │ orc.authorization_fail    │ true  │ ORCID returned an error              │  
  │ orc.unknown_nonce         │ true  │ Nonce validation failed              │  
  │ orc.sub_mismatch          │ true  │ ID token / userinfo subject mismatch │  
  │ orc.already_connected     │ true  │ User already has ORCID linked        │  
   | Temporary technical problems | true | Unknown backend error |
```