### PR TITLE
Type-refactor follow-ups: assert-derived runtime checks

### DIFF
--- a/src/eduid/userdb/db/base.py
+++ b/src/eduid/userdb/db/base.py
@@ -48,9 +48,7 @@ class BaseMongoDB:
         if "replicaSet" in kwargs and kwargs["replicaSet"] is None:
             del kwargs["replicaSet"]
 
-        _options = self._parsed_uri.get("options")
-        if _options is None:
-            raise RuntimeError("parsed mongo URI has no options dict")
+        _options = self._parsed_uri.get("options", {})
 
         if "replicaSet" in _options and _options["replicaSet"] is not None:
             kwargs["replicaSet"] = _options["replicaSet"]

--- a/src/eduid/userdb/element.py
+++ b/src/eduid/userdb/element.py
@@ -331,14 +331,15 @@ class ElementList[ListElement: Element](BaseModel, ABC):
             raise EduIDUserDBError("More than one element found")
         return res[0]
 
-    def add(self, element: ListElement) -> None:
+    def add(self, element: ListElement) -> ListElement:
         """
         Add an element to the list.
 
         :param element: Element
-        :return: None
+        :return: the stored element (pydantic may have copied it during validate_assignment)
         """
         self.elements += [element]
+        return self.elements[-1]
 
     def remove(self, key: ElementKey) -> None:
         """

--- a/src/eduid/userdb/tests/test_mail.py
+++ b/src/eduid/userdb/tests/test_mail.py
@@ -74,6 +74,21 @@ class TestMailAddressList:
 
         assert obtained == expected, "Wrong data after adding mail address to list"
 
+    def test_add_returns_stored_element(self) -> None:
+        """add() returns the stored element so callers can mutate without re-find()."""
+        new = MailAddress(email="new@example.org", created_by="test", is_verified=False, is_primary=False)
+        stored = self.one.add(new)
+
+        # Returned element matches what find() would return.
+        found = self.one.find("new@example.org")
+        assert found is stored
+
+        # Mutating the returned element updates the stored state.
+        stored.is_verified = True
+        refound = self.one.find("new@example.org")
+        assert refound is not None
+        assert refound.is_verified is True
+
     def test_add_duplicate(self) -> None:
         assert self.two.primary
         dup = self.two.find(self.two.primary.email)

--- a/src/eduid/userdb/tests/test_phone.py
+++ b/src/eduid/userdb/tests/test_phone.py
@@ -76,6 +76,19 @@ class TestPhoneNumberList:
         assert match.is_verified
         assert match.verified_ts is None
 
+    def test_add_returns_stored_element(self) -> None:
+        """add() returns the stored element so callers can mutate without re-find()."""
+        new = PhoneNumber(number="+46700000099", created_by="test", is_verified=False, is_primary=False)
+        stored = self.one.add(new)
+
+        found = self.one.find("+46700000099")
+        assert found is stored
+
+        stored.is_verified = True
+        refound = self.one.find("+46700000099")
+        assert refound is not None
+        assert refound.is_verified is True
+
     def test_add(self) -> None:
         second = self.two.find("+46700000002")
         assert second

--- a/src/eduid/vccs/server/config.py
+++ b/src/eduid/vccs/server/config.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from fastapi import Request
 from pydantic import BaseModel
@@ -50,8 +50,5 @@ def init_config(ns: str, app_name: str, test_config: Mapping[str, Any] | None = 
 
 
 def get_config(req: Request) -> VCCSConfig:
-    """Pull the VCCS config off the FastAPI app state with a runtime type check."""
-    config = req.app.state.config
-    if not isinstance(config, VCCSConfig):
-        raise RuntimeError(f"unexpected app.state.config type: {type(config).__name__}")
-    return config
+    """Pull the VCCS config off the FastAPI app state. Trust ourselves — config is set at app init."""
+    return cast(VCCSConfig, req.app.state.config)

--- a/src/eduid/webapp/authn/views.py
+++ b/src/eduid/webapp/authn/views.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from flask import Blueprint, abort, make_response, redirect, request
 from saml2 import BINDING_HTTP_REDIRECT
 from saml2.client import Saml2Client
@@ -21,7 +19,6 @@ from eduid.webapp.common.api.messages import (
     AuthnStatusMsg,
     CommonMsg,
     FluxData,
-    TranslatableMsg,
     error_response,
     redirect_with_msg,
     success_response,
@@ -74,10 +71,9 @@ def support_authenticate() -> WerkzeugResponse:
         req_authn_ctx=[EduidAuthnContextClass.REFEDS_MFA.value],
         finish_url=authn_params.finish_url,
     )
-    result = _authn(sp_authn=sp_authn, idp=_get_idp(), authn_params=authn_params)
-    if result.url is None:
-        raise RuntimeError("_authn returned no url")
-    return redirect(location=result.url, code=302)
+    url = _authn(sp_authn=sp_authn, idp=_get_idp(), authn_params=authn_params)
+
+    return redirect(location=url, code=302)
 
 
 @authn_views.route("/authenticate", methods=["POST"])
@@ -123,12 +119,9 @@ def authenticate(
         finish_url=authn_params.finish_url,
     )
 
-    result = _authn(sp_authn, idp=_get_idp(), authn_params=authn_params)
+    url = _authn(sp_authn, idp=_get_idp(), authn_params=authn_params)
 
-    if result.error:
-        return error_response(message=result.error)
-
-    return success_response(payload={"location": result.url})
+    return success_response(payload={"location": url})
 
 
 def _get_idp() -> str:
@@ -146,14 +139,7 @@ def _get_idp() -> str:
     return idp
 
 
-@dataclass
-class AuthnResult:
-    authn_id: AuthnRequestRef | None = None
-    error: TranslatableMsg | None = None
-    url: str | None = None
-
-
-def _authn(sp_authn: SP_AuthnRequest, idp: str, authn_params: AuthnParameters) -> AuthnResult:
+def _authn(sp_authn: SP_AuthnRequest, idp: str, authn_params: AuthnParameters) -> str:
     # Filter out any previous authns with the same frontend_action because we need to use the frontend_action value to
     # find the authn data for a specific action.
     session.authn.sp.authns = {
@@ -184,7 +170,7 @@ def _authn(sp_authn: SP_AuthnRequest, idp: str, authn_params: AuthnParameters) -
         f"Stored SP_AuthnRequest[{sp_authn.authn_id}]: {session.authn.sp.authns[sp_authn.authn_id]}"
     )
     _idp_redirect_url = get_location(authn_request)
-    return AuthnResult(authn_id=sp_authn.authn_id, url=_idp_redirect_url)
+    return _idp_redirect_url
 
 
 @authn_views.route("/saml2-acs", methods=["POST"])

--- a/src/eduid/webapp/common/api/captcha.py
+++ b/src/eduid/webapp/common/api/captcha.py
@@ -6,7 +6,6 @@ from captcha.image import ImageCaptcha
 from marshmallow import fields
 
 from eduid.common.config.base import CaptchaConfigMixin
-from eduid.common.config.exceptions import BadConfiguration
 from eduid.webapp.common.api.schemas.base import EduidSchema, FluxStandardAction
 from eduid.webapp.common.api.schemas.csrf import CSRFRequestMixin, CSRFResponseMixin
 
@@ -54,6 +53,4 @@ def init_captcha(config: CaptchaConfigMixin) -> InternalCaptcha:
     """
     Add captcha to the app.
     """
-    if not isinstance(config, CaptchaConfigMixin):
-        raise BadConfiguration("CaptchaConfigMixin is not implemented by the config class")
     return InternalCaptcha(config=config)

--- a/src/eduid/webapp/common/api/checks.py
+++ b/src/eduid/webapp/common/api/checks.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 import redis
 from flask import current_app as flask_current_app
 
-from eduid.common.config.base import RedisConfigMixin, VCCSConfigMixin
+from eduid.common.config.base import VCCSConfigMixin
 from eduid.common.misc.timeutil import utc_now
 from eduid.common.rpc.am_relay import AmRelay
 from eduid.common.rpc.lookup_mobile_relay import LookupMobileRelay
@@ -113,8 +113,6 @@ def check_mongo() -> bool:
 def check_redis() -> bool:
     current_app = get_current_app()
     _conf = current_app.conf
-    if not isinstance(_conf, RedisConfigMixin):
-        raise RuntimeError(f"app.conf does not implement RedisConfigMixin: {type(_conf).__name__}")
     pool = get_redis_pool(_conf.redis_config)
     client = redis.StrictRedis(connection_pool=pool)
     try:

--- a/src/eduid/webapp/common/api/helpers.py
+++ b/src/eduid/webapp/common/api/helpers.py
@@ -237,15 +237,11 @@ def get_proofing_log_navet_data(nin: str) -> ProofingNavetData:
 
     navet_data = msg_relay.get_all_navet_data(nin=nin, allow_deregistered=True)
     # the only cause for deregistration we allow is emigration
-    if (
-        navet_data.person.is_deregistered()
-        and navet_data.person.deregistration_information.cause_code is not DeregisteredCauseCode.EMIGRATED
-    ):
-        if navet_data.person.deregistration_information.cause_code is None:
-            raise RuntimeError("deregistration cause_code missing for deregistered person")
-        raise NoNavetData(
-            f"Person deregistered with code {navet_data.person.deregistration_information.cause_code.value}"
-        )
+    if navet_data.person.is_deregistered():
+        cause_code = navet_data.person.deregistration_information.cause_code
+        if cause_code is not DeregisteredCauseCode.EMIGRATED:
+            code_str = cause_code.value if cause_code else "unknown"
+            raise NoNavetData(f"Person deregistered with code {code_str}")
 
     user_postal_address = FullPostalAddress(
         name=navet_data.person.name, official_address=navet_data.person.postal_addresses.official_address

--- a/src/eduid/webapp/common/api/translation.py
+++ b/src/eduid/webapp/common/api/translation.py
@@ -1,4 +1,5 @@
 from importlib.resources import files
+from typing import cast
 
 from flask import current_app, request
 from flask_babel import Babel  # type: ignore[import-untyped]
@@ -10,9 +11,8 @@ __author__ = "lundberg"
 
 
 def get_user_locale() -> str | None:
-    app = current_app
-    if not isinstance(app, EduIDBaseApp):
-        raise RuntimeError(f"unexpected current_app type: {type(app).__name__}")
+    # Trust Flask: this helper is only mounted on EduIDBaseApp instances.
+    app = cast(EduIDBaseApp, current_app)
     lang: str | None  # mypy 0.910 needs this
     # if a user is logged in, use the locale from the user settings
     if session.common.preferred_language is not None:

--- a/src/eduid/webapp/common/session/eduid_session.py
+++ b/src/eduid/webapp/common/session/eduid_session.py
@@ -6,7 +6,7 @@ import os
 import pprint
 from collections.abc import Iterator
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from flask import Flask, Request, Response
 from flask.sessions import SessionInterface, SessionMixin
@@ -408,8 +408,8 @@ class SessionFactory(SessionInterface):
         # avoid circular import
         from eduid.webapp.common.api.app import EduIDBaseApp
 
-        if not isinstance(app, EduIDBaseApp):
-            raise RuntimeError(f"app is not an EduIDBaseApp: {type(app).__name__}")
+        # Trust Flask: SessionFactory is only registered on EduIDBaseApp instances.
+        app = cast(EduIDBaseApp, app)
         # Load token from cookie
         _conf = get_from_current_app("conf", EduIDBaseAppConfig)
         cookie_name = _conf.flask.session_cookie_name
@@ -465,10 +465,10 @@ class SessionFactory(SessionInterface):
         # avoid circular import
         from eduid.webapp.common.api.app import EduIDBaseApp
 
-        if not isinstance(app, EduIDBaseApp):
-            raise RuntimeError(f"app is not an EduIDBaseApp: {type(app).__name__}")
-        if not isinstance(session, EduidSession):
-            raise RuntimeError(f"session is not an EduidSession: {type(session).__name__}")
+        # Trust Flask: SessionFactory is only registered on EduIDBaseApp and
+        # produces EduidSession instances in open_session.
+        app = cast(EduIDBaseApp, app)
+        session = cast(EduidSession, session)
         if session is None:
             # Do not try to save the session and set the cookie if the session is not initialized
             # We have seen this happen...

--- a/src/eduid/webapp/email/verifications.py
+++ b/src/eduid/webapp/email/verifications.py
@@ -79,13 +79,9 @@ def verify_mail_address(state: EmailProofingState, proofing_user: ProofingUser) 
     """
     email = proofing_user.mail_addresses.find(state.verification.email)
     if not email:
