### PR TITLE
Pin open-file-descriptor limit for test MongoDB containers

### DIFF
--- a/src/eduid/queue/testing.py
+++ b/src/eduid/queue/testing.py
@@ -40,6 +40,10 @@ class MongoTemporaryInstanceReplicaSet(MongoTemporaryInstance):
             "docker",
             "run",
             "--rm",
+            # See MongoTemporaryInstance.command: pin nofile so WiredTiger does not run out of
+            # file descriptors and crash mongod when many collections/indexes are created.
+            "--ulimit",
+            "nofile=64000:64000",
             "-p",
             f"{self.port}:{self.port}",
             "-e",

--- a/src/eduid/userdb/testing/__init__.py
+++ b/src/eduid/userdb/testing/__init__.py
@@ -36,6 +36,12 @@ class MongoTemporaryInstance(EduidTemporaryInstance):
             "docker",
             "run",
             "--rm",
+            # Pin the open-file-descriptor limit. Newer Docker no longer forces a high default,
+            # so containers inherit the host's soft nofile (often 1024). WiredTiger holds several
+            # fds per collection/index and panics ("Too many open files") once that is exhausted,
+            # crashing mongod. 64000 is MongoDB's own recommended minimum.
+            "--ulimit",
+            "nofile=64000:64000",
             "-p",
             f"{self.port}:27017",
             "--name",


### PR DESCRIPTION
# Pin open-file-descriptor limit for test MongoDB containers

Test MongoDB containers now start with `--ulimit nofile=64000:64000` so mongod
does not run out of file descriptors and crash mid-test.

## Background

Newer Docker Engine (29.x) no longer forces a high `LimitNOFILE` on containers,
so they inherit the host's soft `nofile` limit (typically 1024). MongoDB's
WiredTiger engine holds several file descriptors per collection/index, and when
that limit is exhausted it fails to `fsync` the data directory:

```
Soft rlimits for open file descriptors too low: currentValue 1024, recommendedMinimum 64000
__posix_directory_sync: /data/: directory-sync: open — "Too many open files" (EMFILE)
WT_PANIC: WiredTiger library panic
```

WiredTiger cannot recover from this, so mongod hits a fatal assertion and
`abort()`s (container exits 139). The client's in-flight command sees the
connection drop, then burns its 20s connect/socket timeouts retrying against the
now-dead server — surfacing as a **test timeout**.

`test_load_many_data_owners` is the canary: it creates ~240+ collections in a
single mongod process, crashing it at collection ~242. Other tests stay well
under 1024 fds even without the fix. No application code or the mongo image
changed — only the container's inherited fd limit did, the moment Docker was
upgraded.

## What changes

- **`MongoTemporaryInstance.command`** (`userdb/testing/__init__.py`) — add
  `--ulimit nofile=64000:64000` to the `docker run` args.

- **`MongoTemporaryInstanceReplicaSet.command`** (`queue/testing.py`) — same,
  for the replica-set variant.

64000 is MongoDB's own recommended minimum. Pinning it in the harness makes the
tests independent of whatever `nofile` default the host Docker happens to hand
out.
