### PR TITLE
feat(signup): allow signup with an already-registered identity

### DIFF
--- a/src/eduid/webapp/signup/schemas.py
+++ b/src/eduid/webapp/signup/schemas.py
@@ -224,3 +224,7 @@ class ReturnToAuthRequest(EduidSchema, CSRFRequestMixin):
 class ExternalMfaRegisterRequest(EduidSchema, CSRFRequestMixin):
     app_name = fields.String(required=True)
     authn_id = fields.String(required=True)
+    # Set by the frontend after the user confirms creating a new account with an
+    # identity that already belongs to an existing user. The AM worker moves the
+    # verified identity off the old account on sync.
+    confirm_replace = fields.Boolean(load_default=False)

--- a/src/eduid/webapp/signup/tests/test_external_mfa.py
+++ b/src/eduid/webapp/signup/tests/test_external_mfa.py
@@ -170,11 +170,16 @@ class ExternalMfaSignupTestsBase(BaseSignupTests):
             with client.session_transaction() as sess:
                 sess.freja_eid.rp.authns[OIDCState(authn_id)] = req
 
-    def _call_external_mfa_register(self, app_name: str, authn_id: str) -> TestResponse:
+    def _call_external_mfa_register(self, app_name: str, authn_id: str, confirm_replace: bool = False) -> TestResponse:
         with self.session_cookie_anon(self.browser) as client:
             with client.session_transaction() as sess:
                 csrf_token = sess.get_csrf_token()