-        email = MailAddress(email=state.verification.email, created_by="email", is_verified=True, is_primary=False)
-        proofing_user.mail_addresses.add(email)
-        # Adding the phone to the list creates a copy of the element, so we have to 'find' it again
-        email = proofing_user.mail_addresses.find(state.verification.email)
-
-    if email is None:
-        raise RuntimeError("mail address not found after add")
+        email = proofing_user.mail_addresses.add(
+            MailAddress(email=state.verification.email, created_by="email", is_verified=True, is_primary=False)
+        )
 
     email.is_verified = True
     if not proofing_user.mail_addresses.primary:

--- a/src/eduid/webapp/phone/verifications.py
+++ b/src/eduid/webapp/phone/verifications.py
@@ -68,12 +68,9 @@ def verify_phone_number(state: PhoneProofingState, proofing_user: ProofingUser) 
     number = state.verification.number
     phone = proofing_user.phone_numbers.find(number)
     if not phone:
-        phone = PhoneNumber(number=number, created_by="eduid_phone", is_verified=True, is_primary=False)
-        proofing_user.phone_numbers.add(phone)
-        # Adding the phone to the list creates a copy of the element, so we have to 'find' it again
-        phone = proofing_user.phone_numbers.find(phone.key)
-        if phone is None:
-            raise RuntimeError("phone number not found after add")
+        phone = proofing_user.phone_numbers.add(
+            PhoneNumber(number=number, created_by="eduid_phone", is_verified=True, is_primary=False)
+        )
 
     phone.is_verified = True
     if not proofing_user.phone_numbers.primary:

--- a/src/eduid/webapp/signup/helpers.py
+++ b/src/eduid/webapp/signup/helpers.py
@@ -240,11 +240,9 @@ def create_and_sync_user(
     record_email_address(signup_user=signup_user, email=email)
 
     # TODO: add_password needs to understand that signup_user is a descendant from User
-    if generated_password is not None or custom_password is not None:
+    password = custom_password or generated_password
+    if password is not None:
         is_generated = custom_password is None
-        password = custom_password or generated_password
-        if password is None:
-            raise RuntimeError("password not set after generated/custom password check")
 
         if not add_password(
             signup_user,

--- a/src/eduid/workers/am/ams/common.py
+++ b/src/eduid/workers/am/ams/common.py
@@ -22,8 +22,6 @@ class AttributeFetcher(ABC):
     whitelist_unset_attrs: ClassVar[list[str]]
 
     def __init__(self, worker_config: AmConfig) -> None:
-        if not isinstance(worker_config, AmConfig):
-            raise TypeError("AttributeFetcher config should be AmConfig")
         self.conf = worker_config
         self.private_db: UserDB[User] | None = None
         if worker_config.mongo_uri:


### PR DESCRIPTION
# Type-refactor follow-ups: assert-derived runtime checks

Follow-up on the S101 cleanup. Several `if X is None: raise RuntimeError(...)`
narrowing checks (originally `assert` statements) were either unreachable,
replaceable with `cast`, or fixable by restructuring. This branch eliminates
them.

## What changes

- **`BaseDB._parsed_options`** — use `dict.get("options", {})` default instead
  of `or {}`; avoids the falsy-but-not-None pitfall and yields a non-Optional dict.

- **`signup/helpers.py`** — reorder so `password = custom_password or generated_password`
  precedes the `if password is not None:` guard. Optional path reads naturally.

- **`authn/views.py::_authn`** — delete the `AuthnResult` dataclass: `error`
  was never set, `authn_id` was never read back from the result. `_authn` now
  returns `str` directly; the two callers collapse to one line each.

- **`ElementList.add()`** — return the stored element (the pydantic-validated
  copy after `validate_assignment`) so callers can mutate without re-find.
  Updates the call sites in email + phone verification.

- **`get_proofing_log_navet_data`** — extract `cause_code` into a local and
  collapse both "missing" and "non-EMIGRATED" cases into a single `NoNavetData`
  raise. The previous `RuntimeError` for missing cause_code was reachable
  (`is_deregistered()` returns True when only `date` is set) and would have
  bypassed the `except NoNavetData` handler in mobile proofing views, turning
  a Navet data anomaly into a 500.

- **`check_redis`** — delete the `isinstance(_conf, RedisConfigMixin)` check;
  `EduIDBaseAppConfig` inherits from `RedisConfigMixin`, so it was statically
  always True (ty flagged the raise as unreachable).

- **`init_captcha`, `AttributeFetcher.__init__`** — drop the isinstance
  re-check of an already-typed parameter; the type checker enforces the
  contract.

- **`vccs/server/config.py::get_config`** — `req.app.state.config` is
  Starlette's `Any`. We set it ourselves at app init; isinstance + raise
  becomes `cast(VCCSConfig, ...)`.

- **Trust Flask in `current_app` / `SessionInterface` overrides** —
  `translation.py` and `eduid_session.py` receive Flask base types per Liskov,
  but our `SessionFactory` is only registered on `EduIDBaseApp` subclasses.
  Four isinstance + `RuntimeError` checks become `cast`. Liskov contract
  preserved.