-            data = {"app_name": app_name, "authn_id": authn_id, "csrf_token": csrf_token}
+            data = {
+                "app_name": app_name,
+                "authn_id": authn_id,
+                "confirm_replace": confirm_replace,
+                "csrf_token": csrf_token,
+            }
             return client.post(
                 "/external-mfa-register",
                 data=json.dumps(data),
@@ -543,6 +548,29 @@ class ExternalMfaSignupTests(ExternalMfaSignupTestsBase):
                 # collision => nothing stored, nothing consumed
                 assert sess.signup.external_mfa is None
                 assert sess.bankid.sp.authns[AuthnRequestRef("authn-1")].consumed is False
+
+    def test_nin_collision_confirm_replace(self) -> None:
+        """With confirm_replace=True the collision is allowed: identity is stored despite the existing user.
+
+        The new account is created with the colliding NIN; the AM worker handles moving the
+        verified identity off the old account on sync.
+        """
+        existing = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
+        assert existing is not None
+        assert existing.identities.nin is not None
+        collision_nin = existing.identities.nin.number  # "197801011234"
+
+        self._seed_bankid_authn(nin=collision_nin)
+        response = self._call_external_mfa_register("bankid", "authn-1", confirm_replace=True)
+        assert response.status_code == 200
+        state = self.get_response_payload(response)["state"]
+        assert state["external_mfa"]["completed"] is True
+
+        with self.session_cookie_anon(self.browser) as client:
+            with client.session_transaction() as sess:
+                # confirmed => stored and consumed
+                assert sess.signup.external_mfa is not None
+                assert sess.bankid.sp.authns[AuthnRequestRef("authn-1")].consumed is True
 
     def test_prid_collision(self) -> None:
         """Signup is hard-blocked when eIDAS PRID already belongs to an existing verified user.
@@ -1075,9 +1103,13 @@ class ExternalMfaSignupTests(ExternalMfaSignupTestsBase):
                 assert sess.signup.external_mfa is None
                 assert sess.signup.user_created is False
 
-    def test_create_user_rejects_identity_registered_since(self) -> None:
-        """Identity that becomes taken between /external-mfa-register and /create-user
-        is rejected at /create-user time."""
+    def test_create_user_allows_identity_registered_since(self) -> None:
+        """Identity collision is not re-checked at /create-user.
+
+        Even if the identity becomes taken between /external-mfa-register and
+        /create-user, user creation proceeds: the collision is allowed by design
+        (the user confirmed at register) and the AM worker moves the verified
+        identity off the existing account on sync."""
         self._seed_bankid_authn(nin="198001011234", authn_id="authn-1")
         self._call_external_mfa_register("bankid", "authn-1")
 
@@ -1086,11 +1118,12 @@ class ExternalMfaSignupTests(ExternalMfaSignupTestsBase):
         existing = self.app.central_userdb.get_user_by_eppn(self.test_user_eppn)
         assert existing is not None
         assert existing.identities.nin is not None
+        collision_nin = existing.identities.nin.number
         with self.session_cookie_anon(self.browser) as client:
             with client.session_transaction() as sess:
                 assert sess.signup.external_mfa is not None
                 assert isinstance(sess.signup.external_mfa.ident, ExternalMfaSignupBankIDIdentity)
-                sess.signup.external_mfa.ident.nin = existing.identities.nin.number
+                sess.signup.external_mfa.ident.nin = collision_nin
 
         self._prepare_for_create_user(
             given_name="Anna",
@@ -1098,14 +1131,19 @@ class ExternalMfaSignupTests(ExternalMfaSignupTestsBase):
             email="anna.andersson@example.com",
         )
 
-        result = self._create_user(expect_success=False)
-        payload = self.get_response_payload(result.response)
-        assert payload["message"] == SignupMsg.identity_already_registered.value
+        # _create_user asserts user_created and a logged-in eppn internally
+        result = self._create_user()
+        assert result.response.status_code == 200
 
-        with self.session_cookie_anon(self.browser) as client:
-            with client.session_transaction() as sess:
-                assert sess.signup.external_mfa is None
-                assert sess.signup.user_created is False
+        # A new account exists with the signup email and the (colliding) verified
+        # NIN; it is distinct from the existing user. The AM worker resolves the
+        # duplicate identity on sync.
+        user = self.app.central_userdb.get_user_by_mail("anna.andersson@example.com")
+        assert user is not None
+        assert user.eppn != existing.eppn
+        assert user.identities.nin is not None
+        assert user.identities.nin.number == collision_nin
+        assert user.identities.nin.is_verified is True
 
 
 class ExternalMfaWebauthnVerificationTests(ExternalMfaSignupTestsBase):

--- a/src/eduid/webapp/signup/views.py
+++ b/src/eduid/webapp/signup/views.py
@@ -434,7 +434,7 @@ def return_to_auth(ref: str, service_info: dict[str, dict[str, str]]) -> FluxDat
 @UnmarshalWith(ExternalMfaRegisterRequest)
 @MarshalWith(SignupStatusResponse)
 @require_not_logged_in
-def external_mfa_register(app_name: str, authn_id: str) -> FluxData:
+def external_mfa_register(app_name: str, authn_id: str, confirm_replace: bool = False) -> FluxData:
     """Store a successful external-MFA authn on the signup session.
 
     The frontend hits ``/profile/ext-return/{app_name}/{authn_id}`` after the
@@ -463,8 +463,16 @@ def external_mfa_register(app_name: str, authn_id: str) -> FluxData:
         raise RuntimeError("No external MFA signup identity")
 
     if existing_user_for_identity(ident=ident) is not None:
-        current_app.logger.info(f"External MFA signup blocked: identity already registered ({app_name})")
-        return error_response(message=SignupMsg.identity_already_registered)
+        if not confirm_replace:
+            # Ask the user to confirm. On confirmation the frontend re-posts with
+            # confirm_replace=True and signup proceeds; the AM worker moves the
+            # verified identity off the existing account on sync.
+            current_app.logger.info(f"External MFA signup needs confirmation: identity already registered ({app_name})")
+            return error_response(message=SignupMsg.identity_already_registered)
+        current_app.logger.info(
+            f"External MFA signup confirmed despite identity already registered ({app_name}); "
+            "new account will be created and the identity replaced by the AM worker"
+        )
 
     _authn_id: AuthnRequestRef | OIDCState
     match authn:
@@ -557,9 +565,13 @@ def _check_credentials_selected(use_password: bool, use_webauthn: bool, custom_p
 def _check_external_mfa_still_valid() -> FluxData | None:
     """Re-validate any stored external MFA at /create-user time.
 
-    The authn's freshness (max_age) and the identity collision are checked at
-    /external-mfa-register, but /create-user can happen an arbitrary time later.
-    Re-check so a stale or now-superseded authn can't be used to finish signup."""
+    The authn's freshness (max_age) is checked at /external-mfa-register, but
+    /create-user can happen an arbitrary time later. Re-check so a stale authn
+    can't be used to finish signup.
+
+    Identity collision is intentionally not re-checked here: it is allowed by
+    design (the user confirmed at /external-mfa-register) and the AM worker
+    handles replacing the identity on sync regardless of timing."""
     ext = session.signup.external_mfa
     if ext is None:
         return None
@@ -568,12 +580,6 @@ def _check_external_mfa_still_valid() -> FluxData | None:
         current_app.logger.info("External MFA signup blocked: authn too old at create-user time")
         session.signup.external_mfa = None
         return error_response(message=SignupMsg.external_mfa_too_old)
-    if existing_user_for_identity(ext.ident) is not None:
-        current_app.logger.info(
-            "External MFA signup blocked: identity registered between /external-mfa-register and /create-user"
-        )
-        session.signup.external_mfa = None
-        return error_response(message=SignupMsg.identity_already_registered)
     return None
 
 


### PR DESCRIPTION
  ## Summary

  Previously, signing up via external MFA (BankID / Freja eID+ / eIDAS / SamlEid) with an identity (NIN / eIDAS PRID / Freja user_id) that already belonged to a verified user was hard-blocked. This changes it to an ask-and-confirm flow: the user is told the identity already belongs to an account and can choose to create a new account anyway. The new account is created with the verified identity; the AM worker  handles moving/replacing the identity off the old account on sync. Signup itself just saves the user as before.

  ## Backend changes

  - ExternalMfaRegisterRequest gains confirm_replace: bool (default false).
  - POST /external-mfa-register: a collision now blocks only when confirm_replace is false. With confirm_replace: true, the identity is stored on the signup session and the flow continues.
  - The collision re-check at POST /create-user is removed (the max_age freshness check stays). Collision is allowed by design and the AM  worker resolves the duplicate on sync.
  - POST /create-user is otherwise unchanged.

  The change is isolated to the external-MFA register step. No change to /create-user.

  1. First call — unchanged. Post to /external-mfa-register as today:
  { "app_name": "...", "authn_id": "...", "csrf_token": "..." }
  1. (confirm_replace defaults to false server-side, so existing callers keep working.)
  2. Detect the "ask" trigger. On a collision the response is a Flux fail:
    - type: POST_SIGNUP_EXTERNAL_MFA_REGISTER_FAIL
    - payload.message: signup.identity-already-registered
    - Today the UI surfaces this as a terminal error. Instead, show a confirmation prompt: e.g. "This identity already belongs to an eduID account. Do you want to create a new account with it anyway? Your verified identity will be moved to the new account."
    
  3. On confirm — re-post the same call with the flag:
  { "app_name": "...", "authn_id": "...", "confirm_replace": true, "csrf_token": "..." }
  4. Use the same app_name / authn_id as the first call — the authn is not consumed on the collision fail, so the retry works. A successful response is POST_SIGNUP_EXTERNAL_MFA_REGISTER_SUCCESS with external_mfa.completed: true in the state.
  5. On cancel — let the user back out / switch to the email+password branch (existing /external-mfa-clear behavior).
  6. Continue to /create-user as normal. No new parameters there.

